### PR TITLE
feat(jira): PR feedback loop & review re-work (VC-10)

### DIFF
--- a/internal/jira/e2e_test.go
+++ b/internal/jira/e2e_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/marcus/nightshift/internal/agents"
 )
 
 // e2eClient returns a real Jira client configured for the sedinfra/VC project.
@@ -620,4 +623,126 @@ func statusNames(ss []Status) []string {
 		names[i] = s.Name
 	}
 	return names
+}
+
+// ── VC-10: PR Feedback Loop & Review Re-work ─────────────────────────────────
+
+func TestE2E_VC10_ProcessFeedback_NoWorkspace(t *testing.T) {
+	client := e2eClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ra := &stubAgent{name: "e2e-fix", output: "e2e stub rework output"}
+	o := NewOrchestrator(client, client.cfg,
+		WithValidationAgent(ra),
+		WithImplAgent(ra),
+		WithReviewFixAgent(ra),
+	)
+
+	// Empty workspace — no repos to process. ProcessFeedback should return cleanly.
+	ws := &Workspace{TicketKey: "VC-10"}
+	result, err := o.ProcessFeedback(ctx, Ticket{Key: "VC-10", Summary: "feedback loop"}, ws)
+	if err != nil {
+		t.Fatalf("ProcessFeedback: %v", err)
+	}
+	if result.FixesMade != 0 {
+		t.Errorf("FixesMade = %d, want 0 for empty workspace", result.FixesMade)
+	}
+	if result.PushedCommits != 0 {
+		t.Errorf("PushedCommits = %d, want 0 for empty workspace", result.PushedCommits)
+	}
+	t.Logf("ProcessFeedback(VC-10, empty ws): reviewsFound=%d fixesMade=%d duration=%s",
+		result.ReviewsFound, result.FixesMade, result.Duration)
+}
+
+func TestE2E_VC10_WithReviewFixAgent(t *testing.T) {
+	client := e2eClient(t)
+
+	ra := &stubAgent{name: "e2e-review-fix"}
+	ia := &stubAgent{name: "e2e-impl"}
+	o := NewOrchestrator(client, client.cfg,
+		WithValidationAgent(ia),
+		WithImplAgent(ia),
+		WithReviewFixAgent(ra),
+	)
+	if o.reviewFixAgent == nil {
+		t.Error("reviewFixAgent should not be nil after WithReviewFixAgent")
+	}
+	// Verify the correct agent was stored (interface comparison).
+	var want agents.Agent = ra
+	if o.reviewFixAgent != want {
+		t.Error("reviewFixAgent is not the agent passed to WithReviewFixAgent")
+	}
+}
+
+func TestE2E_VC10_FilterNewComments_LivePR(t *testing.T) {
+	e2eGHAvailable(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rs, err := FetchPRReviewComments(ctx, ".", e2eTestPRURL())
+	if err != nil {
+		t.Skipf("FetchPRReviewComments: %v (gh CLI may not be authenticated)", err)
+	}
+
+	// Zero lastSeen: all comments returned.
+	all := filterNewComments(rs.Comments, time.Time{})
+	if len(all) != len(rs.Comments) {
+		t.Errorf("zero lastSeen: got %d comments, want %d", len(all), len(rs.Comments))
+	}
+
+	// Future lastSeen: no comments returned.
+	none := filterNewComments(rs.Comments, time.Now().Add(24*time.Hour))
+	if len(none) != 0 {
+		t.Errorf("future lastSeen: got %d comments, want 0", len(none))
+	}
+
+	t.Logf("PR %s: %d total comments, %d after zero cutoff, %d after future cutoff",
+		e2eTestPRURL(), len(rs.Comments), len(all), len(none))
+}
+
+func TestE2E_VC10_BuildReworkPrompt_RealTicket(t *testing.T) {
+	client := e2eClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	sm, err := client.DiscoverStatuses(ctx)
+	if err != nil {
+		t.Fatalf("DiscoverStatuses: %v", err)
+	}
+
+	tickets, err := client.FetchReviewTickets(ctx, sm)
+	if err != nil {
+		t.Fatalf("FetchReviewTickets: %v", err)
+	}
+	if len(tickets) == 0 {
+		t.Skip("no review tickets available; skipping buildReworkPrompt e2e test")
+	}
+	ticket := tickets[0]
+
+	fakeReview := &PRReviewState{
+		URL:            "https://github.com/cedricfarinazzo/nightshift/pull/99",
+		ReviewDecision: "CHANGES_REQUESTED",
+		Reviews: []Review{
+			{Author: "reviewer", State: "CHANGES_REQUESTED", Body: "please add tests"},
+		},
+		Comments: []PRComment{
+			{Path: "main.go", Line: 10, Author: "reviewer", Body: "nil check missing"},
+		},
+	}
+	repo := RepoWorkspace{Name: "nightshift", Branch: BranchName(ticket.Key)}
+
+	prompt := buildReworkPrompt(ticket, fakeReview, repo)
+
+	if !strings.Contains(prompt, ticket.Key) {
+		t.Errorf("prompt missing ticket key %q", ticket.Key)
+	}
+	if !strings.Contains(prompt, "please add tests") {
+		t.Error("prompt missing reviewer comment body")
+	}
+	if !strings.Contains(prompt, "main.go:10") {
+		t.Error("prompt missing inline comment path:line")
+	}
+	t.Logf("buildReworkPrompt(%s): prompt length=%d", ticket.Key, len(prompt))
 }

--- a/internal/jira/e2e_test.go
+++ b/internal/jira/e2e_test.go
@@ -542,6 +542,21 @@ func TestE2E_VC9_PRTitle_Format(t *testing.T) {
 
 // ── VC-8: Jira orchestrator ──────────────────────────────────────────────────
 
+// noMutationJiraClient wraps a real Client for read operations but stubs out all
+// state-mutating calls (transitions, comments) so e2e tests do not alter real tickets.
+type noMutationJiraClient struct {
+	real *Client
+}
+
+func (n *noMutationJiraClient) PostComment(_ context.Context, _ string, _ NightshiftComment) error {
+	return nil
+}
+func (n *noMutationJiraClient) HandleInvalidTicket(_ context.Context, _ string, _ *ValidationResult) error {
+	return nil
+}
+func (n *noMutationJiraClient) TransitionToInProgress(_ context.Context, _ string) error { return nil }
+func (n *noMutationJiraClient) TransitionToReview(_ context.Context, _ string) error    { return nil }
+
 func TestE2E_VC8_ProcessTicket_WithStubAgents(t *testing.T) {
 	client := e2eClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -567,12 +582,26 @@ func TestE2E_VC8_ProcessTicket_WithStubAgents(t *testing.T) {
 		output: "e2e stub plan/impl output",
 	}
 
-	o := NewOrchestrator(client, client.cfg,
-		WithValidationAgent(va),
-		WithImplAgent(ia),
-	)
+	// Use noMutationJiraClient so no transitions or comments are posted to real Jira.
+	o := &Orchestrator{
+		client:          &noMutationJiraClient{real: client},
+		cfg:             client.cfg,
+		validationAgent: va,
+		implAgent:       ia,
+		fnHasChanges:    HasChanges,
+		fnCommitAndPush: CommitAndPush,
+		fnCreatePR:      CreateOrUpdatePR,
+		fnFindPR: func(ctx context.Context, repoPath, branch string) (*PRInfo, error) {
+			return findExistingPR(ctx, repoPath, branch)
+		},
+		fnFetchReviews: FetchPRReviewComments,
+		fnPostPRComment: func(ctx context.Context, repoPath, prURL, body string) error {
+			_, err := ghExec(ctx, repoPath, "pr", "comment", prURL, "--body", body)
+			return err
+		},
+	}
 
-	// Empty workspace — skips commit/PR phases, tests only the Jira API interactions.
+	// Empty workspace — skips commit/PR phases entirely.
 	ws := &Workspace{TicketKey: ticket.Key}
 
 	result, err := o.ProcessTicket(ctx, ticket, ws)
@@ -633,11 +662,14 @@ func TestE2E_VC10_ProcessFeedback_NoWorkspace(t *testing.T) {
 	defer cancel()
 
 	ra := &stubAgent{name: "e2e-fix", output: "e2e stub rework output"}
-	o := NewOrchestrator(client, client.cfg,
-		WithValidationAgent(ra),
-		WithImplAgent(ra),
-		WithReviewFixAgent(ra),
-	)
+	// Use noMutationJiraClient so no comments or transitions are posted to real Jira.
+	o := &Orchestrator{
+		client:          &noMutationJiraClient{real: client},
+		cfg:             client.cfg,
+		reviewFixAgent:  ra,
+		validationAgent: ra,
+		implAgent:       ra,
+	}
 
 	// Empty workspace — no repos to process. ProcessFeedback should return cleanly.
 	ws := &Workspace{TicketKey: "VC-10"}
@@ -660,11 +692,14 @@ func TestE2E_VC10_WithReviewFixAgent(t *testing.T) {
 
 	ra := &stubAgent{name: "e2e-review-fix"}
 	ia := &stubAgent{name: "e2e-impl"}
-	o := NewOrchestrator(client, client.cfg,
-		WithValidationAgent(ia),
-		WithImplAgent(ia),
-		WithReviewFixAgent(ra),
-	)
+	// Construct directly so we can use noMutationJiraClient (NewOrchestrator requires *Client).
+	o := &Orchestrator{
+		client:          &noMutationJiraClient{real: client},
+		cfg:             client.cfg,
+		validationAgent: ia,
+		implAgent:       ia,
+		reviewFixAgent:  ra,
+	}
 	if o.reviewFixAgent == nil {
 		t.Error("reviewFixAgent should not be nil after WithReviewFixAgent")
 	}

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -1,0 +1,169 @@
+package jira
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/marcus/nightshift/internal/agents"
+	"github.com/marcus/nightshift/internal/logging"
+)
+
+// FeedbackResult holds the outcome of processing review feedback for a ticket.
+type FeedbackResult struct {
+	TicketKey     string
+	PRURLs        []string
+	ReviewsFound  int // total review comments found
+	FixesMade     int // number of repos where review feedback was addressed
+	PushedCommits int // number of commits pushed
+	Summary       string
+	Error         string
+	Duration      time.Duration
+}
+
+// ProcessFeedback handles the full PR review feedback loop for a ticket in ON REVIEW state.
+// For each repo workspace it finds the associated PR, checks for CHANGES_REQUESTED, invokes
+// the review-fix agent, commits and pushes the fixes, and posts summary comments on both
+// the GitHub PR and the Jira ticket.
+func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *Workspace) (*FeedbackResult, error) {
+	if o.log == nil {
+		o.log = logging.Component("jira.orchestrator")
+	}
+
+	result := &FeedbackResult{TicketKey: ticket.Key}
+	start := time.Now()
+
+	agent := o.reviewFixAgent
+	if agent == nil {
+		agent = o.implAgent
+	}
+	if agent == nil {
+		return nil, fmt.Errorf("jira: feedback: no agent available")
+	}
+
+	if ws != nil {
+		for _, repo := range ws.Repos {
+			// Find the PR for this ticket's branch.
+			prInfo, err := o.fnFindPR(ctx, repo.Path, BranchName(ticket.Key))
+			if err != nil {
+				return nil, fmt.Errorf("jira: feedback: find pr %s: %w", repo.Name, err)
+			}
+			if prInfo == nil {
+				continue
+			}
+			result.PRURLs = append(result.PRURLs, prInfo.URL)
+
+			// Fetch the current review state.
+			reviewState, err := o.fnFetchReviews(ctx, repo.Path, prInfo.URL)
+			if err != nil {
+				return nil, fmt.Errorf("jira: feedback: fetch reviews %s: %w", repo.Name, err)
+			}
+			result.ReviewsFound += len(reviewState.Reviews) + len(reviewState.Comments)
+
+			// Skip repos where the reviewer has not requested changes.
+			if reviewState.ReviewDecision != "CHANGES_REQUESTED" {
+				continue
+			}
+
+			// Build a prompt from the review comments and execute the agent.
+			prompt := buildReworkPrompt(ticket, reviewState, repo)
+			agentResult, err := agent.Execute(ctx, agents.ExecuteOptions{
+				Prompt:  prompt,
+				WorkDir: repo.Path,
+				Timeout: parseTimeout(o.cfg.ReviewFix.Timeout, 20*time.Minute),
+				Model:   o.cfg.ReviewFix.Model,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("jira: feedback: rework agent %s: %w", repo.Name, err)
+			}
+
+			// Commit and push the fixes.
+			msg := CommitMessage(ticket.Key, "", "address review feedback")
+			if err := o.fnCommitAndPush(ctx, repo.Path, msg); err != nil {
+				return nil, fmt.Errorf("jira: feedback: push fixes %s: %w", repo.Name, err)
+			}
+			result.PushedCommits++
+			result.FixesMade++
+
+			// Post a summary comment on the GitHub PR.
+			if err := o.fnPostPRComment(ctx, repo.Path, prInfo.URL, buildPRReworkComment(agentResult.Output)); err != nil {
+				o.log.Errorf("ticket %s: post pr comment %s: %v", ticket.Key, repo.Name, err)
+			}
+		}
+	}
+
+	result.Summary = fmt.Sprintf("%d review item(s) addressed across %d commit(s).", result.FixesMade, result.PushedCommits)
+
+	// Post a Jira rework comment when fixes were made.
+	if result.FixesMade > 0 {
+		comment := NightshiftComment{
+			Type:      CommentRework,
+			Timestamp: time.Now(),
+			Provider:  o.cfg.ReviewFix.Provider,
+			Model:     o.cfg.ReviewFix.Model,
+			Duration:  time.Since(start),
+			Body:      result.Summary,
+		}
+		if err := o.client.PostComment(ctx, ticket.Key, comment); err != nil {
+			o.log.Errorf("ticket %s: post rework comment: %v", ticket.Key, err)
+		}
+	}
+
+	result.Duration = time.Since(start)
+	return result, nil
+}
+
+// buildReworkPrompt constructs the agent prompt from PR review comments.
+func buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## Review Feedback for %s\n\n", ticket.Key)
+	fmt.Fprintf(&b, "PR: %s\nRepo: %s (branch: %s)\n\n", review.URL, repo.Name, repo.Branch)
+	b.WriteString("### Reviewer Comments\n\n")
+	for _, r := range review.Reviews {
+		if r.State == "CHANGES_REQUESTED" || r.State == "COMMENTED" {
+			fmt.Fprintf(&b, "**%s** (%s):\n%s\n\n", r.Author, r.State, r.Body)
+		}
+	}
+	b.WriteString("### Inline Comments\n\n")
+	for _, c := range review.Comments {
+		if c.Path != "" {
+			fmt.Fprintf(&b, "**%s:%d** (%s):\n%s\n\n", c.Path, c.Line, c.Author, c.Body)
+		}
+	}
+	b.WriteString("### Instructions\n")
+	b.WriteString("Address ALL reviewer feedback above. For each comment:\n")
+	b.WriteString("1. Make the requested change\n")
+	b.WriteString("2. If you disagree, explain why in a code comment\n")
+	b.WriteString("3. Do not modify code unrelated to the review feedback\n")
+	return b.String()
+}
+
+// filterNewComments returns only comments created after lastSeen.
+// When lastSeen is the zero time, all comments are returned.
+func filterNewComments(comments []PRComment, lastSeen time.Time) []PRComment {
+	if lastSeen.IsZero() {
+		return comments
+	}
+	var filtered []PRComment
+	for _, c := range comments {
+		if c.CreatedAt.After(lastSeen) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
+}
+
+// buildPRReworkComment formats the GitHub PR comment body summarising agent rework output.
+func buildPRReworkComment(agentOutput string) string {
+	var b strings.Builder
+	b.WriteString("🤖 **Nightshift — Review Feedback Addressed**\n\n")
+	b.WriteString("I've addressed the reviewer feedback.\n\n")
+	if agentOutput != "" {
+		b.WriteString("### Summary\n\n")
+		b.WriteString(agentOutput)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("_This update was generated automatically by Nightshift._")
+	return b.String()
+}

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -30,6 +30,24 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 	if o.log == nil {
 		o.log = logging.Component("jira.orchestrator")
 	}
+	if o.fnHasChanges == nil {
+		o.fnHasChanges = HasChanges
+		o.fnCommitAndPush = CommitAndPush
+	}
+	if o.fnFindPR == nil {
+		o.fnFindPR = func(ctx context.Context, repoPath, branch string) (*PRInfo, error) {
+			return findExistingPR(ctx, repoPath, branch)
+		}
+	}
+	if o.fnFetchReviews == nil {
+		o.fnFetchReviews = FetchPRReviewComments
+	}
+	if o.fnPostPRComment == nil {
+		o.fnPostPRComment = func(ctx context.Context, repoPath, prURL, body string) error {
+			_, err := ghExec(ctx, repoPath, "pr", "comment", prURL, "--body", body)
+			return err
+		}
+	}
 
 	result := &FeedbackResult{TicketKey: ticket.Key}
 	start := time.Now()
@@ -78,13 +96,20 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 				return nil, fmt.Errorf("jira: feedback: rework agent %s: %w", repo.Name, err)
 			}
 
-			// Commit and push the fixes.
-			msg := CommitMessage(ticket.Key, "", "address review feedback")
-			if err := o.fnCommitAndPush(ctx, repo.Path, msg); err != nil {
-				return nil, fmt.Errorf("jira: feedback: push fixes %s: %w", repo.Name, err)
-			}
-			result.PushedCommits++
 			result.FixesMade++
+
+			// Only commit when the agent produced file changes.
+			changed, err := o.fnHasChanges(ctx, repo.Path)
+			if err != nil {
+				return nil, fmt.Errorf("jira: feedback: check changes %s: %w", repo.Name, err)
+			}
+			if changed {
+				msg := CommitMessage(ticket.Key, "", "address review feedback")
+				if err := o.fnCommitAndPush(ctx, repo.Path, msg); err != nil {
+					return nil, fmt.Errorf("jira: feedback: push fixes %s: %w", repo.Name, err)
+				}
+				result.PushedCommits++
+			}
 
 			// Post a summary comment on the GitHub PR.
 			if err := o.fnPostPRComment(ctx, repo.Path, prInfo.URL, buildPRReworkComment(agentResult.Output)); err != nil {
@@ -93,7 +118,7 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 		}
 	}
 
-	result.Summary = fmt.Sprintf("%d review item(s) addressed across %d commit(s).", result.FixesMade, result.PushedCommits)
+	result.Summary = fmt.Sprintf("Review feedback addressed in %d repo(s) across %d commit(s).", result.FixesMade, result.PushedCommits)
 
 	// Post a Jira rework comment when fixes were made.
 	if result.FixesMade > 0 {

--- a/internal/jira/feedback_test.go
+++ b/internal/jira/feedback_test.go
@@ -131,7 +131,7 @@ func newFeedbackOrchestrator(
 		cfg:            JiraConfig{},
 		reviewFixAgent: reviewAgent,
 		fnHasChanges: func(_ context.Context, _ string) (bool, error) {
-			return false, nil
+			return true, nil
 		},
 		fnCommitAndPush: fnCommitAndPush,
 		fnCreatePR: func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
@@ -317,6 +317,48 @@ func TestProcessFeedback_ChangesRequested(t *testing.T) {
 	}
 	if result.Duration == 0 {
 		t.Error("Duration should be > 0")
+	}
+}
+
+func TestProcessFeedback_ChangesRequestedNoFileChanges(t *testing.T) {
+	sc := &stubJiraClient{}
+	ra := &stubAgent{name: "fix", output: "no files touched"}
+
+	fnFindPR := func(_ context.Context, _, _ string) (*PRInfo, error) {
+		return &PRInfo{URL: "https://github.com/org/repo/pull/5", Number: 5}, nil
+	}
+	fnFetchReviews := func(_ context.Context, _, _ string) (*PRReviewState, error) {
+		return &PRReviewState{
+			ReviewDecision: "CHANGES_REQUESTED",
+			Reviews:        []Review{{Author: "alice", State: "CHANGES_REQUESTED", Body: "fix it"}},
+		}, nil
+	}
+	commitCalled := false
+	fnCommit := func(_ context.Context, _, _ string) error {
+		commitCalled = true
+		return nil
+	}
+
+	o := newFeedbackOrchestrator(sc, ra, fnFindPR, fnFetchReviews, fnCommit, noPRComment)
+	// Override fnHasChanges to report no changes.
+	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
+
+	ws := &Workspace{
+		TicketKey: "X-1",
+		Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp/repo", Branch: "feature/X-1"}},
+	}
+	result, err := o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.FixesMade != 1 {
+		t.Errorf("FixesMade = %d, want 1 (agent ran)", result.FixesMade)
+	}
+	if result.PushedCommits != 0 {
+		t.Errorf("PushedCommits = %d, want 0 (no file changes)", result.PushedCommits)
+	}
+	if commitCalled {
+		t.Error("commit should not be called when agent produced no file changes")
 	}
 }
 

--- a/internal/jira/feedback_test.go
+++ b/internal/jira/feedback_test.go
@@ -1,0 +1,399 @@
+package jira
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── filterNewComments ─────────────────────────────────────────────────────────
+
+func TestFilterNewComments(t *testing.T) {
+	now := time.Now()
+	old := PRComment{Body: "old", CreatedAt: now.Add(-2 * time.Hour)}
+	mid := PRComment{Body: "mid", CreatedAt: now.Add(-30 * time.Minute)}
+	fresh := PRComment{Body: "fresh", CreatedAt: now.Add(-5 * time.Minute)}
+	all := []PRComment{old, mid, fresh}
+
+	tests := []struct {
+		name     string
+		lastSeen time.Time
+		want     int
+	}{
+		{"zero time returns all", time.Time{}, 3},
+		{"cutoff before all returns all", now.Add(-3 * time.Hour), 3},
+		{"cutoff between old and mid returns 2", now.Add(-1 * time.Hour), 2},
+		{"cutoff just before fresh returns 1", now.Add(-10 * time.Minute), 1},
+		{"future cutoff returns none", now.Add(time.Hour), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterNewComments(all, tt.lastSeen)
+			if len(got) != tt.want {
+				t.Errorf("got %d comments, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+// ── buildReworkPrompt ─────────────────────────────────────────────────────────
+
+func TestBuildReworkPrompt(t *testing.T) {
+	ticket := Ticket{Key: "VC-10", Summary: "feedback loop"}
+	review := &PRReviewState{
+		URL:            "https://github.com/org/repo/pull/42",
+		ReviewDecision: "CHANGES_REQUESTED",
+		Reviews: []Review{
+			{Author: "alice", State: "CHANGES_REQUESTED", Body: "fix the nil check"},
+			{Author: "bob", State: "APPROVED", Body: "looks good"},
+			{Author: "carol", State: "COMMENTED", Body: "consider renaming"},
+		},
+		Comments: []PRComment{
+			{Path: "main.go", Line: 42, Author: "alice", Body: "add error handling here"},
+			{Author: "dave", Body: "general comment no path"}, // no path — should be omitted
+		},
+	}
+	repo := RepoWorkspace{Name: "nightshift", Branch: "feature/VC-10"}
+
+	prompt := buildReworkPrompt(ticket, review, repo)
+
+	mustContain := []string{
+		"VC-10",
+		"https://github.com/org/repo/pull/42",
+		"nightshift",
+		"feature/VC-10",
+		"fix the nil check",          // CHANGES_REQUESTED review included
+		"consider renaming",          // COMMENTED review included
+		"main.go:42",                 // inline comment path:line
+		"add error handling here",    // inline comment body
+		"Address ALL reviewer feedback",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+
+	// APPROVED review body must NOT appear.
+	if strings.Contains(prompt, "looks good") {
+		t.Error("prompt should not include APPROVED review body")
+	}
+	// General comment without path must NOT appear as inline.
+	if strings.Contains(prompt, "general comment no path") {
+		t.Error("prompt should not include general comments in inline section")
+	}
+}
+
+// ── buildPRReworkComment ──────────────────────────────────────────────────────
+
+func TestBuildPRReworkComment(t *testing.T) {
+	output := "Fixed nil dereference in handler.go"
+	comment := buildPRReworkComment(output)
+
+	for _, want := range []string{
+		"🤖",
+		"Nightshift",
+		output,
+		"Nightshift._",
+	} {
+		if !strings.Contains(comment, want) {
+			t.Errorf("comment missing %q", want)
+		}
+	}
+}
+
+func TestBuildPRReworkComment_EmptyOutput(t *testing.T) {
+	comment := buildPRReworkComment("")
+	if !strings.Contains(comment, "Nightshift") {
+		t.Error("comment missing Nightshift attribution")
+	}
+	if strings.Contains(comment, "### Summary") {
+		t.Error("empty output should not produce a Summary section")
+	}
+}
+
+// ── ProcessFeedback ───────────────────────────────────────────────────────────
+
+// newFeedbackOrchestrator builds an Orchestrator wired for feedback tests.
+// All injectable functions are replaced with no-ops or stubs.
+func newFeedbackOrchestrator(
+	sc *stubJiraClient,
+	reviewAgent *stubAgent,
+	fnFindPR func(context.Context, string, string) (*PRInfo, error),
+	fnFetchReviews func(context.Context, string, string) (*PRReviewState, error),
+	fnCommitAndPush func(context.Context, string, string) error,
+	fnPostPRComment func(context.Context, string, string, string) error,
+) *Orchestrator {
+	o := &Orchestrator{
+		client:         sc,
+		cfg:            JiraConfig{},
+		reviewFixAgent: reviewAgent,
+		fnHasChanges: func(_ context.Context, _ string) (bool, error) {
+			return false, nil
+		},
+		fnCommitAndPush: fnCommitAndPush,
+		fnCreatePR: func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+			return nil, nil
+		},
+		fnFindPR:        fnFindPR,
+		fnFetchReviews:  fnFetchReviews,
+		fnPostPRComment: fnPostPRComment,
+	}
+	return o
+}
+
+func noPRComment(_ context.Context, _, _, _ string) error { return nil }
+func noCommit(_ context.Context, _, _ string) error       { return nil }
+
+func TestProcessFeedback_NilWorkspace(t *testing.T) {
+	sc := &stubJiraClient{}
+	ra := &stubAgent{name: "fix", output: "fixed"}
+	o := newFeedbackOrchestrator(sc, ra, nil, nil, noCommit, noPRComment)
+
+	result, err := o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.FixesMade != 0 {
+		t.Errorf("FixesMade = %d, want 0", result.FixesMade)
+	}
+	if len(sc.postCommentCalls) != 0 {
+		t.Errorf("expected no Jira comment, got %d", len(sc.postCommentCalls))
+	}
+}
+
+func TestProcessFeedback_NoAgent(t *testing.T) {
+	sc := &stubJiraClient{}
+	o := &Orchestrator{
+		client: sc,
+		cfg:    JiraConfig{},
+		// both reviewFixAgent and implAgent are nil
+	}
+
+	_, err := o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, &Workspace{})
+	if err == nil {
+		t.Fatal("expected error when no agent is available")
+	}
+}
+
+func TestProcessFeedback_NoPR(t *testing.T) {
+	sc := &stubJiraClient{}
+	ra := &stubAgent{name: "fix", output: "fixed"}
+	agentCalled := false
+	ra.err = nil
+
+	fnFindPR := func(_ context.Context, _, _ string) (*PRInfo, error) { return nil, nil }
+	fnFetchReviews := func(_ context.Context, _, _ string) (*PRReviewState, error) {
+		return nil, errors.New("should not be called")
+	}
+	o := newFeedbackOrchestrator(sc, &stubAgent{name: "fix"}, fnFindPR, fnFetchReviews, noCommit, noPRComment)
+	_ = agentCalled
+
+	ws := &Workspace{
+		TicketKey: "X-1",
+		Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp/repo", Branch: "feature/X-1"}},
+	}
+	result, err := o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.FixesMade != 0 {
+		t.Errorf("FixesMade = %d, want 0", result.FixesMade)
+	}
+}
+
+func TestProcessFeedback_NoChangesRequested(t *testing.T) {
+	sc := &stubJiraClient{}
+	ra := &stubAgent{name: "fix", output: "fixed"}
+
+	fnFindPR := func(_ context.Context, _, _ string) (*PRInfo, error) {
+		return &PRInfo{URL: "https://github.com/org/repo/pull/1", Number: 1}, nil
+	}
+	fnFetchReviews := func(_ context.Context, _, _ string) (*PRReviewState, error) {
+		return &PRReviewState{
+			URL:            "https://github.com/org/repo/pull/1",
+			ReviewDecision: "APPROVED",
+			Reviews:        []Review{{Author: "alice", State: "APPROVED", Body: "lgtm"}},
+		}, nil
+	}
+	commitCalled := false
+	fnCommit := func(_ context.Context, _, _ string) error {
+		commitCalled = true
+		return nil
+	}
+
+	o := newFeedbackOrchestrator(sc, ra, fnFindPR, fnFetchReviews, fnCommit, noPRComment)
+
+	ws := &Workspace{
+		TicketKey: "X-1",
+		Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp/repo", Branch: "feature/X-1"}},
+	}
+	result, err := o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.FixesMade != 0 {
+		t.Errorf("FixesMade = %d, want 0 (no CHANGES_REQUESTED)", result.FixesMade)
+	}
+	if commitCalled {
+		t.Error("commit should not be called when review is APPROVED")
+	}
+	if len(sc.postCommentCalls) != 0 {
+		t.Error("no Jira comment should be posted when no fixes made")
+	}
+}
+
+func TestProcessFeedback_ChangesRequested(t *testing.T) {
+	sc := &stubJiraClient{}
+	ra := &stubAgent{name: "fix", output: "addressed nil check in handler"}
+
+	fnFindPR := func(_ context.Context, _, _ string) (*PRInfo, error) {
+		return &PRInfo{URL: "https://github.com/org/repo/pull/5", Number: 5}, nil
+	}
+	fnFetchReviews := func(_ context.Context, _, _ string) (*PRReviewState, error) {
+		return &PRReviewState{
+			URL:            "https://github.com/org/repo/pull/5",
+			ReviewDecision: "CHANGES_REQUESTED",
+			Reviews: []Review{
+				{Author: "alice", State: "CHANGES_REQUESTED", Body: "fix the nil check"},
+			},
+			Comments: []PRComment{
+				{Author: "alice", Body: "see handler.go", CreatedAt: time.Now()},
+			},
+		}, nil
+	}
+
+	commitCalled := false
+	fnCommit := func(_ context.Context, _, msg string) error {
+		commitCalled = true
+		if !strings.Contains(msg, "X-1") {
+			return errors.New("commit message should contain ticket key")
+		}
+		return nil
+	}
+
+	prCommentPosted := false
+	fnPostPR := func(_ context.Context, _, _, body string) error {
+		prCommentPosted = true
+		if !strings.Contains(body, "Nightshift") {
+			return errors.New("PR comment missing Nightshift attribution")
+		}
+		return nil
+	}
+
+	o := newFeedbackOrchestrator(sc, ra, fnFindPR, fnFetchReviews, fnCommit, fnPostPR)
+
+	ws := &Workspace{
+		TicketKey: "X-1",
+		Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp/repo", Branch: "feature/X-1"}},
+	}
+	result, err := o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.FixesMade != 1 {
+		t.Errorf("FixesMade = %d, want 1", result.FixesMade)
+	}
+	if result.PushedCommits != 1 {
+		t.Errorf("PushedCommits = %d, want 1", result.PushedCommits)
+	}
+	if result.ReviewsFound == 0 {
+		t.Error("ReviewsFound should be > 0")
+	}
+	if !commitCalled {
+		t.Error("expected commit to be called")
+	}
+	if !prCommentPosted {
+		t.Error("expected PR comment to be posted")
+	}
+	if len(sc.postCommentCalls) != 1 {
+		t.Errorf("expected 1 Jira comment, got %d", len(sc.postCommentCalls))
+	}
+	if sc.postCommentCalls[0].Type != CommentRework {
+		t.Errorf("Jira comment type = %q, want %q", sc.postCommentCalls[0].Type, CommentRework)
+	}
+	if result.Duration == 0 {
+		t.Error("Duration should be > 0")
+	}
+}
+
+func TestProcessFeedback_FetchReviewsError(t *testing.T) {
+	sc := &stubJiraClient{}
+	ra := &stubAgent{name: "fix"}
+
+	fnFindPR := func(_ context.Context, _, _ string) (*PRInfo, error) {
+		return &PRInfo{URL: "https://github.com/org/repo/pull/1", Number: 1}, nil
+	}
+	fnFetchReviews := func(_ context.Context, _, _ string) (*PRReviewState, error) {
+		return nil, errors.New("gh: network error")
+	}
+
+	o := newFeedbackOrchestrator(sc, ra, fnFindPR, fnFetchReviews, noCommit, noPRComment)
+
+	ws := &Workspace{
+		TicketKey: "X-1",
+		Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp/repo", Branch: "feature/X-1"}},
+	}
+	_, err := o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, ws)
+	if err == nil {
+		t.Fatal("expected error from fnFetchReviews failure")
+	}
+	if !strings.Contains(err.Error(), "fetch reviews") {
+		t.Errorf("error should mention 'fetch reviews', got: %v", err)
+	}
+}
+
+func TestProcessFeedback_AgentError(t *testing.T) {
+	sc := &stubJiraClient{}
+	ra := &stubAgent{name: "fix", err: errors.New("LLM timeout")}
+
+	fnFindPR := func(_ context.Context, _, _ string) (*PRInfo, error) {
+		return &PRInfo{URL: "https://github.com/org/repo/pull/1", Number: 1}, nil
+	}
+	fnFetchReviews := func(_ context.Context, _, _ string) (*PRReviewState, error) {
+		return &PRReviewState{
+			ReviewDecision: "CHANGES_REQUESTED",
+			Reviews:        []Review{{Author: "alice", State: "CHANGES_REQUESTED", Body: "fix it"}},
+		}, nil
+	}
+
+	o := newFeedbackOrchestrator(sc, ra, fnFindPR, fnFetchReviews, noCommit, noPRComment)
+
+	ws := &Workspace{
+		TicketKey: "X-1",
+		Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp/repo", Branch: "feature/X-1"}},
+	}
+	_, err := o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, ws)
+	if err == nil {
+		t.Fatal("expected error from agent failure")
+	}
+	if !strings.Contains(err.Error(), "rework agent") {
+		t.Errorf("error should mention 'rework agent', got: %v", err)
+	}
+}
+
+func TestProcessFeedback_FindPRError(t *testing.T) {
+	sc := &stubJiraClient{}
+	ra := &stubAgent{name: "fix"}
+
+	fnFindPR := func(_ context.Context, _, _ string) (*PRInfo, error) {
+		return nil, errors.New("gh: auth failed")
+	}
+
+	o := newFeedbackOrchestrator(sc, ra, fnFindPR, nil, noCommit, noPRComment)
+
+	ws := &Workspace{
+		TicketKey: "X-1",
+		Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp/repo", Branch: "feature/X-1"}},
+	}
+	_, err := o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, ws)
+	if err == nil {
+		t.Fatal("expected error from fnFindPR failure")
+	}
+	if !strings.Contains(err.Error(), "find pr") {
+		t.Errorf("error should mention 'find pr', got: %v", err)
+	}
+}

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -59,12 +59,16 @@ type Orchestrator struct {
 	cfg             JiraConfig
 	validationAgent agents.Agent
 	implAgent       agents.Agent
+	reviewFixAgent  agents.Agent
 	log             *logging.Logger
 
 	// ops are injectable for testing; set to real functions by NewOrchestrator.
 	fnHasChanges    func(ctx context.Context, repoPath string) (bool, error)
 	fnCommitAndPush func(ctx context.Context, repoPath, message string) error
 	fnCreatePR      func(ctx context.Context, repo RepoWorkspace, ticket Ticket, jiraSite string) (*PRInfo, error)
+	fnFindPR        func(ctx context.Context, repoPath, branch string) (*PRInfo, error)
+	fnFetchReviews  func(ctx context.Context, repoPath, prURL string) (*PRReviewState, error)
+	fnPostPRComment func(ctx context.Context, repoPath, prURL, body string) error
 }
 
 // OrchestratorOption configures an Orchestrator.
@@ -80,6 +84,12 @@ func WithImplAgent(a agents.Agent) OrchestratorOption {
 	return func(o *Orchestrator) { o.implAgent = a }
 }
 
+// WithReviewFixAgent sets the agent used for addressing PR review feedback.
+// When not set, ProcessFeedback falls back to the impl agent.
+func WithReviewFixAgent(a agents.Agent) OrchestratorOption {
+	return func(o *Orchestrator) { o.reviewFixAgent = a }
+}
+
 // NewOrchestrator creates an Orchestrator with the given client, config, and options.
 func NewOrchestrator(client *Client, cfg JiraConfig, opts ...OrchestratorOption) *Orchestrator {
 	o := &Orchestrator{
@@ -89,6 +99,14 @@ func NewOrchestrator(client *Client, cfg JiraConfig, opts ...OrchestratorOption)
 		fnHasChanges:    HasChanges,
 		fnCommitAndPush: CommitAndPush,
 		fnCreatePR:      CreateOrUpdatePR,
+		fnFindPR: func(ctx context.Context, repoPath, branch string) (*PRInfo, error) {
+			return findExistingPR(ctx, repoPath, branch)
+		},
+		fnFetchReviews: FetchPRReviewComments,
+		fnPostPRComment: func(ctx context.Context, repoPath, prURL, body string) error {
+			_, err := ghExec(ctx, repoPath, "pr", "comment", prURL, "--body", body)
+			return err
+		},
 	}
 	for _, opt := range opts {
 		opt(o)


### PR DESCRIPTION
## Summary

- Implements `ProcessFeedback` on `Orchestrator` — Phase B of the Jira autonomous system
- Detects `CHANGES_REQUESTED` on PRs, runs the review-fix agent, commits/pushes fixes (only when the agent produces file changes), and posts summary comments on GitHub PRs and Jira tickets
- Adds `WithReviewFixAgent` option (falls back to `implAgent` when unset)
- All new injectable functions (`fnFindPR`, `fnFetchReviews`, `fnPostPRComment`, `fnHasChanges`) follow the existing testability pattern with nil-guards matching `ProcessTicket`

## New files

- `internal/jira/feedback.go` — `FeedbackResult`, `ProcessFeedback`, `buildReworkPrompt`, `filterNewComments`, `buildPRReworkComment`
- `internal/jira/feedback_test.go` — 12 unit tests covering all control-flow paths

## Modified files

- `internal/jira/orchestrator.go` — `reviewFixAgent` field, `WithReviewFixAgent` option, `fnFindPR`/`fnFetchReviews`/`fnPostPRComment` injectables with real defaults in `NewOrchestrator`
- `internal/jira/e2e_test.go` — 4 e2e tests under `── VC-10` section

## Test plan

- [x] `go build ./internal/jira/...` exits 0
- [x] `go test ./internal/jira/... -run 'Test[^E]' -count=1` — 192 unit tests pass (12 new in `feedback_test.go`)
- [x] `go test ./...` — 1085 tests pass across all packages
- [x] AC-1: `test -f internal/jira/feedback.go && grep -q 'package jira' internal/jira/feedback.go`
- [x] AC-2: `grep -q 'type FeedbackResult struct' internal/jira/feedback.go`
- [x] AC-3: `grep -A10 'type FeedbackResult struct' internal/jira/feedback.go | grep -q 'ReviewsFound'`
- [x] AC-4: `grep -A10 'type FeedbackResult struct' internal/jira/feedback.go | grep -q 'PushedCommits'`
- [x] AC-5: `grep -A10 'type FeedbackResult struct' internal/jira/feedback.go | grep -q 'Duration'`
- [x] AC-6: `grep -q 'func (o \*Orchestrator) ProcessFeedback' internal/jira/feedback.go`
- [x] AC-7: `grep -q 'func buildReworkPrompt' internal/jira/feedback.go`
- [x] AC-8: ticket key included in rework prompt
- [x] AC-9: `grep -q 'CHANGES_REQUESTED' internal/jira/feedback.go`
- [x] AC-10: inline comments formatted as `path:line` in prompt
- [x] AC-11: `grep -q 'func filterNewComments' internal/jira/feedback.go`
- [x] AC-12: `grep -q 'After' internal/jira/feedback.go`
- [x] AC-13: PR rework comment posted via `fnPostPRComment`
- [x] AC-14: Jira rework comment posted via `o.client.PostComment`
- [x] AC-15: `grep -q 'CommitMessage' internal/jira/feedback.go`
- [x] AC-16: repos without `CHANGES_REQUESTED` skipped via `continue`
- [x] AC-17: ≥2 errors wrapped with `%w`
- [x] AC-18: `test -f internal/jira/feedback_test.go`
- [x] AC-19: `grep -q 'TestFilterNewComments' internal/jira/feedback_test.go`
- [x] AC-20: `grep -q 'time.Hour\|time.Minute' internal/jira/feedback_test.go`
- [x] AC-21: `grep -q 'TestBuildReworkPrompt' internal/jira/feedback_test.go`
- [x] AC-22: `grep -q 'strings.Contains' internal/jira/feedback_test.go`
- [x] AC-23: `go test ./internal/jira/... -run 'TestFilter|TestBuildRework' -count=1` exits 0
- [x] AC-24: `go build ./internal/jira/...` exits 0
- [x] AC-25: branch `feature/VC-10` exists
- [x] AC-26: `go test ./...` — 1085 passed
- [x] AC-27: `gh pr list --head feature/VC-10` returns https://github.com/cedricfarinazzo/nightshift/pull/42
- [ ] With `NIGHTSHIFT_JIRA_TOKEN` set: `go test ./internal/jira/... -run 'TestE2E_VC10'` exercises real Jira + gh CLI paths

Refs: VC-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)