### PR TITLE
fix(jira): filter closed PRs in findExistingPR (VC-44)

### DIFF
--- a/internal/jira/pr.go
+++ b/internal/jira/pr.go
@@ -218,7 +218,8 @@ func prTitle(ticket Ticket) string {
 func findExistingPR(ctx context.Context, repoPath, branch string) (*PRInfo, error) {
 	out, err := ghExec(ctx, repoPath, "pr", "list",
 		"--head", branch,
-		"--json", "number,url,state",
+		"--state", "open",
+		"--json", "number,url",
 		"--limit", "1")
 	if err != nil {
 		return nil, fmt.Errorf("gh pr list: %w", err)
@@ -226,7 +227,6 @@ func findExistingPR(ctx context.Context, repoPath, branch string) (*PRInfo, erro
 	var prs []struct {
 		Number int    `json:"number"`
 		URL    string `json:"url"`
-		State  string `json:"state"`
 	}
 	if err := json.Unmarshal([]byte(out), &prs); err != nil {
 		return nil, fmt.Errorf("parse pr list: %w", err)
@@ -254,7 +254,8 @@ func fetchPRInfo(ctx context.Context, repoPath, prURL string) (*PRInfo, error) {
 }
 
 // ghExec runs a gh command in repoPath and returns trimmed combined output.
-func ghExec(ctx context.Context, repoPath string, args ...string) (string, error) {
+// It is a variable so tests can substitute a fake implementation.
+var ghExec = func(ctx context.Context, repoPath string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "gh", args...)
 	cmd.Dir = repoPath
 	out, err := cmd.CombinedOutput()

--- a/internal/jira/pr_test.go
+++ b/internal/jira/pr_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -280,5 +281,71 @@ func TestParsePRReviewState_MissingFields(t *testing.T) {
 	}
 	if rs.Reviews != nil || rs.Comments != nil {
 		t.Error("expected nil slices for missing fields")
+	}
+}
+
+// ── findExistingPR ────────────────────────────────────────────────────────────
+
+func TestFindExistingPR_OpenPR(t *testing.T) {
+	orig := ghExec
+	defer func() { ghExec = orig }()
+
+	ghExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		return `[{"number":42,"url":"https://github.com/org/repo/pull/42"}]`, nil
+	}
+
+	pr, err := findExistingPR(context.Background(), "/repo", "feature/VC-44")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr == nil {
+		t.Fatal("expected PRInfo, got nil")
+	}
+	if pr.Number != 42 {
+		t.Errorf("Number = %d, want 42", pr.Number)
+	}
+	if pr.URL != "https://github.com/org/repo/pull/42" {
+		t.Errorf("URL = %q", pr.URL)
+	}
+}
+
+func TestFindExistingPR_NoPR(t *testing.T) {
+	orig := ghExec
+	defer func() { ghExec = orig }()
+
+	ghExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		return `[]`, nil
+	}
+
+	pr, err := findExistingPR(context.Background(), "/repo", "feature/VC-44")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr != nil {
+		t.Errorf("expected nil for empty list, got %+v", pr)
+	}
+}
+
+func TestFindExistingPR_StateOpenFlagPassed(t *testing.T) {
+	orig := ghExec
+	defer func() { ghExec = orig }()
+
+	var capturedArgs []string
+	ghExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		capturedArgs = args
+		return `[]`, nil
+	}
+
+	_, _ = findExistingPR(context.Background(), "/repo", "feature/VC-44")
+
+	found := false
+	for i, a := range capturedArgs {
+		if a == "--state" && i+1 < len(capturedArgs) && capturedArgs[i+1] == "open" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --state open in gh pr list args, got: %v", capturedArgs)
 	}
 }


### PR DESCRIPTION
## VC-44 — findExistingPR matches closed PRs, preventing new PR creation

Adds `--state open` to the `gh pr list` invocation so closed PRs on the same branch are ignored. Also removes the now-unused `State` field from the JSON unmarshal struct and makes `ghExec` a variable for test substitution, with three new unit tests covering the fix.

**Bug:** `findExistingPR` was calling `gh pr list --head branch --limit 1` without `--state open`, causing a closed PR from a previous attempt to match and be "updated" via `gh pr edit` instead of creating a fresh open PR.

Refs: VC-44

🤖 Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift)