### PR TITLE
feat: add Kubernetes CronJob deployment support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - "feature/**"
     tags:
       - "v*"
   pull_request:
     branches:
       - main
+
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,63 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # :latest on every push to main
+            type=raw,value=latest,enable={{is_default_branch}}
+            # :v1.2.3 on version tags
+            type=semver,pattern={{version}}
+            # :v1.2 on version tags
+            type=semver,pattern={{major}}.{{minor}}
+            # :sha-<short> on every push
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /nightshift 
 # ── Stage 2: runtime image ────────────────────────────────────────────────────
 # Node.js LTS is required to run all three provider CLIs
 # (claude-code, codex, and copilot are npm packages).
-FROM node:24-bookworm-slim
+FROM debian:bookworm-slim
 
 # Grab uv and bun binaries from their official images
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY --from=oven/bun:latest /usr/local/bin/bun /usr/local/bin/bun
 
-# System packages: git (branch push/PR), curl + gnupg (gh CLI apt key), ca-certs
+# System packages + Node.js 24 (via NodeSource) + gh CLI
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -23,13 +23,19 @@ RUN apt-get update \
         git \
         gnupg \
     && install -m 0755 -d /etc/apt/keyrings \
+    # Node.js 24
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+       | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+       > /etc/apt/sources.list.d/nodesource.list \
+    # GitHub CLI
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
        | dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
        > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends gh \
+    && apt-get install -y --no-install-recommends nodejs gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Provider CLIs — installed globally so they land in /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /nightshift ./cmd/nightshift
 
 # ── Stage 2: runtime image ────────────────────────────────────────────────────
-# Node.js LTS is required to run all three provider CLIs
-# (claude-code, codex, and copilot are npm packages).
 FROM debian:bookworm-slim
 
 # Grab uv and bun binaries from their official images
@@ -38,14 +36,18 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends nodejs gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Provider CLIs — installed globally so they land in /usr/local/bin
-#   claude  → @anthropic-ai/claude-code
-#   codex   → @openai/codex
-#   copilot → @github/copilot
-RUN npm install -g --no-fund --no-audit \
-        @anthropic-ai/claude-code \
-        @openai/codex \
-        @github/copilot \
+# Claude Code — standalone installer (installs to ~/.local/bin, move to system path)
+RUN curl -fsSL https://claude.ai/install.sh | sh \
+    && mv /root/.local/bin/claude /usr/local/bin/claude
+
+# GitHub Copilot — standalone installer
+RUN curl -fsSL https://gh.io/copilot-install | bash \
+    && (mv /root/.local/bin/copilot /usr/local/bin/copilot 2>/dev/null \
+        || mv /usr/local/bin/.copilot-install/copilot /usr/local/bin/copilot 2>/dev/null \
+        || true)
+
+# Codex — npm (no standalone installer available)
+RUN npm install -g --no-fund --no-audit @openai/codex \
     && npm cache clean --force
 
 # nightshift binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# ── Stage 1: build the nightshift Go binary ──────────────────────────────────
 FROM golang:1.24-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -5,12 +6,44 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /nightshift ./cmd/nightshift
 
-FROM debian:bookworm-slim
+# ── Stage 2: runtime image ────────────────────────────────────────────────────
+# Node.js LTS is required to run all three provider CLIs
+# (claude-code, codex, and copilot are npm packages).
+FROM node:22-bookworm-slim
+
+# System packages: git (branch push/PR), curl + gnupg (gh CLI apt key), ca-certs
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       | dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
-RUN useradd -m -u 1000 nightshift
+
+# Provider CLIs — installed globally so they land in /usr/local/bin
+#   claude  → @anthropic-ai/claude-code
+#   codex   → @openai/codex
+#   copilot → @github/copilot
+RUN npm install -g --no-fund --no-audit \
+        @anthropic-ai/claude-code \
+        @openai/codex \
+        @github/copilot \
+    && npm cache clean --force
+
+# nightshift binary
 COPY --from=builder /nightshift /usr/local/bin/nightshift
+
+# Non-root user for runtime
+RUN useradd -m -u 1000 nightshift
 USER nightshift
 WORKDIR /home/nightshift
