### PR TITLE
[VC-39] Error comments attribute wrong provider/model for non-plan phases

### DIFF
--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -559,14 +559,22 @@ func (o *Orchestrator) providerForCommentType(ct CommentType) (provider, model s
 	return o.cfg.Implement.Provider, o.cfg.Implement.Model
 }
 
+// providerForPhase returns the provider/model for the agent that runs a given phase.
+func (o *Orchestrator) providerForPhase(phase Phase) (provider, model string) {
+	switch phase {
+	case PhaseValidate:
+		return o.cfg.Validation.Provider, o.cfg.Validation.Model
+	case PhasePlan:
+		return o.cfg.Plan.Provider, o.cfg.Plan.Model
+	default: // PhaseImplement, PhaseCommit, PhasePR, PhaseStatus
+		return o.cfg.Implement.Provider, o.cfg.Implement.Model
+	}
+}
+
 // postErrorComment posts an error comment to the Jira ticket.
 func (o *Orchestrator) postErrorComment(ctx context.Context, ticketKey string, phase Phase, err error) {
-	// Select provider/model based on which phase failed.
 	ct := CommentError
-	provider, model := o.providerForCommentType(CommentImplement)
-	if phase == PhasePlan {
-		provider, model = o.providerForCommentType(CommentPlan)
-	}
+	provider, model := o.providerForPhase(phase)
 	comment := NightshiftComment{
 		Type:      ct,
 		Timestamp: time.Now(),

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -550,7 +550,7 @@ func buildPRImplementationComment(ticket Ticket, summary, jiraSite string) strin
 	return b.String()
 }
 
-// providerForCommentType selects provider/model metadata based on the comment type.
+// providerForCommentType selects provider/model attribution metadata for a comment type.
 func (o *Orchestrator) providerForCommentType(ct CommentType) (provider, model string) {
 	switch ct {
 	case CommentValidation:
@@ -562,15 +562,21 @@ func (o *Orchestrator) providerForCommentType(ct CommentType) (provider, model s
 	}
 }
 
-// providerForPhase returns the provider/model for the agent that runs a given phase.
+// providerForPhase returns the configured provider/model metadata associated with
+// a phase for comment attribution and error reporting. This reflects phase config
+// rather than necessarily the actual agent that executed the phase.
 func (o *Orchestrator) providerForPhase(phase Phase) (provider, model string) {
+	return o.providerForCommentType(commentTypeForPhase(phase))
+}
+
+func commentTypeForPhase(phase Phase) CommentType {
 	switch phase {
 	case PhaseValidate:
-		return o.cfg.Validation.Provider, o.cfg.Validation.Model
+		return CommentValidation
 	case PhasePlan:
-		return o.cfg.Plan.Provider, o.cfg.Plan.Model
+		return CommentPlan
 	default: // PhaseImplement, PhaseCommit, PhasePR, PhaseStatus
-		return o.cfg.Implement.Provider, o.cfg.Implement.Model
+		return CommentImplement
 	}
 }
 

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -551,12 +551,15 @@ func buildPRImplementationComment(ticket Ticket, summary, jiraSite string) strin
 }
 
 // providerForCommentType selects provider/model metadata based on the comment type.
-// Plan comments use the plan phase config; everything else uses the implement config.
 func (o *Orchestrator) providerForCommentType(ct CommentType) (provider, model string) {
-	if ct == CommentPlan {
+	switch ct {
+	case CommentValidation:
+		return o.cfg.Validation.Provider, o.cfg.Validation.Model
+	case CommentPlan:
 		return o.cfg.Plan.Provider, o.cfg.Plan.Model
+	default:
+		return o.cfg.Implement.Provider, o.cfg.Implement.Model
 	}
-	return o.cfg.Implement.Provider, o.cfg.Implement.Model
 }
 
 // providerForPhase returns the provider/model for the agent that runs a given phase.

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -959,3 +959,31 @@ func TestProcessTicket_SkipsValidationWhenAlreadyValidated(t *testing.T) {
 		t.Errorf("status = %s, want completed", result.Status)
 	}
 }
+
+func TestProviderForPhase(t *testing.T) {
+	cfg := JiraConfig{
+		Validation: PhaseConfig{Provider: "claude", Model: "claude-haiku-4.5"},
+		Plan:       PhaseConfig{Provider: "claude", Model: "claude-opus-4"},
+		Implement:  PhaseConfig{Provider: "codex", Model: "o3"},
+	}
+	o := &Orchestrator{cfg: cfg}
+
+	cases := []struct {
+		phase    Phase
+		wantProv string
+		wantMod  string
+	}{
+		{PhaseValidate, "claude", "claude-haiku-4.5"},
+		{PhasePlan, "claude", "claude-opus-4"},
+		{PhaseImplement, "codex", "o3"},
+		{PhaseCommit, "codex", "o3"},
+		{PhasePR, "codex", "o3"},
+		{PhaseStatus, "codex", "o3"},
+	}
+	for _, tc := range cases {
+		prov, mod := o.providerForPhase(tc.phase)
+		if prov != tc.wantProv || mod != tc.wantMod {
+			t.Errorf("phase %s: got %s/%s, want %s/%s", tc.phase, prov, mod, tc.wantProv, tc.wantMod)
+		}
+	}
+}

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -1014,3 +1014,27 @@ func TestProviderForCommentType(t *testing.T) {
 		}
 	}
 }
+
+func TestValidationCommentMetadataMatchesPhase(t *testing.T) {
+	sc := &stubJiraClient{}
+	o := &Orchestrator{
+		client: sc,
+		cfg: JiraConfig{
+			Validation: PhaseConfig{Provider: "claude", Model: "claude-haiku-4.5"},
+			Plan:       PhaseConfig{Provider: "claude", Model: "claude-opus-4"},
+			Implement:  PhaseConfig{Provider: "codex", Model: "o3"},
+		},
+	}
+
+	o.postPhaseComment(context.Background(), "T-1", CommentValidation, "Ticket validated.", time.Second)
+	o.postErrorComment(context.Background(), "T-1", PhaseValidate, errors.New("validation failed"))
+
+	if len(sc.postCommentCalls) != 2 {
+		t.Fatalf("expected 2 comments, got %d", len(sc.postCommentCalls))
+	}
+	for i, c := range sc.postCommentCalls {
+		if c.Provider != "claude" || c.Model != "claude-haiku-4.5" {
+			t.Errorf("comment[%d] metadata = %s/%s, want claude/claude-haiku-4.5", i, c.Provider, c.Model)
+		}
+	}
+}

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -987,3 +987,30 @@ func TestProviderForPhase(t *testing.T) {
 		}
 	}
 }
+
+func TestProviderForCommentType(t *testing.T) {
+	cfg := JiraConfig{
+		Validation: PhaseConfig{Provider: "claude", Model: "claude-haiku-4.5"},
+		Plan:       PhaseConfig{Provider: "claude", Model: "claude-opus-4"},
+		Implement:  PhaseConfig{Provider: "codex", Model: "o3"},
+	}
+	o := &Orchestrator{cfg: cfg}
+
+	cases := []struct {
+		ct       CommentType
+		wantProv string
+		wantMod  string
+	}{
+		{CommentValidation, "claude", "claude-haiku-4.5"},
+		{CommentPlan, "claude", "claude-opus-4"},
+		{CommentImplement, "codex", "o3"},
+		{CommentPR, "codex", "o3"},
+		{CommentStatusChange, "codex", "o3"},
+	}
+	for _, tc := range cases {
+		prov, mod := o.providerForCommentType(tc.ct)
+		if prov != tc.wantProv || mod != tc.wantMod {
+			t.Errorf("comment type %s: got %s/%s, want %s/%s", tc.ct, prov, mod, tc.wantProv, tc.wantMod)
+		}
+	}
+}


### PR DESCRIPTION
## VC-39 — Error comments attribute wrong provider/model for non-plan phases

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-39

### Description

postErrorComment in orchestrator.go:341-348 always uses the implement phase provider/model for all phases except PhasePlan. Validation, commit, PR, and status-transition failures all report the implement provider/model in the Jira comment, making it impossible to tell which provider actually failed.\n\nFile: internal/jira/orchestrator.go:341-348\n\nFix: Map each Phase to its corresponding CommentType (e.g. PhaseValidate → validation config, PhaseCommit/PhasePR → implement config, PhaseStatus → implement config) instead of defaulting everything to CommentImplement.

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