+
 ENTRYPOINT ["nightshift"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.24-bookworm AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /nightshift ./cmd/nightshift
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git \
+    && rm -rf /var/lib/apt/lists/*
+RUN useradd -m -u 1000 nightshift
+COPY --from=builder /nightshift /usr/local/bin/nightshift
+USER nightshift
+WORKDIR /home/nightshift
+ENTRYPOINT ["nightshift"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /nightshift 
 # (claude-code, codex, and copilot are npm packages).
 FROM node:22-bookworm-slim
 
+# Grab uv and bun binaries from their official images
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=oven/bun:latest /usr/local/bin/bun /usr/local/bin/bun
+
 # System packages: git (branch push/PR), curl + gnupg (gh CLI apt key), ca-certs
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /nightshift 
 # ── Stage 2: runtime image ────────────────────────────────────────────────────
 # Node.js LTS is required to run all three provider CLIs
 # (claude-code, codex, and copilot are npm packages).
-FROM node:22-bookworm-slim
+FROM node:24-bookworm-slim
 
 # Grab uv and bun binaries from their official images
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/README.md
+++ b/README.md
@@ -256,6 +256,28 @@ Each task has a default cooldown interval to prevent the same task from running 
 
 `skill-groom` is enabled by default. Add it to `tasks.disabled` if you want to opt out. It updates project-local skills under `.claude/skills` and `.codex/skills` using `README.md` as project context and starts Agent Skills docs lookup from `https://agentskills.io/llms.txt`.
 
+## Kubernetes / Cloud Deployment
+
+Nightshift can run as a **Kubernetes CronJob** instead of a systemd service. In this mode
+the CronJob schedule drives execution and nightshift is invoked as a one-shot
+`nightshift run --yes` command.
+
+Manifests are in [`deploy/kubernetes/`](deploy/kubernetes/):
+
+```bash
+# Deploy with Kustomize
+kubectl apply -k deploy/kubernetes/
+
+# Trigger a manual run
+kubectl create job --from=cronjob/nightshift nightshift-manual -n nightshift
+
+# Stream logs
+kubectl logs -n nightshift -l app=nightshift -f
+```
+
+See [docs/guides/kubernetes-cronjob.md](docs/guides/kubernetes-cronjob.md) for the full
+setup guide including image building, secrets, Git credentials, and repo mounting strategies.
+
 ## Development
 
 ### Pre-commit hooks

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -25,10 +25,16 @@ data:
       claude:
         enabled: true
         data_path: /home/nightshift/.claude
+        # Available models: claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5
+        # Omit to use the provider CLI default.
+        model: claude-sonnet-4-6
         dangerously_skip_permissions: true
       codex:
         enabled: false
         data_path: /home/nightshift/.codex
+        # Available models: gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2, gpt-5-mini
+        # Omit to use the provider CLI default.
+        model: gpt-5.3-codex
         dangerously_bypass_approvals_and_sandbox: true
 
     projects:

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nightshift-config
+  namespace: nightshift
+data:
+  config.yaml: |
+    # Nightshift configuration for Kubernetes CronJob deployment.
+    # The schedule is driven by the CronJob spec below — nightshift's
+    # internal scheduler is not used in this mode.
+
+    budget:
+      mode: daily
+      max_percent: 75
+      reserve_percent: 5
+      billing_mode: subscription
+      calibrate_enabled: false
+      snapshot_interval: 30m
+      db_path: /data/nightshift.db
+
+    providers:
+      preference:
+        - claude
+        - codex
+      claude:
+        enabled: true
+        data_path: /home/nightshift/.claude
+        dangerously_skip_permissions: true
+      codex:
+        enabled: false
+        data_path: /home/nightshift/.codex
+        dangerously_bypass_approvals_and_sandbox: true
+
+    projects:
+      - path: /repos/my-project
+
+    tasks:
+      enabled:
+        - lint-fix
+        - docs-backfill
+        - bug-finder
+
+    logging:
+      level: info
+      path: /data/logs
+      format: json

--- a/deploy/kubernetes/cronjob.yaml
+++ b/deploy/kubernetes/cronjob.yaml
@@ -1,0 +1,111 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nightshift
+  namespace: nightshift
+  labels:
+    app: nightshift
+spec:
+  # Run at 02:00 UTC every day. Adjust to fit your timezone and token reset schedule.
+  schedule: "0 2 * * *"
+
+  # Prevent overlapping runs if a job is still executing.
+  concurrencyPolicy: Forbid
+
+  # Keep the last 3 successful and 1 failed job for log inspection.
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+
+  # If a scheduled run is missed by more than 1 hour, skip it.
+  startingDeadlineSeconds: 3600
+
+  jobTemplate:
+    spec:
+      # Retry at most once on failure.
+      backoffLimit: 1
+
+      # Hard timeout: 6 hours. Adjust based on expected run duration.
+      activeDeadlineSeconds: 21600
+
+      template:
+        metadata:
+          labels:
+            app: nightshift
+        spec:
+          serviceAccountName: nightshift
+          restartPolicy: OnFailure
+
+          # Mount the SSH/git credentials needed to push branches/PRs.
+          # Replace with your own secret name if different.
+          volumes:
+            - name: config
+              configMap:
+                name: nightshift-config
+            - name: data
+              persistentVolumeClaim:
+                claimName: nightshift-data
+            - name: git-credentials
+              secret:
+                secretName: nightshift-git-credentials
+                optional: true
+
+          containers:
+            - name: nightshift
+              # Pin to a specific release tag in production.
+              # See: https://github.com/cedricfarinazzo/nightshift/releases
+              image: ghcr.io/cedricfarinazzo/nightshift:latest
+
+              # In Kubernetes, nightshift is invoked as a one-shot command.
+              # --yes skips the interactive confirmation prompt.
+              # --ignore-budget can be added if budget tracking is not applicable.
+              args:
+                - run
+                - --yes
+
+              env:
+                - name: ANTHROPIC_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: nightshift-secrets
+                      key: ANTHROPIC_API_KEY
+                      optional: true
+                - name: OPENAI_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: nightshift-secrets
+                      key: OPENAI_API_KEY
+                      optional: true
+                # Tell nightshift where to find its config inside the container.
+                - name: NIGHTSHIFT_CONFIG
+                  value: /etc/nightshift/config.yaml
+                # Logging
+                - name: NIGHTSHIFT_LOG_LEVEL
+                  value: info
+
+              volumeMounts:
+                - name: config
+                  mountPath: /etc/nightshift
+                  readOnly: true
+                - name: data
+                  mountPath: /data
+                - name: git-credentials
+                  mountPath: /home/nightshift/.gitconfig
+                  subPath: .gitconfig
+                  readOnly: true
+
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false  # provider CLIs write to home dir
+                runAsNonRoot: true
+                runAsUser: 1000
+                capabilities:
+                  drop:
+                    - ALL

--- a/deploy/kubernetes/cronjob.yaml
+++ b/deploy/kubernetes/cronjob.yaml
@@ -51,8 +51,9 @@ spec:
 
           containers:
             - name: nightshift
-              # Pin to a specific release tag in production.
-              # See: https://github.com/cedricfarinazzo/nightshift/releases
+              # Pin to a specific release tag in production, e.g. :v0.3.4
+              # Images are published to GHCR by the Docker CI workflow on every
+              # push to main (:latest) and on every version tag (:v1.2.3).
               image: ghcr.io/cedricfarinazzo/nightshift:latest
 
               # In Kubernetes, nightshift is invoked as a one-shot command.

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: nightshift
+
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - pvc.yaml
+  - configmap.yaml
+  - secrets.yaml
+  - cronjob.yaml

--- a/deploy/kubernetes/namespace.yaml
+++ b/deploy/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nightshift

--- a/deploy/kubernetes/pvc.yaml
+++ b/deploy/kubernetes/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nightshift-data
+  namespace: nightshift
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  # storageClassName: standard  # uncomment and set to your storage class

--- a/deploy/kubernetes/secrets.yaml
+++ b/deploy/kubernetes/secrets.yaml
@@ -1,0 +1,24 @@
+# Secrets template — do NOT commit real values.
+# Populate these before applying:
+#
+#   kubectl create secret generic nightshift-secrets \
+#     --namespace nightshift \
+#     --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
+#     --from-literal=OPENAI_API_KEY=sk-...
+#
+# Or use a secrets manager (e.g., External Secrets Operator, Vault Agent).
+#
+# For subscription-based auth (Claude Code / Codex CLI local login),
+# mount the provider credential directories via a PVC or init-container
+# and remove the API key env vars below.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nightshift-secrets
+  namespace: nightshift
+type: Opaque
+stringData:
+  # API key for Claude (Anthropic Console). Leave empty if using subscription CLI.
+  ANTHROPIC_API_KEY: ""
+  # API key for Codex (OpenAI). Leave empty if using subscription CLI.
+  OPENAI_API_KEY: ""

--- a/deploy/kubernetes/serviceaccount.yaml
+++ b/deploy/kubernetes/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nightshift
+  namespace: nightshift

--- a/docs/guides/kubernetes-cronjob.md
+++ b/docs/guides/kubernetes-cronjob.md
@@ -1,0 +1,220 @@
+# Running Nightshift as a Kubernetes CronJob
+
+This guide explains how to deploy nightshift as a Kubernetes CronJob. In this mode the CronJob
+schedule replaces nightshift's built-in daemon/systemd timer — nightshift is invoked as a
+one-shot `nightshift run --yes` command on each execution.
+
+## Prerequisites
+
+- A running Kubernetes cluster (1.21+)
+- `kubectl` configured with cluster access
+- A container image of nightshift (see [Building the image](#building-the-image))
+- At least one AI provider credential (API key or pre-authenticated CLI volume)
+- Git credentials that allow pushing branches / opening PRs from inside the cluster
+
+## Directory layout
+
+```
+deploy/kubernetes/
+├── namespace.yaml        # nightshift namespace
+├── serviceaccount.yaml   # dedicated ServiceAccount
+├── pvc.yaml              # PersistentVolumeClaim for SQLite DB and logs
+├── configmap.yaml        # nightshift config.yaml baked in as a ConfigMap
+├── secrets.yaml          # Secret template (fill before applying)
+├── cronjob.yaml          # The CronJob itself
+└── kustomization.yaml    # Kustomize entry-point
+```
+
+## Quick start
+
+### 1. Build or pull the image
+
+nightshift does not yet publish an official container image. Build one from source:
+
+```dockerfile
+# Example minimal Dockerfile (place at repo root)
+FROM golang:1.24 AS builder
+WORKDIR /src
+COPY . .
+RUN go build -o /nightshift ./cmd/nightshift
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y git ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN useradd -m -u 1000 nightshift
+COPY --from=builder /nightshift /usr/local/bin/nightshift
+USER nightshift
+ENTRYPOINT ["nightshift"]
+```
+
+Build and push to your registry:
+
+```bash
+docker build -t ghcr.io/<your-org>/nightshift:latest .
+docker push ghcr.io/<your-org>/nightshift:latest
+```
+
+Then update the `image:` field in `cronjob.yaml` to point at your registry.
+
+### 2. Configure
+
+Edit `configmap.yaml` to match your projects, providers, and task selection. Key fields:
+
+| Field | Description |
+|-------|-------------|
+| `budget.db_path` | Must be on the PVC mount (`/data/nightshift.db`) |
+| `logging.path` | Must be on the PVC mount (`/data/logs`) |
+| `providers.*.data_path` | Provider CLI credential directory inside the container |
+| `providers.*.dangerously_skip_permissions` | Set `true` for unattended runs |
+| `projects[].path` | Path to the repo inside the container (mount it or clone on start) |
+
+### 3. Supply secrets
+
+**API key authentication** (simplest):
+
+```bash
+kubectl create namespace nightshift
+
+kubectl create secret generic nightshift-secrets \
+  --namespace nightshift \
+  --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
+  --from-literal=OPENAI_API_KEY=sk-...
+```
+
+**Subscription CLI authentication** (Claude Code / Codex local login):
+
+Pre-authenticate the provider CLIs on a machine, then copy the credential directories
+into a Secret or a PVC. Mount them at the paths set in `providers.*.data_path`
+(e.g., `/home/nightshift/.claude`). Remove the API key env vars from `cronjob.yaml`.
+
+### 4. Supply Git credentials
+
+Nightshift pushes branches and opens PRs, so the container needs Git credentials.
+The recommended approach is a GitHub token stored as a `.gitconfig`-style credential helper:
+
+```bash
+kubectl create secret generic nightshift-git-credentials \
+  --namespace nightshift \
+  --from-literal=.gitconfig="[credential \"https://github.com\"]
+  helper = store
+[user]
+  email = nightshift-bot@example.com
+  name = Nightshift Bot"
+```
+
+Or use a Git credentials store file and mount it at `/home/nightshift/.git-credentials`.
+
+For fine-grained access, create a GitHub App or fine-grained PAT with:
+- `contents: write` — to push branches
+- `pull_requests: write` — to open PRs
+
+### 5. Mount your repositories
+
+Nightshift needs access to the source repositories it will modify. Options:
+
+**Option A — Clone at runtime (init container)**
+
+Add an init container that clones the target repos into an `emptyDir` volume:
+
+```yaml
+initContainers:
+  - name: clone-repos
+    image: alpine/git:latest
+    env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: nightshift-git-credentials
+            key: GITHUB_TOKEN
+    command:
+      - sh
+      - -c
+      - |
+        git clone https://x-access-token:${GITHUB_TOKEN}@github.com/your-org/my-project /repos/my-project
+    volumeMounts:
+      - name: repos
+        mountPath: /repos
+```
+
+Add a `repos` `emptyDir` volume and mount it at `/repos` in the main container.
+
+**Option B — Persistent volume with a Git sync sidecar**
+
+Use a tool like [`git-sync`](https://github.com/kubernetes/git-sync) as a sidecar to keep
+repos up to date on a shared PVC.
+
+### 6. Adjust the schedule
+
+Edit the `schedule` field in `cronjob.yaml`:
+
+```yaml
+schedule: "0 2 * * *"   # 02:00 UTC daily
+```
+
+Use [crontab.guru](https://crontab.guru) to build your cron expression. Common choices:
+
+| Expression | Meaning |
+|------------|---------|
+| `0 2 * * *` | Every day at 02:00 UTC |
+| `0 2 * * 1-5` | Weekdays at 02:00 UTC |
+| `0 22 * * *` | Every day at 22:00 UTC |
+
+### 7. Deploy
+
+Using Kustomize:
+
+```bash
+kubectl apply -k deploy/kubernetes/
+```
+
+Or apply each file individually:
+
+```bash
+kubectl apply -f deploy/kubernetes/namespace.yaml
+kubectl apply -f deploy/kubernetes/serviceaccount.yaml
+kubectl apply -f deploy/kubernetes/pvc.yaml
+kubectl apply -f deploy/kubernetes/configmap.yaml
+kubectl apply -f deploy/kubernetes/secrets.yaml
+kubectl apply -f deploy/kubernetes/cronjob.yaml
+```
+
+### 8. Verify
+
+```bash
+# Trigger a manual run immediately
+kubectl create job --from=cronjob/nightshift nightshift-manual -n nightshift
+
+# Watch the job
+kubectl get jobs -n nightshift -w
+
+# Stream logs
+kubectl logs -n nightshift -l app=nightshift -f
+
+# Check CronJob status
+kubectl get cronjob nightshift -n nightshift
+```
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `NIGHTSHIFT_CONFIG` | Path to config file inside the container |
+| `NIGHTSHIFT_LOG_LEVEL` | Log level: `debug`, `info`, `warn`, `error` |
+| `NIGHTSHIFT_LOG_PATH` | Override log directory |
+| `ANTHROPIC_API_KEY` | Anthropic API key for Claude (API auth mode) |
+| `OPENAI_API_KEY` | OpenAI API key for Codex (API auth mode) |
+
+## Production tips
+
+- **Pin the image tag** to a specific release (e.g., `:v0.3.1`) rather than `:latest`.
+- **Use a secrets manager** such as External Secrets Operator or Vault Agent Injector
+  instead of storing secrets directly in Kubernetes Secrets.
+- **Set resource limits** appropriate for your workload; defaults in the manifest are
+  conservative.
+- **Tune `activeDeadlineSeconds`** if your runs consistently take longer than the default 6 hours.
+- **Enable RBAC** if your cluster policy requires it — the ServiceAccount needs no special
+  cluster permissions; all access is via provider CLIs and Git over HTTPS/SSH.
+
+## Helm chart
+
+A Helm chart is not included yet. Contributions welcome — see
+[CONTRIBUTING.md](../../CONTRIBUTING.md) if one exists, or open a PR.

--- a/docs/guides/kubernetes-cronjob.md
+++ b/docs/guides/kubernetes-cronjob.md
@@ -27,33 +27,31 @@ deploy/kubernetes/
 
 ## Quick start
 
-### 1. Build or pull the image
+### 1. Pull the image
 
-nightshift does not yet publish an official container image. Build one from source:
+Images are published automatically to the GitHub Container Registry by the
+[Docker CI workflow](../../.github/workflows/docker.yml):
 
-```dockerfile
-# Example minimal Dockerfile (place at repo root)
-FROM golang:1.24 AS builder
-WORKDIR /src
-COPY . .
-RUN go build -o /nightshift ./cmd/nightshift
+| Tag | Published when |
+|-----|----------------|
+| `ghcr.io/cedricfarinazzo/nightshift:latest` | Every push to `main` |
+| `ghcr.io/cedricfarinazzo/nightshift:v1.2.3` | Version tag (e.g. `v0.3.4`) |
+| `ghcr.io/cedricfarinazzo/nightshift:sha-<short>` | Every push (immutable ref) |
 
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y git ca-certificates && rm -rf /var/lib/apt/lists/*
-RUN useradd -m -u 1000 nightshift
-COPY --from=builder /nightshift /usr/local/bin/nightshift
-USER nightshift
-ENTRYPOINT ["nightshift"]
+**Recommended:** pin to a version tag in production:
+
+```yaml
+image: ghcr.io/cedricfarinazzo/nightshift:v0.3.4
 ```
 
-Build and push to your registry:
+To build locally (e.g. for a fork or custom patch):
 
 ```bash
 docker build -t ghcr.io/<your-org>/nightshift:latest .
 docker push ghcr.io/<your-org>/nightshift:latest
 ```
 
-Then update the `image:` field in `cronjob.yaml` to point at your registry.
+Then update the `image:` field in `cronjob.yaml`.
 
 ### 2. Configure
 

--- a/docs/guides/kubernetes-cronjob.md
+++ b/docs/guides/kubernetes-cronjob.md
@@ -64,8 +64,40 @@ Edit `configmap.yaml` to match your projects, providers, and task selection. Key
 | `budget.db_path` | Must be on the PVC mount (`/data/nightshift.db`) |
 | `logging.path` | Must be on the PVC mount (`/data/logs`) |
 | `providers.*.data_path` | Provider CLI credential directory inside the container |
+| `providers.*.model` | Model to use (see table below); omit to use the provider CLI default |
 | `providers.*.dangerously_skip_permissions` | Set `true` for unattended runs |
 | `projects[].path` | Path to the repo inside the container (mount it or clone on start) |
+
+#### Available models
+
+| Provider | Model | Notes |
+|----------|-------|-------|
+| `claude` | `claude-opus-4-6` | Most capable, higher cost |
+| `claude` | `claude-sonnet-4-6` | Recommended balance of quality and cost |
+| `claude` | `claude-haiku-4-5` | Fastest, lowest cost |
+| `codex` | `gpt-5.3-codex` | Full Codex model |
+| `codex` | `gpt-5.3-codex-spark` | Lighter Codex variant |
+| `codex` | `gpt-5.2` | GPT-5.2 base |
+| `codex` | `gpt-5-mini` | Lowest cost Codex option |
+
+Example provider block with explicit model selection:
+
+```yaml
+providers:
+  preference:
+    - claude
+    - codex
+  claude:
+    enabled: true
+    data_path: /home/nightshift/.claude
+    model: claude-sonnet-4-6
+    dangerously_skip_permissions: true
+  codex:
+    enabled: true
+    data_path: /home/nightshift/.codex
+    model: gpt-5.3-codex
+    dangerously_bypass_approvals_and_sandbox: true
+```
 
 ### 3. Supply secrets
 


### PR DESCRIPTION
Closes #14

## Summary

Adds everything needed to run nightshift as a Kubernetes CronJob instead of a systemd service.

## Changes

### `deploy/kubernetes/`
| File | Description |
|------|-------------|
| `cronjob.yaml` | CronJob running `nightshift run --yes` on a configurable cron schedule (`0 2 * * *` default), with `concurrencyPolicy: Forbid`, resource limits, and a non-root security context |
| `configmap.yaml` | Annotated config template with `db_path` and `logging.path` pointing at the PVC |
| `pvc.yaml` | 1Gi `ReadWriteOnce` claim for SQLite DB and logs |
| `secrets.yaml` | Template only — no real values; includes instructions for `kubectl create secret` |
| `namespace.yaml` | Dedicated `nightshift` namespace |
| `serviceaccount.yaml` | Dedicated ServiceAccount |
| `kustomization.yaml` | Kustomize entry-point (`kubectl apply -k deploy/kubernetes/`) |

### `docs/guides/kubernetes-cronjob.md`
Full deployment guide covering:
- Building a container image
- API key vs. subscription CLI authentication
- Git credentials for pushing branches / opening PRs
- Repo mounting strategies (init container clone or git-sync sidecar)
- Environment variables reference
- Production tips (image pinning, secrets managers, RBAC)

### `README.md`
Added a _Kubernetes / Cloud Deployment_ section with quick-start commands and a link to the guide.