### PR TITLE
feat(jira): idempotent review loop, real-time progress & deduplication

### DIFF
--- a/.continues-handoff.md
+++ b/.continues-handoff.md
@@ -1,0 +1,767 @@
+# Previous Session Chain Context
+
+The current Claude session appears compacted; best-effort predecessor sessions are included below.
+
+## Chained Previous Sessions
+
+### 1. 5e6091aa-a09f-4139-bf31-e9e8fe1461db (2026-04-07 20:58)
+- **Session file**: `~/.claude/projects/-home-sed-doc-github-nightshift/5e6091aa-a09f-4139-bf31-e9e8fe1461db.jsonl`
+- **Summary**: plan ticket VC-13, also read epic VC-2 to have the
+
+### 2. 4d18cfe9-2348-4c8c-96a8-392dbb919b83 (2026-04-28 21:23)
+- **Session file**: `~/.claude/projects/-home-sed-doc-github-nightshift/4d18cfe9-2348-4c8c-96a8-392dbb919b83.jsonl`
+- **Summary**: plan jira VC-28
+- **Compact summary**: This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.
+
+Summary:
+1. Primary Request and Intent:
+   - Fix compile error in `orchestrator_test.go` (broken `TestProcessTicket_SkipsValidationWhenAlreadyValidated`)
+   - Investigate why VC-44 stayed "En cours" despite PR existing → manually transition it
+   - Add tests, docs, update CLAUDE.md, update PR #44 for VC-28
+   - Fix `nightshift jira preview` Phase Assignments to show model used
+   - Fix blocked ticket detection (VC-35 not showing as blocked by VC-33)
+   - Label `(20m)` timeout explicitly in preview output
+   - Show blocked tickets inside the execution order (not just a separate section)
+   - Add `--type` flag to filter tickets by issue t...
+
+---
+
+# Session Handoff Context
+
+
+## Session Overview
+
+| Field | Value |
+|-------|-------|
+| **Source** | Claude Code |
+| **Session ID** | `26dc7c0f-0304-4986-8c3c-3da6af3f6d81` |
+| **Working Directory** | `~/doc/github/nightshift` |
+| **Session File** | `~/.claude/projects/-home-sed-doc-github-nightshift/26dc7c0f-0304-4986-8c3c-3da6af3f6d81.jsonl` |
+| **Repository** | github/nightshift @ `main` |
+| **Model** | claude-sonnet-4-6 |
+| **Last Active** | 2026-04-28 23:42:54 UTC |
+| **Tokens Used** | 31,468 in / 125,700 out |
+| **Cache Tokens** | 21,995,359 read / 2,708,580 created |
+| **Files Modified** | 6 |
+| **Messages** | 10 |
+
+
+## Summary
+
+> review the jira setup, make sure everything is rel
+
+
+## Session Context (Compacted)
+
+> This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.
+
+Summary:
+1. Primary Request and Intent:
+   - **Initial**: Comprehensive Jira pipeline reliability audit: load parent ticket + all comments before plan/implement, strengthen "stop only when done" instructions, improve Jira/PR reporting detail, ensure every phase is respected
+   - **Ongoing**: Multiple iterative fixes to the review feedback loo...
+
+
+## Current State
+
+Done. Second run on an already-reworked ticket now filters reviews/comments to only those newer than the last `CommentRework` Jira comment. If nothing new → emits "✓ no new review comments since last rework — skipping" and skips without posting to PR or Jira.
+
+
+## Subagent Results
+
+### Read and analyze these files in /home/sed/doc/github/nightshift/internal/jira/: (a3096e085ce075569)
+> Perfect! Now I have all the information I need. Let me create a comprehensive analysis document.
+> 
+> ## Analysis Report: Jira Integration in Nightshift
+> 
+> Based on analysis of `/home/sed/doc/github/nightshift/internal/jira/`, here are my findings:
+> 
+> ---
+> 
+> ## 1. PR Descriptions — Detail and Format
+> 
+> **Function Signature:**
+> ```go
+> func CreateOrUpdatePR(ctx context.Context, repo RepoWorkspace, ticket Ticket, jiraSite string) (*PRInfo, error)
+> ```
+> 
+> **PR Body Content (via `buildPRBody`):**
+> - **Title**: `[TI...
+> Tools used: 14
+
+### Read these files in /home/sed/doc/github/nightshift/: (acc00d7bea2a500bb)
+> Perfect! Now I have all the information I need. Let me create a comprehensive report:
+> 
+> ---
+> 
+> ## Complete Analysis: Jira Run Command Orchestration & Claude Agent Context
+> 
+> ### 1. HOW JIRA RUN INVOKES THE ORCHESTRATOR
+> 
+> **Entry Point:** `cmd/nightshift/commands/jira_run.go` - `runJira()` function
+> 
+> **Orchestrator Creation (lines 83-108):**
+> ```go
+> // Phase agents are created with provider/model from config
+> validationAgent, err := createJiraAgent(cfg, cfg.Jira.Validation)
+> implAgent, err := createJiraA...
+> Tools used: 16
+
+### Read and analyze the Jira orchestrator in /home/sed/doc/github/nightshift/internal/jira/orchestrator.go fully. I need to understand: (a0b989c8179ab44bb)
+> Perfect. Now I have all the information needed. Let me create a comprehensive analysis report.
+> 
+> ## Comprehensive Analysis: Jira Orchestrator in Nightshift
+> 
+> Based on my thorough review of the codebase, here is the complete breakdown of the Jira orchestrator and its phase lifecycle:
+> 
+> ---
+> 
+> ### 1. **PHASE LIFECYCLE (validate → plan → implement → commit → PR → status)**
+> 
+> **Exact Phase Definition** (`orchestrator.go`, lines 16-23):
+> ```go
+> type Phase string
+> 
+> const (
+>     PhaseValidate  Phase = "valida...
+> Tools used: 18
+
+
+## Key Decisions
+
+- Subagent "Read and analyze these files in /home/sed/doc/github/nightshift/internal/jira/:": Perfect! Now I have all the information I need. Let me create a comprehensive analysis document.
+
+## Analysis Report: Jira Integration in Nightshift
+
+Based on analysis of `/home/sed/doc/github/nightshift/internal/jira/`, here are my findings:
+
+---
+
+## 1. PR Descriptions — Detail and Format
+
+**Function Signature:**
+```go
+func CreateOrUpdatePR(ctx context.Context, repo RepoWorkspace, ticket Ticket, jiraSite string) (*PRInfo, error)
+```
+
+**PR Body Content (via `buildPRBody`):**
+- **Title**: `[TI...
+- Subagent "Read these files in /home/sed/doc/github/nightshift/:": Perfect! Now I have all the information I need. Let me create a comprehensive report:
+
+---
+
+## Complete Analysis: Jira Run Command Orchestration & Claude Agent Context
+
+### 1. HOW JIRA RUN INVOKES THE ORCHESTRATOR
+
+**Entry Point:** `cmd/nightshift/commands/jira_run.go` - `runJira()` function
+
+**Orchestrator Creation (lines 83-108):**
+```go
+// Phase agents are created with provider/model from config
+validationAgent, err := createJiraAgent(cfg, cfg.Jira.Validation)
+implAgent, err := createJiraA...
+- Subagent "Read and analyze the Jira orchestrator in /home/sed/doc/github/nightshift/internal/jira/orchestrator.go fully. I need to understand:": Perfect. Now I have all the information needed. Let me create a comprehensive analysis report.
+
+## Comprehensive Analysis: Jira Orchestrator in Nightshift
+
+Based on my thorough review of the codebase, here is the complete breakdown of the Jira orchestrator and its phase lifecycle:
+
+---
+
+### 1. **PHASE LIFECYCLE (validate → plan → implement → commit → PR → status)**
+
+**Exact Phase Definition** (`orchestrator.go`, lines 16-23):
+```go
+type Phase string
+
+const (
+    PhaseValidate  Phase = "valida...
+
+
+## Recent Conversation
+
+### Assistant (2026-04-28 23:34:29 UTC)
+
+Now wire `WithProgressPrinter` and update the phase callback in `jira_run.go`:
+
+### Assistant (2026-04-28 23:34:39 UTC)
+
+Also print ticket fetch results and workspace setup to stdout:
+
+### Assistant (2026-04-28 23:35:01 UTC)
+
+Also need to add `emit` to `ProcessFeedback` — but it lives on `Orchestrator` which doesn't have access in feedback.go yet. It does — `o.emit` is defined on `*Orchestrator`. But `ProcessFeedback` also calls `postErrorComment` via `o` but not through an interface. Let me verify `feedback.go` compiles:
+
+### Assistant (2026-04-28 23:35:45 UTC)
+
+Pushed. Output will now look like:
+
+```
+  🔍 VC-39  Error comments attribute wrong provider/model for non-plan phases
+    setting up workspace…
+    📎 PR https://github.com/cedricfarinazzo/nightshift/pull/47
+    fetching PR review comments from GitHub…
+    🤖 claude running: review-fix  (claude-sonnet-4-6, timeout 20m0s)
+    committing + pushing review fixes → feature/VC-39
+    posting rework summary to PR https://…/pull/47
+    📝 posting rework summary to Jira VC-39
+    🔄 reworked 1 repo(s), 1…
+
+### User (2026-04-28 23:38:13 UTC)
+
+when running it for review twice, the first time it first bug (https://github.com/cedricfarinazzo/nightshift/pull/47#issuecomment-4339825447) but the second time (https://github.com/cedricfarinazzo/nightshift/pull/47#issuecomment-4339848374) it redo a comment on the pr which is useless, so make sure running it twice dont do multiples usless comments
+
+### User (2026-04-28 23:38:28 UTC)
+
+when running it for review twice, the first time it first bug (https://github.com/cedricfarinazzo/nightshift/pull/47#issuecomment-4339825447) but the second time (https://github.com/cedricfarinazzo/nightshift/pull/47#issuecomment-4339848374) it redo a comment on the pr which is useless, so make sure running it twice dont do multiples usless comments, same on jira
+
+### Assistant (2026-04-28 23:40:32 UTC)
+
+Now I have everything. The fix: in `ProcessFeedback`, find last `CommentRework` timestamp, filter reviews/comments to only those newer than that timestamp, skip if nothing actionable remains.
+
+### Assistant (2026-04-28 23:41:25 UTC)
+
+Now `ProcessFeedback` needs `ticket.Comments` — check that it's passed in. The function signature takes `ticket Ticket` which has `Comments []Comment` from `FetchReviewTickets`.
+
+### Assistant (2026-04-28 23:41:37 UTC)
+
+Clean. Commit and push.
+
+### Assistant (2026-04-28 23:42:35 UTC)
+
+Done. Second run on an already-reworked ticket now filters reviews/comments to only those newer than the last `CommentRework` Jira comment. If nothing new → emits "✓ no new review comments since last rework — skipping" and skips without posting to PR or Jira.
+
+
+## Tool Activity
+
+### Shell (57 calls, 5 errors)
+
+> `$ grep -n "Parent\|parent" /home/sed/doc/github/nightshift/vendor/github.com/ctreminiom/go-atlassian/v2/pkg/infra/models/sm_issue.go 2>/dev/null | head -20; grep -rn "ParentScheme\|type.*Parent" /home/sed/doc/github/nightshift/vendor/github.com/ctreminiom/go-atlassian/v2/pkg/infra/models/ 2>/dev/null | head -20`
+> ```
+> 0 matches for 'Parent\|parent'
+> ```
+
+> `$ grep -rn "Parent\b" /home/sed/doc/github/nightshift/vendor/github.com/ctreminiom/go-atlassian/v2/pkg/infra/models/ 2>/dev/null | grep -i "struct\|type\|field" | head -20`
+> ```
+> (Bash completed with no output)
+> ```
+
+> `$ grep -rn "Parent" /home/sed/doc/github/nightshift/vendor/github.com/ctreminiom/go-atlassian/v2/pkg/infra/models/jira_issue.go 2>/dev/null | head -20`
+> ```
+> (Bash completed with no output)
+> ```
+
+> `$ find /home/sed/doc/github/nightshift/vendor/github.com/ctreminiom/go-atlassian -name "*.go" | xargs grep -l "Parent" 2>/dev/null | head -5`
+> ```
+> bfs: error: /home/sed/doc/github/nightshift/vendor/github.com/ctreminiom/go-atlassian: No such file or directory.
+> ```
+
+> `$ ls /home/sed/doc/github/nightshift/vendor/github.com/ctreminiom/go-atlassian/v2/pkg/infra/models/ | head -20`
+> ```
+> ls: cannot access '/home/sed/doc/github/nightshift/vendor/github.com/ctreminiom/go-atlassian/v2/pkg/infra/models/': No such file or directory
+> ```
+
+> `$ find /home/sed/doc/github/nightshift -name "*.go" -path "*/ctreminiom/*" | head -5; ls /home/sed/doc/github/nightshift/go.sum | head -1; find /home/sed -name "*.go" -path "*/ctreminiom/*infra/models*" 2>/dev/null | head -5`
+> ```
+> /home/sed/go/pkg/mod/github.com/ctreminiom/go-atlassian/v2@v2.11.0/pkg/infra/models/jira_issue_type_screen_scheme.go
+> /home/sed/go/pkg/mod/github.com/ctreminiom/go-atlassian/v2@v2.11.0/pkg/infra/models/jira_watcher.go
+> /home/sed/go/pkg/mod/github.com/ctreminiom/go-atlassian/v2@v2.11.0/pkg/infra/models/confluence_attachment.go
+> /home/sed/go/pkg/mod/github.com/ctreminiom/go-atlassian/v2@v2.11.0/pkg/infra/models/jira_work_log.go
+> /home/sed/go/pkg/mod/github.com/ctreminiom/go-atlassian/v2@v2.11.0/pkg/infra/models/admin_scim_group.go
+> ```
+
+> `$ grep -n "Parent" /home/sed/go/pkg/mod/github.com/ctreminiom/go-atlassian/v2@v2.11.0/pkg/infra/models/jira_issue.go | head -20`
+> ```
+> /usr/bin/grep: /home/sed/go/pkg/mod/github.com/ctreminiom/go-atlassian/v2@v2.11.0/pkg/infra/models/jira_issue.go: No such file or directory
+> 0 matches for 'Parent'
+> ```
+
+> `$ grep -rn "\.Issue\.Get\b" /home/sed/doc/github/nightshift/internal/jira/ | head -5`
+> ```
+> (Bash completed with no output)
+> ```
+
+*...and 49 more shell calls*
+
+
+### Write (1 calls)
+
+> **`/home/sed/.claude/plans/review-the-jira-setup-linked-rainbow.md`** (new file) (+201 lines)
+> ```diff
+> +# Plan: Jira Setup Reliability Review
+> +
+> +## Context
+> +
+> +User wants a comprehensive audit and fix of the Jira autonomous pipeline. Specific concerns:
+> +- Every phase must be respected (VC-2 as reference)
+> +- Agent must load ticket + parent + all comments before plan/implement
+> +- Agent must not stop until done
+> +- Everything must be well reported in Jira comments and in the PR
+> +
+> +After reading all code, here are the concrete gaps and fixes.
+> +
+> +---
+> +
+> +## Gaps Identified
+> +
+> +### 1. Parent ticket not loaded (CRITICAL)
+> +`fetchTickets` requests fields `["summary","description","comment","labels","status","issuelinks","reporter","assignee","issuetype"]` — no `"parent"`.
+> +`Ticket` struct has no `ParentKey`/`ParentSummary`/`ParentDescription`.
+> +Neither `buildPlanPrompt` nor `buildImplementPrompt` includes parent context.
+> +
+> +### 2. Implement prompt missing ticket comments
+> +`buildPlanPrompt` includes comments. `buildImplementPrompt` does NOT include comments — agent can't see clarifications made in the ticket during implementation.
+> +
+> +### 3. "Stop only when done" is weak
+> +Implement instruction is only "Do not commit or push". No instruction to complete ALL acceptance criteria, not stop early, or handle ambiguity. Agent may finish a partial implementation.
+> +
+> +### 4. PR body has no implementation summary
+> +`buildPRBody` is built from ticket fields only — no trace of what the agent actually did. Reviewers can't see the agent's reasoning without reading Jira.
+> +
+> +### 5. `CommentStatusChange` omits PR URLs
+> +Final completion comment says "Ticket processing complete. Duration: X. PRs: N." but doesn't include the actual PR URLs inline.
+> +
+> +### 6. `FetchPRReviewComments` misses inline review thread comments
+> +`gh pr view --json reviews,comments` fetches general comments, not inline review threads. `PRComment.Path` and `.Line` are always empty. The rework agent has no file/line context for inline feedback.
+> +
+> +### 7. `--skip-validation` is a no-op
+> +Flag is accepted, logged as "pending", but validation always runs. Confusing.
+> +
+> +---
+> +
+> +## Implementation Plan
+> +
+> +### Step 1: Load parent ticket in `Ticket` struct + fetch
+> +**File:** `internal/jira/tickets.go`
+> +
+> +1. Add to `Ticket` struct:
+> +   ```go
+> +   ParentKey         string
+> +   ParentSummary     string
+> +   ParentDescription string
+> +   ```
+> +
+> +2. Add `"parent"` to `fields` slice in `fetchTickets`.
+> +
+> +3. In `issueToTicket`, after existing field mapping, add:
+> +   ```go
+> +   if f.Parent != nil {
+> +       t.ParentKey = f.Parent.Key
+> +       t.ParentSummary = f.Parent.Summary
+> +   }
+> +   ```
+> +   (go-atlassian `IssueScheme.Fields` has a `Parent *ParentScheme` with `Key` and `Summary`)
+> +
+> +4. Add `fetchParentDescription` helper on `*Client`:
+> +   ```go
+> +   func (c *Client) fetchParentDescription(ctx context.Context, key string) string
+> +   ```
+> +   Uses `c.jira.Issue.Get(ctx, key, []string{"description"}, nil)` and calls `extractText`. Returns empty string on error (non-fatal).
+> +
+> +5. In `FetchTodoTickets` (and `FetchReviewTickets`), after `fetchTickets`, loop over tickets with non-empty `ParentKey` and populate `ParentDescription` via `fetchParentDescription`. Batch deduplicate parent fetches if multiple tickets share the same parent.
+> +
+> +### Step 2: Include parent + comments in implement prompt
+> +**File:** `internal/jira/orchestrator.go`
+> +
+> +In `buildPlanPrompt` — already includes comments. Also add parent section:
+> +```
+> +## Parent Ticket
+> +Key: {ticket.ParentKey}
+> +Summary: {ticket.ParentSummary}
+> +Description:
+> +{ticket.ParentDescription}
+> +```
+> +(only when `ticket.ParentKey != ""`)
+> +
+> +In `buildImplementPrompt` — add:
+> +- Comments section (same as plan prompt)
+> +- Parent section (same as plan prompt)
+> +- Issue links section (blockers, if any)
+> +
+> +### Step 3: Stronger "stop only when done" instruction
+> +**File:** `internal/jira/orchestrator.go`, `buildImplementPrompt`
+> +
+> +Replace instructions block with:
+> +```
+> +## Instructions
+> +1. Implement the plan step by step — complete EVERY step before stopping
+> +2. Make all necessary code changes
+> +3. Ensure tests pass (run them; fix failures before stopping)
+> +4. Verify ALL acceptance criteria are met before stopping
+> +5. Do not commit or push — that is handled separately
+> +6. If you encounter ambiguity, make a reasonable assumption and document it in a comment
+> +7. Do NOT stop early. Continue until the entire plan is implemented and tests pass
+> +```
+> +
+> +### Step 4: Post implementation summary as PR comment
+> +**File:** `internal/jira/orchestrator.go`
+> +
+> +After implement phase succeeds, store `implResult.Output` in `result.ImplementationSummary` (new field on `TicketResult`).
+> +
+> +After PR creation loop (phase 5), for each created PR, call `fnPostPRComment` with a summary:
+> +```
+> +## 🤖 Nightshift Implementation Summary
+> +
+> +**Ticket:** {ticket.Key} — {ticket.Summary}
+> +**Jira:** {jiraBrowseURL}
+> +
+> +{implementationSummary}
+> +```
+> +
+> +This gives PR reviewers full context inline without needing to check Jira.
+> +
+> +### Step 5: Include PR URLs in `CommentStatusChange`
+> +**File:** `internal/jira/orchestrator.go`, end of `ProcessTicket`
+> +
+> +Change body from:
+> +```go
+> +fmt.Sprintf("Ticket processing complete. Duration: %s. PRs: %d.", ...)
+> +```
+> +to:
+> +```go
+> +var prList string
+> +if len(result.PRURLs) > 0 {
+> +    prList = "\n\nPRs:\n" + strings.Join(result.PRURLs, "\n")
+> +}
+> +fmt.Sprintf("Ticket processing complete. Duration: %s. PRs: %d.%s", ..., prList)
+> +```
+> +
+> +### Step 6: Fetch inline review thread comments
+> +**File:** `internal/jira/pr.go`
+> +
+> +Extend `FetchPRReviewComments` to also call:
+> +```
+> +gh api repos/{owner}/{repo}/pulls/{number}/comments
+> +```
+> +This returns inline review comments with `path`, `line`, and `body`. Parse into `PRComment` with `Path` and `Line` populated.
+> +
+> +Alternatively, add `reviewThreads` to `gh pr view --json` if the gh version supports it. Check with `gh pr view --help`.
+> +
+> +The simpler reliable approach: run a second `gh` call to `gh api` for the pull request review comments endpoint, merge results with the existing general comments.
+> +
+> +**File:** `internal/jira/feedback.go`
+> +
+> +Update `buildReworkPrompt` to display inline comments with file/line context:
+> +```
+> +### Inline Comments
+> +**{file}:{line}** ({author}):
+> +{comment_body}
+> +```
+> +(currently the inline comment section exists but Path/Line are always empty)
+> +
+> +### Step 7: Implement `--skip-validation` properly
+> +**File:** `internal/jira/orchestrator.go`
+> +
+> +Add `OrchestratorOption`:
+> +```go
+> +func WithSkipValidation() OrchestratorOption {
+> +    return func(o *Orchestrator) { o.skipValidation = true }
+> +}
+> +```
+> +
+> +In `ProcessTicket`, wrap phase 1 with:
+> +```go
+> +if !skip(PhaseValidate) && !o.skipValidation {
+> +    // ... validation logic
+> +} else if !skip(PhaseValidate) && o.skipValidation {
+> +    // Still transition to in-progress
+> +    o.client.TransitionToInProgress(ctx, ticket.Key)
+> +}
+> +```
+> +
+> +**File:** `cmd/nightshift/commands/jira_run.go`
+> +
+> +Wire up:
+> +```go
+> +if skipValidation {
+> +    orchOpts = append(orchOpts, jira.WithSkipValidation())
+> +}
+> +```
+> +Remove the dead no-op log line.
+> +
+> +---
+> +
+> +## Files to Modify
+> +
+> +| File | Changes |
+> +|------|---------|
+> +| `internal/jira/tickets.go` | Add `ParentKey/Summary/Description` to `Ticket`; add `"parent"` to fields; fetch parent description |
+> +| `internal/jira/orchestrator.go` | Add parent+comments to both prompts; strengthen implement instructions; post impl summary as PR comment; enrich `CommentStatusChange`; add `skipValidation` field + `WithSkipValidation` |
+> +| `internal/jira/pr.go` | Fetch inline review thread comments via `gh api`; extend `PRReviewState` |
+> ```
+> *+1 lines truncated*
+
+
+### Edit (54 calls)
+
+> **`/home/sed/doc/github/nightshift/internal/jira/tickets.go`** (+17 -14 lines)
+> ```diff
+> -// Ticket represents a Jira issue with all fields needed for agent context.
+> -type Ticket struct {
+> -	Key                string
+> -	Summary            string
+> -	Description        string
+> -	Comments           []Comment
+> -	AcceptanceCriteria string
+> -	Labels             []string
+> -	Status             Status
+> -	IssueType          string // e.g. "Bug", "Story", "Task"
+> -	IssueLinks         []IssueLink
+> -	Reporter           string
+> -	Assignee           string
+> -}
+> +// Ticket represents a Jira issue with all fields needed for agent context.
+> +type Ticket struct {
+> +	Key                string
+> +	Summary            string
+> +	Description        string
+> +	Comments           []Comment
+> +	AcceptanceCriteria string
+> +	Labels             []string
+> +	Status             Status
+> +	IssueType          string // e.g. "Bug", "Story", "Task"
+> +	IssueLinks         []IssueLink
+> +	Reporter           string
+> +	Assignee           string
+> +	ParentKey          string
+> +	ParentSummary      string
+> +	ParentDescription  string
+> +}
+> ```
+
+> **`/home/sed/doc/github/nightshift/internal/jira/tickets.go`** (+4 -4 lines)
+> ```diff
+> -	fields := []string{
+> -		"summary", "description", "comment", "labels", "status",
+> -		"issuelinks", "reporter", "assignee", "issuetype",
+> -	}
+> +	fields := []string{
+> +		"summary", "description", "comment", "labels", "status",
+> +		"issuelinks", "reporter", "assignee", "issuetype", "parent",
+> +	}
+> ```
+
+> **`/home/sed/doc/github/nightshift/internal/jira/tickets.go`** (+41 -6 lines)
+> ```diff
+> -		for _, link := range f.IssueLinks {
+> -			t.IssueLinks = append(t.IssueLinks, issueLinkToLink(issue.Key, link))
+> -		}
+> -	}
+> -	return t
+> -}
+> +		for _, link := range f.IssueLinks {
+> +			t.IssueLinks = append(t.IssueLinks, issueLinkToLink(issue.Key, link))
+> +		}
+> +		if f.Parent != nil {
+> +			t.ParentKey = f.Parent.Key
+> +			if f.Parent.Fields != nil {
+> +				t.ParentSummary = f.Parent.Fields.Summary
+> +			}
+> +		}
+> +	}
+> +	return t
+> +}
+> +
+> +// fetchParentDescriptions fetches the description for each unique parent key and
+> +// populates ParentDescription on the tickets that reference it. Failures are
+> +// non-fatal: the ticket is still usable, just without parent description.
+> +func (c *Client) fetchParentDescriptions(ctx context.Context, tickets []Ticket) []Ticket {
+> +	// Deduplicate parent keys.
+> +	parentDescs := make(map[string]string)
+> +	for _, t := range tickets {
+> +		if t.ParentKey != "" {
+> +			parentDescs[t.ParentKey] = ""
+> +		}
+> +	}
+> +	for key := range parentDescs {
+> +		issue, _, err := c.jira.Issue.Get(ctx, key, []string{"description"}, nil)
+> +		if err != nil {
+> +			c.log.Errorf("fetch parent %s description: %v", key, err)
+> +			continue
+> +		}
+> +		if issue != nil && issue.Fields != nil && issue.Fields.Description != nil {
+> +			parentDescs[key] = extractText(issue.Fields.Description)
+> +		}
+> +	}
+> +	for i, t := range tickets {
+> +		if t.ParentKey != "" {
+> +			tickets[i].ParentDescription = parentDescs[t.ParentKey]
+> +		}
+> +	}
+> +	return tickets
+> +}
+> ```
+
+> **`/home/sed/doc/github/nightshift/internal/jira/tickets.go`** (+32 -24 lines)
+> ```diff
+> -// FetchTodoTickets fetches issues in the "To Do" status category filtered by the configured label.
+> -func (c *Client) FetchTodoTickets(ctx context.Context) ([]Ticket, error) {
+> -	jql := fmt.Sprintf(
+> -		`project = "%s" AND statusCategory = "To Do" AND labels = "%s" ORDER BY created ASC`,
+> -		c.cfg.Project, c.cfg.Label,
+> -	)
+> -	return c.fetchTickets(ctx, jql)
+> -}
+> -
+> -// FetchReviewTickets fetches issues that are in a review status, filtered by the configured label.
+> -func (c *Client) FetchReviewTickets(ctx context.Context, statusMap *StatusMap) ([]Ticket, error) {
+> -	if statusMap == nil || len(statusMap.ReviewStatuses) == 0 {
+> -		return nil, nil
+> -	}
+> -	names := make([]string, len(statusMap.ReviewStatuses))
+> -	for i, s := range statusMap.ReviewStatuses {
+> -		names[i] = fmt.Sprintf(`"%s"`, s.Name)
+> -	}
+> -	jql := fmt.Sprintf(
+> -		`project = "%s" AND status in (%s) AND labels = "%s" ORDER BY created ASC`,
+> -		c.cfg.Project, strings.Join(names, ", "), c.cfg.Label,
+> -	)
+> -	return c.fetchTickets(ctx, jql)
+> -}
+> +// FetchTodoTickets fetches issues in the "To Do" status category filtered by the configured label.
+> +func (c *Client) FetchTodoTickets(ctx context.Context) ([]Ticket, error) {
+> +	jql := fmt.Sprintf(
+> +		`project = "%s" AND statusCategory = "To Do" AND labels = "%s" ORDER BY created ASC`,
+> +		c.cfg.Project, c.cfg.Label,
+> +	)
+> +	tickets, err := c.fetchTickets(ctx, jql)
+> +	if err != nil {
+> +		return nil, err
+> +	}
+> +	return c.fetchParentDescriptions(ctx, tickets), nil
+> +}
+> +
+> +// FetchReviewTickets fetches issues that are in a review status, filtered by the configured label.
+> +func (c *Client) FetchReviewTickets(ctx context.Context, statusMap *StatusMap) ([]Ticket, error) {
+> +	if statusMap == nil || len(statusMap.ReviewStatuses) == 0 {
+> +		return nil, nil
+> +	}
+> +	names := make([]string, len(statusMap.ReviewStatuses))
+> +	for i, s := range statusMap.ReviewStatuses {
+> +		names[i] = fmt.Sprintf(`"%s"`, s.Name)
+> +	}
+> +	jql := fmt.Sprintf(
+> +		`project = "%s" AND status in (%s) AND labels = "%s" ORDER BY created ASC`,
+> +		c.cfg.Project, strings.Join(names, ", "), c.cfg.Label,
+> +	)
+> +	tickets, err := c.fetchTickets(ctx, jql)
+> +	if err != nil {
+> +		return nil, err
+> +	}
+> +	return c.fetchParentDescriptions(ctx, tickets), nil
+> +}
+> ```
+
+> **`/home/sed/doc/github/nightshift/internal/jira/orchestrator.go`** (+12 -11 lines)
+> ```diff
+> -// TicketResult holds the outcome of processing a single Jira ticket.
+> -type TicketResult struct {
+> -	TicketKey string        `json:"ticket_key"`
+> -	Status    TicketStatus  `json:"status"`
+> -	Phase     Phase         `json:"phase"`
+> -	PRURLs    []string      `json:"pr_urls,omitempty"`
+> -	Plan      string        `json:"plan,omitempty"`
+> -	Summary   string        `json:"summary,omitempty"`
+> -	Error     string        `json:"error,omitempty"`
+> -	Duration  time.Duration `json:"duration"`
+> -}
+> +// TicketResult holds the outcome of processing a single Jira ticket.
+> +type TicketResult struct {
+> +	TicketKey              string        `json:"ticket_key"`
+> +	Status                 TicketStatus  `json:"status"`
+> +	Phase                  Phase         `json:"phase"`
+> +	PRURLs                 []string      `json:"pr_urls,omitempty"`
+> +	Plan                   string        `json:"plan,omitempty"`
+> +	ImplementationSummary  string        `json:"implementation_summary,omitempty"`
+> +	Summary                string        `json:"summary,omitempty"`
+> +	Error                  string        `json:"error,omitempty"`
+> +	Duration               time.Duration `json:"duration"`
+> +}
+> ```
+
+*...and 49 more edits*
+
+
+### Read (24 calls)
+
+- `/home/sed/doc/github/nightshift/internal/jira/orchestrator.go`
+- `/home/sed/doc/github/nightshift/internal/jira/tickets.go`
+- `/home/sed/doc/github/nightshift/internal/jira/pr.go`
+- `/home/sed/doc/github/nightshift/cmd/nightshift/commands/jira_run.go`
+- `/home/sed/doc/github/nightshift/internal/jira/feedback.go`
+- `/home/sed/go/pkg/mod/github.com/ctreminiom/go-atlassian/v2@v2.11.0/pkg/infra/models/jira_issue_v3.go` (lines 1-130)
+- `/home/sed/doc/github/nightshift/internal/jira/client.go`
+- `/home/sed/doc/github/nightshift/internal/jira/orchestrator.go` (lines 369-418)
+- `/home/sed/doc/github/nightshift/internal/jira/orchestrator.go` (lines 395-419)
+- `/home/sed/doc/github/nightshift/internal/jira/orchestrator_test.go` (lines 651-710)
+- `/home/sed/doc/github/nightshift/internal/jira/orchestrator_test.go` (lines 544-573)
+- `/home/sed/doc/github/nightshift/cmd/nightshift/commands/jira_run.go` (lines 150-309)
+- `/home/sed/doc/github/nightshift/cmd/nightshift/commands/jira_run.go` (lines 360-439)
+- `/home/sed/doc/github/nightshift/internal/jira/orchestrator.go` (lines 55-74)
+- `/home/sed/doc/github/nightshift/internal/jira/orchestrator.go` (lines 270-289)
+- `/home/sed/doc/github/nightshift/internal/jira/orchestrator.go` (lines 277-456)
+- `/home/sed/doc/github/nightshift/internal/jira/orchestrator.go` (from line [620)
+- `/home/sed/doc/github/nightshift/internal/jira/feedback.go` (lines 75-124)
+- `/home/sed/doc/github/nightshift/internal/jira/pr.go` (lines 150-199)
+- `/home/sed/doc/github/nightshift/internal/jira/feedback.go` (lines 62-121)
+- *...and 4 more files read*
+
+
+### Task (3 calls)
+
+- "Explore Jira orchestrator and phase lifecycle" (type: `Explore`)
+- "Explore Jira PR, branch, workspace, and client code" (type: `Explore`)
+- "Explore jira_run.go command and agent prompt construction" (type: `Explore`)
+
+
+### MCP (2 calls)
+
+- `ToolSearch(query=select:ExitPlanMode, max_results=1)`
+- `ToolSearch(query=select:mcp__atlassian__getJiraIssue,mcp__github__list_pull_requests,mcp__github__pull_request_read, max_results=3)`
+
+
+### MCP (1 calls)
+
+- `ExitPlanMode(allowedPrompts=[{"tool":"Bash","prompt":"run go tests"},{"tool":"Bash","prompt":"run go build"},{"tool":"Bash","..., plan=# Plan: Jira Setup Reliability Review
+
+## Context
+
+User wants a comprehensive audit and fix of th..., planFilePath=/home/sed/.claude/plans/review-the-jira-setup-linked-rainbow.md)` — "User has approved your plan. You can now start coding. Start with updating your todo list if applica"
+
+
+### MCP (1 calls)
+
+- `mcp__atlassian__getJiraIssue(cloudId=692d5954-a52b-4d34-8c0a-6565fc0fc505, issueIdOrKey=VC-39, responseContentFormat=markdown)` — "{"issues":{"totalCount":1,"nodes":[{"expand":"renderedFields,names,schema,operations,editmeta,change"
+
+
+### MCP (4 calls)
+
+- `mcp__github__list_pull_requests(owner=cedricfarinazzo, repo=nightshift, state=open)` — "[{"number":47,"title":"[VC-39] Error comments attribute wrong provider/model for non-plan phases","b"
+- `mcp__github__pull_request_read(method=get_comments, owner=cedricfarinazzo, repo=nightshift, pullNumber=47)` — "[{"id":4339692033,"body":"🤖 **Nightshift — Implementation Summary**\n\n**Ticket:** [VC-39 — Error c"
+- `mcp__github__pull_request_read(method=get_reviews, owner=cedricfarinazzo, repo=nightshift, pullNumber=47)` — "[{"id":4193062476,"state":"COMMENTED","body":"## Pull request overview\n\nFixes Jira error-comment m"
+- `mcp__github__pull_request_read(method=get_review_comments, owner=cedricfarinazzo, repo=nightshift, pullNumber=47)` — "{"review_threads":[{"is_resolved":false,"is_outdated":true,"is_collapsed":false,"comments":[{"body":"
+
+
+
+## Files Modified
+
+- `~/.claude/plans/review-the-jira-setup-linked-rainbow.md`
+- `./internal/jira/tickets.go`
+- `./internal/jira/orchestrator.go`
+- `./cmd/nightshift/commands/jira_run.go`
+- `./internal/jira/pr.go`
+- `./internal/jira/feedback.go`
+
+
+## Session Origin
+
+This session was extracted from **Claude Code** session data.
+- **Session file**: `~/.claude/projects/-home-sed-doc-github-nightshift/26dc7c0f-0304-4986-8c3c-3da6af3f6d81.jsonl`
+- **Session ID**: `26dc7c0f-0304-4986-8c3c-3da6af3f6d81`
+- **Project directory**: `~/doc/github/nightshift`
+
+> To access the raw session data, inspect the file path above.
+
+---
+
+**You are continuing this session. Pick up exactly where it left off — review the conversation above, check pending tasks, and keep going.**

--- a/cmd/nightshift/commands/helpers.go
+++ b/cmd/nightshift/commands/helpers.go
@@ -6,7 +6,12 @@ import (
 	"strings"
 
 	"github.com/marcus/nightshift/internal/agents"
+	"github.com/marcus/nightshift/internal/budget"
+	"github.com/marcus/nightshift/internal/calibrator"
 	"github.com/marcus/nightshift/internal/config"
+	"github.com/marcus/nightshift/internal/db"
+	"github.com/marcus/nightshift/internal/providers"
+	"github.com/marcus/nightshift/internal/trends"
 )
 
 // agentByName creates an agent for the given provider name.
@@ -36,9 +41,9 @@ func agentByName(cfg *config.Config, provider string) (agents.Agent, error) {
 	}
 }
 
-func newClaudeAgentFromConfig(cfg *config.Config) *agents.ClaudeAgent {
+func newClaudeAgentFromConfig(cfg *config.Config, extra ...agents.ClaudeOption) *agents.ClaudeAgent {
 	if cfg == nil {
-		return agents.NewClaudeAgent()
+		return agents.NewClaudeAgent(extra...)
 	}
 	opts := []agents.ClaudeOption{
 		agents.WithDangerouslySkipPermissions(cfg.Providers.Claude.DangerouslySkipPermissions),
@@ -46,12 +51,13 @@ func newClaudeAgentFromConfig(cfg *config.Config) *agents.ClaudeAgent {
 	if cfg.Providers.Claude.Model != "" {
 		opts = append(opts, agents.WithModel(cfg.Providers.Claude.Model))
 	}
+	opts = append(opts, extra...)
 	return agents.NewClaudeAgent(opts...)
 }
 
-func newCodexAgentFromConfig(cfg *config.Config) *agents.CodexAgent {
+func newCodexAgentFromConfig(cfg *config.Config, extra ...agents.CodexOption) *agents.CodexAgent {
 	if cfg == nil {
-		return agents.NewCodexAgent()
+		return agents.NewCodexAgent(extra...)
 	}
 	// The --dangerously-bypass-approvals-and-sandbox flag is required for
 	// non-interactive (headless) Codex execution. The agent defaults to true.
@@ -72,6 +78,7 @@ func newCodexAgentFromConfig(cfg *config.Config) *agents.CodexAgent {
 	if cfg.Providers.Codex.Model != "" {
 		opts = append(opts, agents.WithCodexModel(cfg.Providers.Codex.Model))
 	}
+	opts = append(opts, extra...)
 	return agents.NewCodexAgent(opts...)
 }
 
@@ -102,4 +109,16 @@ func newCopilotAgentFromConfig(cfg *config.Config, binaryPath string, extra ...a
 	}
 	opts = append(opts, extra...)
 	return agents.NewCopilotAgent(opts...)
+}
+
+// newBudgetManager builds a budget.Manager from config and an open database.
+// Shared between run.go and jira_preview.go to avoid duplicating provider + calibrator setup.
+func newBudgetManager(cfg *config.Config, database *db.DB) *budget.Manager {
+	claudeProvider := providers.NewClaudeWithPath(cfg.ExpandedProviderPath("claude"))
+	codexProvider := providers.NewCodexWithPath(cfg.ExpandedProviderPath("codex"))
+	copilotProvider := providers.NewCopilotWithPath(cfg.ExpandedProviderPath("copilot"))
+	cal := calibrator.New(database, cfg)
+	trend := trends.NewAnalyzer(database, cfg.Budget.SnapshotRetentionDays)
+	return budget.NewManagerFromProviders(cfg, claudeProvider, codexProvider, copilotProvider,
+		budget.WithBudgetSource(cal), budget.WithTrendAnalyzer(trend))
 }

--- a/cmd/nightshift/commands/helpers.go
+++ b/cmd/nightshift/commands/helpers.go
@@ -26,7 +26,7 @@ func agentByName(cfg *config.Config, provider string) (agents.Agent, error) {
 		}
 		return a, nil
 	case "copilot":
-		a := newCopilotAgentFromConfig(cfg)
+		a := newCopilotAgentFromConfig(cfg, "")
 		if !a.Available() {
 			return nil, fmt.Errorf("copilot CLI not found in PATH (install via 'gh' or standalone)")
 		}
@@ -78,15 +78,14 @@ func newCodexAgentFromConfig(cfg *config.Config) *agents.CodexAgent {
 // newCopilotAgentFromConfig creates a CopilotAgent from config. If binaryPath
 // is non-empty it overrides auto-detection; otherwise the binary is resolved
 // from PATH (preferring standalone "copilot", falling back to "gh").
-func newCopilotAgentFromConfig(cfg *config.Config, binaryPath ...string) *agents.CopilotAgent {
+// Extra CopilotOptions (e.g. phase-specific model/timeout) are applied last.
+func newCopilotAgentFromConfig(cfg *config.Config, binaryPath string, extra ...agents.CopilotOption) *agents.CopilotAgent {
 	if cfg == nil {
 		return agents.NewCopilotAgent()
 	}
 
-	binary := ""
-	if len(binaryPath) > 0 && binaryPath[0] != "" {
-		binary = binaryPath[0]
-	} else {
+	binary := binaryPath
+	if binary == "" {
 		// Auto-detect: prefer standalone copilot, fallback to gh
 		binary = "gh"
 		if _, err := exec.LookPath("copilot"); err == nil {
@@ -101,5 +100,6 @@ func newCopilotAgentFromConfig(cfg *config.Config, binaryPath ...string) *agents
 	if cfg.Providers.Copilot.Model != "" {
 		opts = append(opts, agents.WithCopilotModel(cfg.Providers.Copilot.Model))
 	}
+	opts = append(opts, extra...)
 	return agents.NewCopilotAgent(opts...)
 }

--- a/cmd/nightshift/commands/jira_preview.go
+++ b/cmd/nightshift/commands/jira_preview.go
@@ -12,11 +12,8 @@ import (
 
 	"github.com/marcus/nightshift/internal/agents"
 	"github.com/marcus/nightshift/internal/budget"
-	"github.com/marcus/nightshift/internal/calibrator"
 	"github.com/marcus/nightshift/internal/db"
 	"github.com/marcus/nightshift/internal/jira"
-	"github.com/marcus/nightshift/internal/providers"
-	"github.com/marcus/nightshift/internal/trends"
 	"github.com/spf13/cobra"
 )
 
@@ -240,12 +237,7 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 			result.BudgetErr = fmt.Sprintf("open db: %v", dbErr)
 		} else {
 			defer func() { _ = database.Close() }()
-			claudeProvider := providers.NewClaudeWithPath(cfg.ExpandedProviderPath("claude"))
-			codexProvider := providers.NewCodexWithPath(cfg.ExpandedProviderPath("codex"))
-			copilotProvider := providers.NewCopilotWithPath(cfg.ExpandedProviderPath("copilot"))
-			cal := calibrator.New(database, cfg)
-			trend := trends.NewAnalyzer(database, cfg.Budget.SnapshotRetentionDays)
-			budgetMgr := budget.NewManagerFromProviders(cfg, claudeProvider, codexProvider, copilotProvider, budget.WithBudgetSource(cal), budget.WithTrendAnalyzer(trend))
+			budgetMgr := newBudgetManager(cfg, database)
 
 			provider := cfg.Jira.Implement.Provider
 			if provider == "" {

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -365,20 +365,20 @@ func createJiraAgent(cfg *config.Config, phase jira.PhaseConfig) (agents.Agent, 
 		return a, nil
 
 	case "copilot":
-		opts := []agents.CopilotOption{
-			agents.WithCopilotDangerouslySkipPermissions(cfg.Providers.Copilot.DangerouslySkipPermissions),
-		}
+		// Use newCopilotAgentFromConfig for auto-detection (prefers standalone
+		// "copilot" binary, falls back to "gh copilot"), matching run.go behaviour.
 		model := phase.Model
 		if model == "" {
 			model = cfg.Providers.Copilot.Model
 		}
+		extraOpts := []agents.CopilotOption{}
 		if model != "" {
-			opts = append(opts, agents.WithCopilotModel(model))
+			extraOpts = append(extraOpts, agents.WithCopilotModel(model))
 		}
 		if timeout > 0 {
-			opts = append(opts, agents.WithCopilotDefaultTimeout(timeout))
+			extraOpts = append(extraOpts, agents.WithCopilotDefaultTimeout(timeout))
 		}
-		a := agents.NewCopilotAgent(opts...)
+		a := newCopilotAgentFromConfig(cfg, "", extraOpts...)
 		if !a.Available() {
 			return nil, fmt.Errorf("copilot CLI not found in PATH")
 		}

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -97,6 +97,11 @@ func runJira(cmd *cobra.Command, _ []string) error {
 		jira.WithImplAgent(implAgent),
 		jira.WithReviewFixAgent(reviewFixAgent),
 		jira.WithValidationAgent(validationAgent),
+		jira.WithPhaseCallback(func(ticketKey string, phase jira.Phase, done bool) {
+			if !done {
+				fmt.Printf("    ⟳ %-12s …\n", phase)
+			}
+		}),
 	}
 	if skipValidation {
 		orchOpts = append(orchOpts, jira.WithSkipValidation())
@@ -233,9 +238,11 @@ func runTodoPhase(
 		if count >= jiracfg.MaxTickets {
 			break
 		}
+		fmt.Printf("\n  ▶ %s  %s\n", ticket.Key, ticket.Summary)
 		ws, err := jira.SetupWorkspace(ctx, jiracfg, ticket.Key)
 		if err != nil {
 			log.Errorf("workspace %s: %v", ticket.Key, err)
+			fmt.Printf("    ✗ workspace setup failed: %v\n", err)
 			*results = append(*results, jira.TicketResult{TicketKey: ticket.Key, Status: jira.TicketFailed, Error: err.Error()})
 			count++
 			continue
@@ -245,6 +252,7 @@ func runTodoPhase(
 			log.Errorf("process %s: %v", ticket.Key, err)
 		}
 		if result != nil {
+			printTicketResult(result)
 			*results = append(*results, *result)
 		}
 		count++
@@ -268,9 +276,11 @@ func runReviewPhase(
 	log.Infof("review tickets: %d found", len(reviewTickets))
 
 	for _, ticket := range reviewTickets {
+		fmt.Printf("\n  🔍 %s  %s\n", ticket.Key, ticket.Summary)
 		ws, err := jira.SetupWorkspace(ctx, jiracfg, ticket.Key)
 		if err != nil {
 			log.Errorf("workspace %s: %v", ticket.Key, err)
+			fmt.Printf("    ✗ workspace setup failed: %v\n", err)
 			*feedbackResults = append(*feedbackResults, jira.FeedbackResult{TicketKey: ticket.Key, Error: err.Error()})
 			continue
 		}
@@ -279,6 +289,7 @@ func runReviewPhase(
 			log.Errorf("process feedback %s: %v", ticket.Key, err)
 		}
 		if result != nil {
+			printFeedbackResult(result)
 			*feedbackResults = append(*feedbackResults, *result)
 		}
 	}
@@ -378,6 +389,35 @@ func printJiraPreflightSummary(cfg jira.JiraConfig, _ *jira.StatusMap) {
 	fmt.Printf("  Implement:    %s/%s\n", cfg.Implement.Provider, cfg.Implement.Model)
 	fmt.Printf("  ReviewFix:    %s/%s\n", cfg.ReviewFix.Provider, cfg.ReviewFix.Model)
 	fmt.Printf("  Max tickets:  %d\n", cfg.MaxTickets)
+}
+
+func printTicketResult(r *jira.TicketResult) {
+	switch r.Status {
+	case jira.TicketCompleted:
+		fmt.Printf("    ✅ completed in %s", r.Duration.Round(time.Second))
+		if len(r.PRURLs) > 0 {
+			fmt.Printf("  →  %s", strings.Join(r.PRURLs, "  "))
+		}
+		fmt.Println()
+	case jira.TicketRejected:
+		fmt.Printf("    ❌ rejected — %s\n", r.Summary)
+	case jira.TicketSkipped:
+		fmt.Printf("    ⏭️  skipped\n")
+	default:
+		fmt.Printf("    ⚠️  failed at phase %s — %s\n", r.Phase, r.Error)
+	}
+}
+
+func printFeedbackResult(r *jira.FeedbackResult) {
+	if r.Error != "" {
+		fmt.Printf("    ⚠️  error — %s\n", r.Error)
+		return
+	}
+	if r.FixesMade == 0 {
+		fmt.Printf("    ℹ️  no changes requested in %s\n", r.Duration.Round(time.Second))
+		return
+	}
+	fmt.Printf("    🔄 reworked %d repo(s), %d commit(s) in %s\n", r.FixesMade, r.PushedCommits, r.Duration.Round(time.Second))
 }
 
 func printJiraRunSummary(results []jira.TicketResult, feedback []jira.FeedbackResult, d time.Duration) {

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -40,7 +40,7 @@ func init() {
 func runJira(cmd *cobra.Command, _ []string) error {
 	log := logging.Component("jira")
 
-	cfg, err := config.Load()
+	cfg, err := loadConfig("")
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
@@ -344,61 +344,42 @@ func createJiraAgent(cfg *config.Config, phase jira.PhaseConfig) (agents.Agent, 
 
 	switch provider {
 	case "codex":
-		opts := []agents.CodexOption{}
-		if cfg.Providers.Codex.DangerouslyBypassApprovalsAndSandbox {
-			opts = append(opts, agents.WithDangerouslyBypassApprovalsAndSandbox(true))
-		}
-		model := phase.Model
-		if model == "" {
-			model = cfg.Providers.Codex.Model
-		}
-		if model != "" {
-			opts = append(opts, agents.WithCodexModel(model))
+		var extra []agents.CodexOption
+		if m := phase.Model; m != "" {
+			extra = append(extra, agents.WithCodexModel(m))
 		}
 		if timeout > 0 {
-			opts = append(opts, agents.WithCodexDefaultTimeout(timeout))
+			extra = append(extra, agents.WithCodexDefaultTimeout(timeout))
 		}
-		a := agents.NewCodexAgent(opts...)
+		a := newCodexAgentFromConfig(cfg, extra...)
 		if !a.Available() {
 			return nil, fmt.Errorf("codex CLI not found in PATH")
 		}
 		return a, nil
 
 	case "copilot":
-		// Use newCopilotAgentFromConfig for auto-detection (prefers standalone
-		// "copilot" binary, falls back to "gh copilot"), matching run.go behaviour.
-		model := phase.Model
-		if model == "" {
-			model = cfg.Providers.Copilot.Model
-		}
-		extraOpts := []agents.CopilotOption{}
-		if model != "" {
-			extraOpts = append(extraOpts, agents.WithCopilotModel(model))
+		var extra []agents.CopilotOption
+		if m := phase.Model; m != "" {
+			extra = append(extra, agents.WithCopilotModel(m))
 		}
 		if timeout > 0 {
-			extraOpts = append(extraOpts, agents.WithCopilotDefaultTimeout(timeout))
+			extra = append(extra, agents.WithCopilotDefaultTimeout(timeout))
 		}
-		a := newCopilotAgentFromConfig(cfg, "", extraOpts...)
+		a := newCopilotAgentFromConfig(cfg, "", extra...)
 		if !a.Available() {
 			return nil, fmt.Errorf("copilot CLI not found in PATH")
 		}
 		return a, nil
 
 	default: // "claude" or unrecognized
-		opts := []agents.ClaudeOption{
-			agents.WithDangerouslySkipPermissions(cfg.Providers.Claude.DangerouslySkipPermissions),
-		}
-		model := phase.Model
-		if model == "" {
-			model = cfg.Providers.Claude.Model
-		}
-		if model != "" {
-			opts = append(opts, agents.WithModel(model))
+		var extra []agents.ClaudeOption
+		if m := phase.Model; m != "" {
+			extra = append(extra, agents.WithModel(m))
 		}
 		if timeout > 0 {
-			opts = append(opts, agents.WithDefaultTimeout(timeout))
+			extra = append(extra, agents.WithDefaultTimeout(timeout))
 		}
-		a := agents.NewClaudeAgent(opts...)
+		a := newClaudeAgentFromConfig(cfg, extra...)
 		if !a.Available() {
 			return nil, fmt.Errorf("claude CLI not found in PATH")
 		}

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -99,8 +99,26 @@ func runJira(cmd *cobra.Command, _ []string) error {
 		jira.WithValidationAgent(validationAgent),
 		jira.WithPhaseCallback(func(ticketKey string, phase jira.Phase, done bool) {
 			if !done {
-				fmt.Printf("    ⟳ %-12s …\n", phase)
+				switch phase {
+				case jira.PhaseValidate:
+					fmt.Printf("    ⟳ validate      checking ticket quality…\n")
+				case jira.PhasePlan:
+					fmt.Printf("    ⟳ plan          generating implementation plan…\n")
+				case jira.PhaseImplement:
+					fmt.Printf("    ⟳ implement     coding — this may take a while…\n")
+				case jira.PhaseCommit:
+					fmt.Printf("    ⟳ commit        committing changes…\n")
+				case jira.PhasePR:
+					fmt.Printf("    ⟳ pr            opening pull request…\n")
+				case jira.PhaseStatus:
+					fmt.Printf("    ⟳ status        updating Jira ticket…\n")
+				default:
+					fmt.Printf("    ⟳ %-12s …\n", phase)
+				}
 			}
+		}),
+		jira.WithProgressPrinter(func(format string, args ...any) {
+			fmt.Printf("    "+format+"\n", args...)
 		}),
 	}
 	if skipValidation {
@@ -231,6 +249,10 @@ func runTodoPhase(
 	ready, blocked := graph.ResolveOrder()
 	for _, b := range blocked {
 		log.Infof("ticket %s blocked by %v, skipping", b.Ticket.Key, b.Blockers)
+		fmt.Printf("  ⏭  %s  blocked by %v\n", b.Ticket.Key, b.Blockers)
+	}
+	if len(ready) == 0 {
+		fmt.Println("  no tickets ready to process")
 	}
 
 	count := 0
@@ -239,6 +261,7 @@ func runTodoPhase(
 			break
 		}
 		fmt.Printf("\n  ▶ %s  %s\n", ticket.Key, ticket.Summary)
+		fmt.Printf("    setting up workspace…\n")
 		ws, err := jira.SetupWorkspace(ctx, jiracfg, ticket.Key)
 		if err != nil {
 			log.Errorf("workspace %s: %v", ticket.Key, err)
@@ -275,8 +298,12 @@ func runReviewPhase(
 	}
 	log.Infof("review tickets: %d found", len(reviewTickets))
 
+	if len(reviewTickets) == 0 {
+		fmt.Println("  no tickets in review")
+	}
 	for _, ticket := range reviewTickets {
 		fmt.Printf("\n  🔍 %s  %s\n", ticket.Key, ticket.Summary)
+		fmt.Printf("    setting up workspace…\n")
 		ws, err := jira.SetupWorkspace(ctx, jiracfg, ticket.Key)
 		if err != nil {
 			log.Errorf("workspace %s: %v", ticket.Key, err)

--- a/cmd/nightshift/commands/run.go
+++ b/cmd/nightshift/commands/run.go
@@ -17,16 +17,13 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/marcus/nightshift/internal/agents"
 	"github.com/marcus/nightshift/internal/budget"
-	"github.com/marcus/nightshift/internal/calibrator"
 	"github.com/marcus/nightshift/internal/config"
 	"github.com/marcus/nightshift/internal/db"
 	"github.com/marcus/nightshift/internal/logging"
 	"github.com/marcus/nightshift/internal/orchestrator"
-	"github.com/marcus/nightshift/internal/providers"
 	"github.com/marcus/nightshift/internal/reporting"
 	"github.com/marcus/nightshift/internal/state"
 	"github.com/marcus/nightshift/internal/tasks"
-	"github.com/marcus/nightshift/internal/trends"
 	"github.com/mattn/go-isatty"
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
@@ -196,15 +193,8 @@ func runRun(cmd *cobra.Command, args []string) error {
 		log.Infof("cleared %d stale assignments", cleared)
 	}
 
-	// Initialize providers
-	claudeProvider := providers.NewClaudeWithPath(cfg.ExpandedProviderPath("claude"))
-	codexProvider := providers.NewCodexWithPath(cfg.ExpandedProviderPath("codex"))
-	copilotProvider := providers.NewCopilotWithPath(cfg.ExpandedProviderPath("copilot"))
-
 	// Initialize budget manager
-	cal := calibrator.New(database, cfg)
-	trend := trends.NewAnalyzer(database, cfg.Budget.SnapshotRetentionDays)
-	budgetMgr := budget.NewManagerFromProviders(cfg, claudeProvider, codexProvider, copilotProvider, budget.WithBudgetSource(cal), budget.WithTrendAnalyzer(trend))
+	budgetMgr := newBudgetManager(cfg, database)
 
 	// Determine projects to run
 	projects, err := resolveProjects(cfg, projectPath)

--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -4,11 +4,8 @@ package agents
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -222,78 +219,12 @@ func (a *ClaudeAgent) ExecuteWithFiles(ctx context.Context, prompt string, files
 	})
 }
 
-// buildFileContext reads files and formats them as context.
 func (a *ClaudeAgent) buildFileContext(files []string) (string, error) {
-	var sb strings.Builder
-
-	sb.WriteString("# Context Files\n\n")
-
-	for _, path := range files {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return "", fmt.Errorf("reading %s: %w", path, err)
-		}
-
-		// Use absolute path for cleaner output
-		displayPath := path
-		if abs, err := filepath.Abs(path); err == nil {
-			displayPath = abs
-		}
-
-		fmt.Fprintf(&sb, "## File: %s\n\n```\n%s\n```\n\n", displayPath, string(content))
-	}
-
-	return sb.String(), nil
+	return buildFileContext(files)
 }
 
-// extractJSON attempts to find and parse JSON from the output.
-// Returns nil if no valid JSON found.
 func (a *ClaudeAgent) extractJSON(output []byte) []byte {
-	// Try to parse the entire output as JSON
-	if json.Valid(output) {
-		return output
-	}
-
-	// Look for JSON object or array in output
-	// Find first { or [ and matching closer
-	start := -1
-	var opener, closer byte
-
-	for i, b := range output {
-		if b == '{' || b == '[' {
-			start = i
-			opener = b
-			if b == '{' {
-				closer = '}'
-			} else {
-				closer = ']'
-			}
-			break
-		}
-	}
-
-	if start == -1 {
-		return nil
-	}
-
-	// Find matching closer by counting nesting
-	depth := 0
-	for i := start; i < len(output); i++ {
-		if output[i] == opener {
-			depth++
-		} else if output[i] == closer {
-			depth--
-			if depth == 0 {
-				candidate := output[start : i+1]
-				if json.Valid(candidate) {
-					return candidate
-				}
-				break
-			}
-		}
-	}
-
-	return nil
+	return extractJSON(output)
 }
 
 // Available checks if the claude binary is available in PATH.

--- a/internal/agents/codex.go
+++ b/internal/agents/codex.go
@@ -3,11 +3,8 @@ package agents
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -177,78 +174,12 @@ func (a *CodexAgent) ExecuteWithFiles(ctx context.Context, prompt string, files 
 	})
 }
 
-// buildFileContext reads files and formats them as context.
 func (a *CodexAgent) buildFileContext(files []string) (string, error) {
-	var sb strings.Builder
-
-	sb.WriteString("# Context Files\n\n")
-
-	for _, path := range files {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return "", fmt.Errorf("reading %s: %w", path, err)
-		}
-
-		// Use absolute path for cleaner output
-		displayPath := path
-		if abs, err := filepath.Abs(path); err == nil {
-			displayPath = abs
-		}
-
-		fmt.Fprintf(&sb, "## File: %s\n\n```\n%s\n```\n\n", displayPath, string(content))
-	}
-
-	return sb.String(), nil
+	return buildFileContext(files)
 }
 
-// extractJSON attempts to find and parse JSON from the output.
-// Returns nil if no valid JSON found.
 func (a *CodexAgent) extractJSON(output []byte) []byte {
-	// Try to parse the entire output as JSON
-	if json.Valid(output) {
-		return output
-	}
-
-	// Look for JSON object or array in output
-	// Find first { or [ and matching closer
-	start := -1
-	var opener, closer byte
-
-	for i, b := range output {
-		if b == '{' || b == '[' {
-			start = i
-			opener = b
-			if b == '{' {
-				closer = '}'
-			} else {
-				closer = ']'
-			}
-			break
-		}
-	}
-
-	if start == -1 {
-		return nil
-	}
-
-	// Find matching closer by counting nesting
-	depth := 0
-	for i := start; i < len(output); i++ {
-		if output[i] == opener {
-			depth++
-		} else if output[i] == closer {
-			depth--
-			if depth == 0 {
-				candidate := output[start : i+1]
-				if json.Valid(candidate) {
-					return candidate
-				}
-				break
-			}
-		}
-	}
-
-	return nil
+	return extractJSON(output)
 }
 
 // Available checks if the codex binary is available in PATH.

--- a/internal/agents/copilot.go
+++ b/internal/agents/copilot.go
@@ -3,11 +3,8 @@ package agents
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -184,78 +181,12 @@ func (a *CopilotAgent) ExecuteWithFiles(ctx context.Context, prompt string, file
 	})
 }
 
-// buildFileContext reads files and formats them as context.
 func (a *CopilotAgent) buildFileContext(files []string) (string, error) {
-	var sb strings.Builder
-
-	sb.WriteString("# Context Files\n\n")
-
-	for _, path := range files {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return "", fmt.Errorf("reading %s: %w", path, err)
-		}
-
-		// Use absolute path for cleaner output
-		displayPath := path
-		if abs, err := filepath.Abs(path); err == nil {
-			displayPath = abs
-		}
-
-		fmt.Fprintf(&sb, "## File: %s\n\n```\n%s\n```\n\n", displayPath, string(content))
-	}
-
-	return sb.String(), nil
+	return buildFileContext(files)
 }
 
-// extractJSON attempts to find and parse JSON from the output.
-// Returns nil if no valid JSON found.
 func (a *CopilotAgent) extractJSON(output []byte) []byte {
-	// Try to parse the entire output as JSON
-	if json.Valid(output) {
-		return output
-	}
-
-	// Look for JSON object or array in output
-	// Find first { or [ and matching closer
-	start := -1
-	var opener, closer byte
-
-	for i, b := range output {
-		if b == '{' || b == '[' {
-			start = i
-			opener = b
-			if b == '{' {
-				closer = '}'
-			} else {
-				closer = ']'
-			}
-			break
-		}
-	}
-
-	if start == -1 {
-		return nil
-	}
-
-	// Find matching closer by counting nesting
-	depth := 0
-	for i := start; i < len(output); i++ {
-		if output[i] == opener {
-			depth++
-		} else if output[i] == closer {
-			depth--
-			if depth == 0 {
-				candidate := output[start : i+1]
-				if json.Valid(candidate) {
-					return candidate
-				}
-				break
-			}
-		}
-	}
-
-	return nil
+	return extractJSON(output)
 }
 
 // Available checks if the gh binary is available in PATH and copilot extension is installed.

--- a/internal/agents/util.go
+++ b/internal/agents/util.go
@@ -1,0 +1,71 @@
+package agents
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// buildFileContext reads the given files and formats them as a markdown context
+// block suitable for injection into an agent prompt.
+func buildFileContext(files []string) (string, error) {
+	var sb strings.Builder
+	sb.WriteString("# Context Files\n\n")
+	for _, path := range files {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("reading %s: %w", path, err)
+		}
+		displayPath := path
+		if abs, err := filepath.Abs(path); err == nil {
+			displayPath = abs
+		}
+		fmt.Fprintf(&sb, "## File: %s\n\n```\n%s\n```\n\n", displayPath, string(content))
+	}
+	return sb.String(), nil
+}
+
+// extractJSON attempts to find and parse JSON from raw output bytes.
+// Returns nil if no valid JSON is found.
+func extractJSON(output []byte) []byte {
+	if json.Valid(output) {
+		return output
+	}
+
+	start := -1
+	var opener, closer byte
+	for i, b := range output {
+		if b == '{' || b == '[' {
+			start = i
+			opener = b
+			if b == '{' {
+				closer = '}'
+			} else {
+				closer = ']'
+			}
+			break
+		}
+	}
+	if start == -1 {
+		return nil
+	}
+
+	depth := 0
+	for i := start; i < len(output); i++ {
+		if output[i] == opener {
+			depth++
+		} else if output[i] == closer {
+			depth--
+			if depth == 0 {
+				candidate := output[start : i+1]
+				if json.Valid(candidate) {
+					return candidate
+				}
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -73,9 +73,11 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 				continue
 			}
 			o.log.Infof("ticket %s: found PR %s in repo %s", ticket.Key, prInfo.URL, repo.Name)
+			o.emit("  📎 PR %s", prInfo.URL)
 			result.PRURLs = append(result.PRURLs, prInfo.URL)
 
 			// Fetch the current review state.
+			o.emit("  fetching PR review comments from GitHub…")
 			reviewState, err := o.fnFetchReviews(ctx, repo.Path, prInfo.URL)
 			if err != nil {
 				return nil, fmt.Errorf("jira: feedback: fetch reviews %s: %w", repo.Name, err)
@@ -106,10 +108,12 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 
 			// Build a prompt from the review comments and execute the agent.
 			prompt := buildReworkPrompt(ticket, reviewState, repo)
+			timeout := parseTimeout(o.cfg.ReviewFix.Timeout, 20*time.Minute)
+			o.emit("🤖 claude running: review-fix  (%s, timeout %s)", o.cfg.ReviewFix.Model, timeout.Round(time.Minute))
 			agentResult, err := agent.Execute(ctx, agents.ExecuteOptions{
 				Prompt:  prompt,
 				WorkDir: repo.Path,
-				Timeout: parseTimeout(o.cfg.ReviewFix.Timeout, 20*time.Minute),
+				Timeout: timeout,
 				Model:   o.cfg.ReviewFix.Model,
 			})
 			if err != nil {
@@ -125,6 +129,7 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			}
 			if changed {
 				msg := CommitMessage(ticket.Key, "", "address review feedback")
+				o.emit("  committing + pushing review fixes → %s", repo.Branch)
 				if err := o.fnCommitAndPush(ctx, repo.Path, msg); err != nil {
 					return nil, fmt.Errorf("jira: feedback: push fixes %s: %w", repo.Name, err)
 				}
@@ -132,6 +137,7 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			}
 
 			// Post a summary comment on the GitHub PR.
+			o.emit("  posting rework summary to PR %s", prInfo.URL)
 			if err := o.fnPostPRComment(ctx, repo.Path, prInfo.URL, buildPRReworkComment(agentResult.Output)); err != nil {
 				o.log.Errorf("ticket %s: post pr comment %s: %v", ticket.Key, repo.Name, err)
 			}
@@ -142,6 +148,7 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 
 	// Post a Jira rework comment when fixes were made.
 	if result.FixesMade > 0 {
+		o.emit("📝 posting rework summary to Jira %s", ticket.Key)
 		comment := NightshiftComment{
 			Type:      CommentRework,
 			Timestamp: time.Now(),

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -142,11 +142,13 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 }
 
 // hasActionableComments returns true when the review state has at least one
-// unresolved, non-outdated inline comment — used to trigger rework even when
-// ReviewDecision is not CHANGES_REQUESTED (e.g. Copilot COMMENTED reviews).
+// inline comment — used to trigger rework even when ReviewDecision is not
+// CHANGES_REQUESTED (e.g. Copilot COMMENTED reviews). Outdated comments are
+// included: position=null means the diff moved after a push, not that the
+// suggestion was resolved.
 func hasActionableComments(rs *PRReviewState) bool {
 	for _, c := range rs.Comments {
-		if c.Path != "" && !c.Outdated {
+		if c.Path != "" {
 			return true
 		}
 	}
@@ -166,8 +168,12 @@ func buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace)
 	}
 	b.WriteString("### Inline Comments\n\n")
 	for _, c := range review.Comments {
-		if c.Path != "" && !c.Outdated {
-			fmt.Fprintf(&b, "**%s:%d** (%s):\n%s\n\n", c.Path, c.Line, c.Author, c.Body)
+		if c.Path != "" {
+			if c.Outdated {
+				fmt.Fprintf(&b, "**%s:%d** (%s) [OUTDATED — verify if still applies to current code]:\n%s\n\n", c.Path, c.Line, c.Author, c.Body)
+			} else {
+				fmt.Fprintf(&b, "**%s:%d** (%s):\n%s\n\n", c.Path, c.Line, c.Author, c.Body)
+			}
 		}
 	}
 	b.WriteString("### Instructions\n")

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -12,14 +12,15 @@ import (
 
 // FeedbackResult holds the outcome of processing review feedback for a ticket.
 type FeedbackResult struct {
-	TicketKey     string
-	PRURLs        []string
-	ReviewsFound  int // total review comments found
-	FixesMade     int // number of repos where review feedback was addressed
-	PushedCommits int // number of commits pushed
-	Summary       string
-	Error         string
-	Duration      time.Duration
+	TicketKey        string
+	PRURLs           []string
+	ReviewsFound     int // total review comments found
+	FixesMade        int // number of repos where review feedback was addressed
+	PushedCommits    int // number of commits pushed
+	AcknowledgedOnly bool // true when the agent ran but made no changes (review already handled)
+	Summary          string
+	Error            string
+	Duration         time.Duration
 }
 
 // ProcessFeedback handles the full PR review feedback loop for a ticket in ON REVIEW state.
@@ -166,8 +167,11 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 				return nil, fmt.Errorf("jira: feedback: check changes %s: %w", repo.Name, err)
 			}
 			if !changed {
-				o.log.Infof("ticket %s: rework agent made no file changes — skipping commit and comment", ticket.Key)
-				o.emit("  ✓ agent made no changes — nothing to commit or report")
+				o.log.Infof("ticket %s: rework agent made no file changes — acknowledging timestamp", ticket.Key)
+				o.emit("  ✓ agent made no changes — acknowledging review as handled")
+				// Still record a CommentRework timestamp on Jira so the next run's
+				// timestamp filter knows these review comments were already examined.
+				result.AcknowledgedOnly = true
 				continue
 			}
 
@@ -189,16 +193,24 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 
 	result.Summary = fmt.Sprintf("Review feedback addressed in %d repo(s) across %d commit(s).", result.FixesMade, result.PushedCommits)
 
-	// Post a Jira rework comment only when code changes were actually committed.
-	if result.PushedCommits > 0 {
-		o.emit("📝 posting rework summary to Jira %s", ticket.Key)
+	// Post a Jira rework comment when:
+	// - code was actually committed (PushedCommits > 0), OR
+	// - agent examined the review but found no changes needed (AcknowledgedOnly).
+	// In both cases, recording the CommentRework timestamp prevents the next run
+	// from re-triggering the agent on the same already-seen review comments.
+	if result.PushedCommits > 0 || result.AcknowledgedOnly {
+		body := result.Summary
+		if result.AcknowledgedOnly {
+			body = "Reviewed open comments — no code changes needed; review feedback already addressed."
+		}
+		o.emit("📝 recording rework acknowledgement on Jira %s", ticket.Key)
 		comment := NightshiftComment{
 			Type:      CommentRework,
 			Timestamp: time.Now(),
 			Provider:  o.cfg.ReviewFix.Provider,
 			Model:     o.cfg.ReviewFix.Model,
 			Duration:  time.Since(start),
-			Body:      result.Summary,
+			Body:      body,
 		}
 		if err := o.client.PostComment(ctx, ticket.Key, comment); err != nil {
 			o.log.Errorf("ticket %s: post rework comment: %v", ticket.Key, err)

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -76,20 +76,44 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			o.emit("  📎 PR %s", prInfo.URL)
 			result.PRURLs = append(result.PRURLs, prInfo.URL)
 
+			// Determine last rework timestamp for idempotency: skip reviews/comments
+			// that were already addressed in a previous run.
+			var lastReworkAt time.Time
+			if nsComments := ParseNightshiftComments(ticket.Comments); len(nsComments) > 0 {
+				if last := GetLastCommentOfType(nsComments, CommentRework); last != nil {
+					lastReworkAt = last.Timestamp
+				}
+			}
+
 			// Fetch the current review state.
 			o.emit("  fetching PR review comments from GitHub…")
 			reviewState, err := o.fnFetchReviews(ctx, repo.Path, prInfo.URL)
 			if err != nil {
 				return nil, fmt.Errorf("jira: feedback: fetch reviews %s: %w", repo.Name, err)
 			}
+			if reviewState.InlineFetchErr != nil {
+				o.log.Errorf("ticket %s: fetch inline comments %s: %v", ticket.Key, prInfo.URL, reviewState.InlineFetchErr)
+			}
+
+			// Filter to only reviews/comments newer than the last rework.
+			if !lastReworkAt.IsZero() {
+				var newReviews []Review
+				for _, r := range reviewState.Reviews {
+					if r.CreatedAt.After(lastReworkAt) {
+						newReviews = append(newReviews, r)
+					}
+				}
+				reviewState.Reviews = newReviews
+				reviewState.Comments = filterNewComments(reviewState.Comments, lastReworkAt)
+				o.log.Infof("ticket %s: idempotency filter lastReworkAt=%s — reviews=%d comments=%d",
+					ticket.Key, lastReworkAt.Format(time.RFC3339), len(reviewState.Reviews), len(reviewState.Comments))
+			}
+
 			inlineCount := 0
 			for _, c := range reviewState.Comments {
 				if c.Path != "" {
 					inlineCount++
 				}
-			}
-			if reviewState.InlineFetchErr != nil {
-				o.log.Errorf("ticket %s: fetch inline comments %s: %v", ticket.Key, prInfo.URL, reviewState.InlineFetchErr)
 			}
 			o.log.Infof("ticket %s: PR %s — reviewDecision=%q reviews=%d comments=%d inline=%d actionable=%v",
 				ticket.Key, prInfo.URL, reviewState.ReviewDecision,
@@ -103,6 +127,7 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			// means the diff moved after a push, not that the suggestion was resolved.
 			if reviewState.ReviewDecision != "CHANGES_REQUESTED" && !hasActionableComments(reviewState) {
 				o.log.Infof("ticket %s: skipping rework — no actionable comments", ticket.Key)
+				o.emit("  ✓ no new review comments since last rework — skipping")
 				continue
 			}
 

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -63,13 +63,16 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 	if ws != nil {
 		for _, repo := range ws.Repos {
 			// Find the PR for this ticket's branch.
-			prInfo, err := o.fnFindPR(ctx, repo.Path, BranchName(ticket.Key))
+			branch := BranchName(ticket.Key)
+			prInfo, err := o.fnFindPR(ctx, repo.Path, branch)
 			if err != nil {
 				return nil, fmt.Errorf("jira: feedback: find pr %s: %w", repo.Name, err)
 			}
 			if prInfo == nil {
+				o.log.Infof("ticket %s: no open PR found for branch %s in repo %s", ticket.Key, branch, repo.Name)
 				continue
 			}
+			o.log.Infof("ticket %s: found PR %s in repo %s", ticket.Key, prInfo.URL, repo.Name)
 			result.PRURLs = append(result.PRURLs, prInfo.URL)
 
 			// Fetch the current review state.
@@ -77,12 +80,27 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			if err != nil {
 				return nil, fmt.Errorf("jira: feedback: fetch reviews %s: %w", repo.Name, err)
 			}
+			inlineCount := 0
+			for _, c := range reviewState.Comments {
+				if c.Path != "" {
+					inlineCount++
+				}
+			}
+			if reviewState.InlineFetchErr != nil {
+				o.log.Errorf("ticket %s: fetch inline comments %s: %v", ticket.Key, prInfo.URL, reviewState.InlineFetchErr)
+			}
+			o.log.Infof("ticket %s: PR %s — reviewDecision=%q reviews=%d comments=%d inline=%d actionable=%v",
+				ticket.Key, prInfo.URL, reviewState.ReviewDecision,
+				len(reviewState.Reviews), len(reviewState.Comments), inlineCount,
+				hasActionableComments(reviewState))
 			result.ReviewsFound += len(reviewState.Reviews) + len(reviewState.Comments)
 
 			// Trigger rework when changes are explicitly requested OR when there
-			// are unresolved non-outdated inline review comments (e.g. Copilot
-			// posts COMMENTED reviews, not CHANGES_REQUESTED).
+			// are inline review comments (e.g. Copilot posts COMMENTED reviews,
+			// not CHANGES_REQUESTED). Outdated comments are included — position=null
+			// means the diff moved after a push, not that the suggestion was resolved.
 			if reviewState.ReviewDecision != "CHANGES_REQUESTED" && !hasActionableComments(reviewState) {
+				o.log.Infof("ticket %s: skipping rework — no actionable comments", ticket.Key)
 				continue
 			}
 

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -158,21 +158,24 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 				return nil, fmt.Errorf("jira: feedback: rework agent %s: %w", repo.Name, err)
 			}
 
-			result.FixesMade++
-
-			// Only commit when the agent produced file changes.
+			// Only commit and report when the agent produced file changes.
 			changed, err := o.fnHasChanges(ctx, repo.Path)
 			if err != nil {
 				return nil, fmt.Errorf("jira: feedback: check changes %s: %w", repo.Name, err)
 			}
-			if changed {
-				msg := CommitMessage(ticket.Key, "", "address review feedback")
-				o.emit("  committing + pushing review fixes → %s", repo.Branch)
-				if err := o.fnCommitAndPush(ctx, repo.Path, msg); err != nil {
-					return nil, fmt.Errorf("jira: feedback: push fixes %s: %w", repo.Name, err)
-				}
-				result.PushedCommits++
+			if !changed {
+				o.log.Infof("ticket %s: rework agent made no file changes — skipping commit and comment", ticket.Key)
+				o.emit("  ✓ agent made no changes — nothing to commit or report")
+				continue
 			}
+
+			result.FixesMade++
+			msg := CommitMessage(ticket.Key, "", "address review feedback")
+			o.emit("  committing + pushing review fixes → %s", repo.Branch)
+			if err := o.fnCommitAndPush(ctx, repo.Path, msg); err != nil {
+				return nil, fmt.Errorf("jira: feedback: push fixes %s: %w", repo.Name, err)
+			}
+			result.PushedCommits++
 
 			// Post a summary comment on the GitHub PR.
 			o.emit("  posting rework summary to PR %s", prInfo.URL)
@@ -184,8 +187,8 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 
 	result.Summary = fmt.Sprintf("Review feedback addressed in %d repo(s) across %d commit(s).", result.FixesMade, result.PushedCommits)
 
-	// Post a Jira rework comment when fixes were made.
-	if result.FixesMade > 0 {
+	// Post a Jira rework comment only when code changes were actually committed.
+	if result.PushedCommits > 0 {
 		o.emit("📝 posting rework summary to Jira %s", ticket.Key)
 		comment := NightshiftComment{
 			Type:      CommentRework,

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -91,9 +91,6 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			if err != nil {
 				return nil, fmt.Errorf("jira: feedback: fetch reviews %s: %w", repo.Name, err)
 			}
-			if reviewState.InlineFetchErr != nil {
-				o.log.Errorf("ticket %s: fetch inline comments %s: %v", ticket.Key, prInfo.URL, reviewState.InlineFetchErr)
-			}
 
 			// Filter to only reviews/comments newer than the last rework.
 			if !lastReworkAt.IsZero() {
@@ -110,14 +107,19 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			}
 
 			inlineCount := 0
+			resolvedCount := 0
 			for _, c := range reviewState.Comments {
 				if c.Path != "" {
-					inlineCount++
+					if c.Resolved {
+						resolvedCount++
+					} else {
+						inlineCount++
+					}
 				}
 			}
-			o.log.Infof("ticket %s: PR %s — reviewDecision=%q reviews=%d comments=%d inline=%d actionable=%v",
+			o.log.Infof("ticket %s: PR %s — reviewDecision=%q reviews=%d comments=%d inline=%d resolved=%d actionable=%v",
 				ticket.Key, prInfo.URL, reviewState.ReviewDecision,
-				len(reviewState.Reviews), len(reviewState.Comments), inlineCount,
+				len(reviewState.Reviews), len(reviewState.Comments), inlineCount, resolvedCount,
 				hasActionableComments(reviewState))
 			result.ReviewsFound += len(reviewState.Reviews) + len(reviewState.Comments)
 
@@ -208,13 +210,12 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 }
 
 // hasActionableComments returns true when the review state has at least one
-// inline comment — used to trigger rework even when ReviewDecision is not
-// CHANGES_REQUESTED (e.g. Copilot COMMENTED reviews). Outdated comments are
-// included: position=null means the diff moved after a push, not that the
-// suggestion was resolved.
+// unresolved inline comment. Resolved threads are excluded — they have already
+// been addressed. Outdated comments are included: position=null means the diff
+// moved after a push, not that the suggestion was resolved.
 func hasActionableComments(rs *PRReviewState) bool {
 	for _, c := range rs.Comments {
-		if c.Path != "" {
+		if c.Path != "" && !c.Resolved {
 			return true
 		}
 	}
@@ -234,7 +235,7 @@ func buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace)
 	}
 	b.WriteString("### Inline Comments\n\n")
 	for _, c := range review.Comments {
-		if c.Path != "" {
+		if c.Path != "" && !c.Resolved {
 			if c.Outdated {
 				fmt.Fprintf(&b, "**%s:%d** (%s) [OUTDATED — verify if still applies to current code]:\n%s\n\n", c.Path, c.Line, c.Author, c.Body)
 			} else {

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -150,7 +150,7 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			// Build a prompt from the review comments and execute the agent.
 			prompt := buildReworkPrompt(ticket, reviewState, repo)
 			timeout := parseTimeout(o.cfg.ReviewFix.Timeout, 20*time.Minute)
-			o.emit("🤖 claude running: review-fix  (%s, timeout %s)", o.cfg.ReviewFix.Model, timeout.Round(time.Minute))
+			o.emit("🤖 %s running: review-fix  (%s, timeout %s)", o.cfg.ReviewFix.Provider, o.cfg.ReviewFix.Model, timeout.Round(time.Minute))
 			agentResult, err := agent.Execute(ctx, agents.ExecuteOptions{
 				Prompt:  prompt,
 				WorkDir: repo.Path,

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -79,8 +79,10 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			}
 			result.ReviewsFound += len(reviewState.Reviews) + len(reviewState.Comments)
 
-			// Skip repos where the reviewer has not requested changes.
-			if reviewState.ReviewDecision != "CHANGES_REQUESTED" {
+			// Trigger rework when changes are explicitly requested OR when there
+			// are unresolved non-outdated inline review comments (e.g. Copilot
+			// posts COMMENTED reviews, not CHANGES_REQUESTED).
+			if reviewState.ReviewDecision != "CHANGES_REQUESTED" && !hasActionableComments(reviewState) {
 				continue
 			}
 
@@ -139,6 +141,18 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 	return result, nil
 }
 
+// hasActionableComments returns true when the review state has at least one
+// unresolved, non-outdated inline comment — used to trigger rework even when
+// ReviewDecision is not CHANGES_REQUESTED (e.g. Copilot COMMENTED reviews).
+func hasActionableComments(rs *PRReviewState) bool {
+	for _, c := range rs.Comments {
+		if c.Path != "" && !c.Outdated {
+			return true
+		}
+	}
+	return false
+}
+
 // buildReworkPrompt constructs the agent prompt from PR review comments.
 func buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace) string {
 	var b strings.Builder
@@ -152,7 +166,7 @@ func buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace)
 	}
 	b.WriteString("### Inline Comments\n\n")
 	for _, c := range review.Comments {
-		if c.Path != "" {
+		if c.Path != "" && !c.Outdated {
 			fmt.Fprintf(&b, "**%s:%d** (%s):\n%s\n\n", c.Path, c.Line, c.Author, c.Body)
 		}
 	}

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -121,14 +121,27 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 				hasActionableComments(reviewState))
 			result.ReviewsFound += len(reviewState.Reviews) + len(reviewState.Comments)
 
-			// Trigger rework when changes are explicitly requested OR when there
-			// are inline review comments (e.g. Copilot posts COMMENTED reviews,
-			// not CHANGES_REQUESTED). Outdated comments are included — position=null
-			// means the diff moved after a push, not that the suggestion was resolved.
-			if reviewState.ReviewDecision != "CHANGES_REQUESTED" && !hasActionableComments(reviewState) {
-				o.log.Infof("ticket %s: skipping rework — no actionable comments", ticket.Key)
-				o.emit("  ✓ no new review comments since last rework — skipping")
-				continue
+			// Skip logic depends on whether we've previously reworked this ticket.
+			// After filtering by lastReworkAt, if nothing remains → skip regardless
+			// of ReviewDecision (it stays CHANGES_REQUESTED until a re-review).
+			// On first run (lastReworkAt zero), fall back to the original heuristic.
+			if !lastReworkAt.IsZero() {
+				if len(reviewState.Reviews) == 0 && !hasActionableComments(reviewState) {
+					o.log.Infof("ticket %s: skipping rework — no new content since lastReworkAt=%s",
+						ticket.Key, lastReworkAt.Format(time.RFC3339))
+					o.emit("  ✓ no new review comments since last rework — skipping")
+					continue
+				}
+			} else {
+				// No previous rework: proceed only when changes are explicitly requested
+				// or there are actionable inline comments (Copilot posts COMMENTED reviews,
+				// not CHANGES_REQUESTED). Outdated comments are included — position=null
+				// means the diff moved after a push, not that the suggestion was resolved.
+				if reviewState.ReviewDecision != "CHANGES_REQUESTED" && !hasActionableComments(reviewState) {
+					o.log.Infof("ticket %s: skipping rework — no actionable comments", ticket.Key)
+					o.emit("  ✓ no actionable review comments — skipping")
+					continue
+				}
 			}
 
 			// Build a prompt from the review comments and execute the agent.

--- a/internal/jira/feedback_test.go
+++ b/internal/jira/feedback_test.go
@@ -351,8 +351,10 @@ func TestProcessFeedback_ChangesRequestedNoFileChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.FixesMade != 1 {
-		t.Errorf("FixesMade = %d, want 1 (agent ran)", result.FixesMade)
+	// With no file changes: agent ran but FixesMade and PushedCommits stay 0,
+	// and no commit or PR/Jira comment is posted.
+	if result.FixesMade != 0 {
+		t.Errorf("FixesMade = %d, want 0 (no file changes made)", result.FixesMade)
 	}
 	if result.PushedCommits != 0 {
 		t.Errorf("PushedCommits = %d, want 0 (no file changes)", result.PushedCommits)

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -63,6 +63,7 @@ type Orchestrator struct {
 	reviewFixAgent  agents.Agent
 	skipValidation  bool
 	onPhase         func(ticketKey string, phase Phase, done bool) // optional progress callback
+	progressf       func(format string, args ...any)               // optional human-readable progress printer
 	log             *logging.Logger
 
 	// ops are injectable for testing; set to real functions by NewOrchestrator.
@@ -103,6 +104,12 @@ func WithSkipValidation() OrchestratorOption {
 // end (done=true) of each phase. Useful for real-time progress reporting.
 func WithPhaseCallback(fn func(ticketKey string, phase Phase, done bool)) OrchestratorOption {
 	return func(o *Orchestrator) { o.onPhase = fn }
+}
+
+// WithProgressPrinter registers a printf-style function called for human-readable
+// progress events (agent start, PR creation, Jira transitions, etc.).
+func WithProgressPrinter(fn func(format string, args ...any)) OrchestratorOption {
+	return func(o *Orchestrator) { o.progressf = fn }
 }
 
 // NewOrchestrator creates an Orchestrator with the given client, config, and options.
@@ -319,6 +326,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	if !skip(PhasePlan) {
 		result.Phase = PhasePlan
 		o.notifyPhase(ticket.Key, PhasePlan, false)
+		o.emit("🤖 claude running: plan  (%s)", o.cfg.Plan.Model)
 		planStart := time.Now()
 		planResult, err := o.implAgent.Execute(ctx, agents.ExecuteOptions{
 			Prompt:  o.buildPlanPrompt(ticket),
@@ -334,6 +342,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			return result, nil
 		}
 		result.Plan = planResult.Output
+		o.emit("📝 posting plan to Jira %s", ticket.Key)
 		o.postPhaseComment(ctx, ticket.Key, CommentPlan, planResult.Output, time.Since(planStart))
 		o.log.Infof("ticket %s: plan complete", ticket.Key)
 	}
@@ -342,6 +351,8 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	if !skip(PhaseImplement) {
 		result.Phase = PhaseImplement
 		o.notifyPhase(ticket.Key, PhaseImplement, false)
+		timeout := parseTimeout(o.cfg.Implement.Timeout, 30*time.Minute)
+		o.emit("🤖 claude running: implement  (%s, timeout %s)", o.cfg.Implement.Model, timeout.Round(time.Minute))
 		implStart := time.Now()
 		workDir := ""
 		if ws != nil && len(ws.Repos) > 0 {
@@ -350,7 +361,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 		implResult, err := o.implAgent.Execute(ctx, agents.ExecuteOptions{
 			Prompt:  o.buildImplementPrompt(ticket, result.Plan, ws),
 			WorkDir: workDir,
-			Timeout: parseTimeout(o.cfg.Implement.Timeout, 30*time.Minute),
+			Timeout: timeout,
 			Model:   o.cfg.Implement.Model,
 		})
 		if err != nil {
@@ -362,6 +373,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			return result, nil
 		}
 		result.ImplementationSummary = implResult.Output
+		o.emit("📝 posting implementation summary to Jira %s", ticket.Key)
 		o.postPhaseComment(ctx, ticket.Key, CommentImplement, implResult.Output, time.Since(implStart))
 		o.log.Infof("ticket %s: implementation complete", ticket.Key)
 	}
@@ -382,9 +394,11 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 					return result, nil
 				}
 				if !changed {
+					o.emit("  no changes in repo %s — skipping commit", repo.Name)
 					continue
 				}
 				msg := CommitMessage(ticket.Key, "", ticket.Summary)
+				o.emit("  committing + pushing %s → %s", repo.Name, repo.Branch)
 				if err := o.fnCommitAndPush(ctx, repo.Path, msg); err != nil {
 					o.postErrorComment(ctx, ticket.Key, PhaseCommit, err)
 					result.Status = TicketFailed
@@ -406,6 +420,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 		}
 		var repoPRs []repoPR
 		for _, repo := range changedRepos {
+			o.emit("  creating PR for %s (%s → %s)", repo.Name, repo.Branch, repo.BaseBranch)
 			prInfo, err := o.fnCreatePR(ctx, repo, ticket, o.cfg.Site)
 			if err != nil {
 				o.postErrorComment(ctx, ticket.Key, PhasePR, err)
@@ -414,17 +429,20 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				result.Duration = time.Since(start)
 				return result, nil
 			}
+			o.emit("  ✓ PR created: %s", prInfo.URL)
 			result.PRURLs = append(result.PRURLs, prInfo.URL)
 			repoPRs = append(repoPRs, repoPR{repo: repo, url: prInfo.URL})
 		}
 		if len(result.PRURLs) > 0 {
+			o.emit("📝 posting PR links to Jira %s", ticket.Key)
 			o.postPhaseComment(ctx, ticket.Key, CommentPR,
 				fmt.Sprintf("PRs created:\n%s", strings.Join(result.PRURLs, "\n")),
 				time.Since(prStart))
 			// Post implementation summary as PR comment so reviewers have full context.
 			if result.ImplementationSummary != "" {
-				prComment := buildPRImplementationComment(ticket, result.ImplementationSummary, o.cfg.Site)
 				for _, rpr := range repoPRs {
+					o.emit("  posting implementation summary to PR %s", rpr.url)
+					prComment := buildPRImplementationComment(ticket, result.ImplementationSummary, o.cfg.Site)
 					if err := o.fnPostPRComment(ctx, rpr.repo.Path, rpr.url, prComment); err != nil {
 						o.log.Errorf("ticket %s: post impl summary on PR %s: %v", ticket.Key, rpr.url, err)
 					}
@@ -457,6 +475,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	if !skip(PhaseStatus) {
 		result.Phase = PhaseStatus
 		o.notifyPhase(ticket.Key, PhaseStatus, false)
+		o.emit("🔄 transitioning %s → review (Jira)", ticket.Key)
 		if err := o.client.TransitionToReview(ctx, ticket.Key); err != nil {
 			o.postErrorComment(ctx, ticket.Key, PhaseStatus, err)
 			result.Status = TicketFailed
@@ -624,5 +643,12 @@ func parseTimeout(s string, fallback time.Duration) time.Duration {
 func (o *Orchestrator) notifyPhase(ticketKey string, phase Phase, done bool) {
 	if o.onPhase != nil {
 		o.onPhase(ticketKey, phase, done)
+	}
+}
+
+// emit calls the progress printer when one is registered.
+func (o *Orchestrator) emit(format string, args ...any) {
+	if o.progressf != nil {
+		o.progressf(format, args...)
 	}
 }

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -62,6 +62,7 @@ type Orchestrator struct {
 	implAgent       agents.Agent
 	reviewFixAgent  agents.Agent
 	skipValidation  bool
+	onPhase         func(ticketKey string, phase Phase, done bool) // optional progress callback
 	log             *logging.Logger
 
 	// ops are injectable for testing; set to real functions by NewOrchestrator.
@@ -96,6 +97,12 @@ func WithReviewFixAgent(a agents.Agent) OrchestratorOption {
 // to in-progress directly, skipping the quality-score check.
 func WithSkipValidation() OrchestratorOption {
 	return func(o *Orchestrator) { o.skipValidation = true }
+}
+
+// WithPhaseCallback registers a callback invoked at the start (done=false) and
+// end (done=true) of each phase. Useful for real-time progress reporting.
+func WithPhaseCallback(fn func(ticketKey string, phase Phase, done bool)) OrchestratorOption {
+	return func(o *Orchestrator) { o.onPhase = fn }
 }
 
 // NewOrchestrator creates an Orchestrator with the given client, config, and options.
@@ -270,6 +277,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	// Phase 1: Validate
 	if !skip(PhaseValidate) {
 		result.Phase = PhaseValidate
+		o.notifyPhase(ticket.Key, PhaseValidate, false)
 		if !o.skipValidation {
 			vr, err := ValidateTicket(ctx, o.validationAgent, ticket)
 			if err != nil {
@@ -310,6 +318,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	// Phase 2: Plan
 	if !skip(PhasePlan) {
 		result.Phase = PhasePlan
+		o.notifyPhase(ticket.Key, PhasePlan, false)
 		planStart := time.Now()
 		planResult, err := o.implAgent.Execute(ctx, agents.ExecuteOptions{
 			Prompt:  o.buildPlanPrompt(ticket),
@@ -332,6 +341,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	// Phase 3: Implement
 	if !skip(PhaseImplement) {
 		result.Phase = PhaseImplement
+		o.notifyPhase(ticket.Key, PhaseImplement, false)
 		implStart := time.Now()
 		workDir := ""
 		if ws != nil && len(ws.Repos) > 0 {
@@ -359,6 +369,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	// Phase 4: Commit
 	if !skip(PhaseCommit) {
 		result.Phase = PhaseCommit
+		o.notifyPhase(ticket.Key, PhaseCommit, false)
 		var changedRepos []RepoWorkspace
 		if ws != nil {
 			for _, repo := range ws.Repos {
@@ -387,6 +398,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 
 		// Phase 5: PR
 		result.Phase = PhasePR
+		o.notifyPhase(ticket.Key, PhasePR, false)
 		prStart := time.Now()
 		type repoPR struct {
 			repo RepoWorkspace
@@ -444,6 +456,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	// Phase 6: Status
 	if !skip(PhaseStatus) {
 		result.Phase = PhaseStatus
+		o.notifyPhase(ticket.Key, PhaseStatus, false)
 		if err := o.client.TransitionToReview(ctx, ticket.Key); err != nil {
 			o.postErrorComment(ctx, ticket.Key, PhaseStatus, err)
 			result.Status = TicketFailed
@@ -605,4 +618,11 @@ func parseTimeout(s string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return d
+}
+
+// notifyPhase invokes the onPhase callback when one is registered.
+func (o *Orchestrator) notifyPhase(ticketKey string, phase Phase, done bool) {
+	if o.onPhase != nil {
+		o.onPhase(ticketKey, phase, done)
+	}
 }

--- a/internal/jira/pr.go
+++ b/internal/jira/pr.go
@@ -27,6 +27,7 @@ type PRReviewState struct {
 	ReviewDecision string
 	Reviews        []Review
 	Comments       []PRComment
+	InlineFetchErr error // non-nil when inline comment fetch failed (non-fatal)
 }
 
 // Review represents a single pull request review.
@@ -167,10 +168,10 @@ func FetchPRReviewComments(ctx context.Context, repoPath, prURL string) (*PRRevi
 	}
 
 	// Also fetch inline review thread comments via the GitHub API.
-	inline, err := fetchInlineReviewComments(ctx, repoPath, rs.Number)
-	if err != nil {
-		// Non-fatal: log and continue with only general comments.
-		_ = err
+	inline, inlineErr := fetchInlineReviewComments(ctx, repoPath, rs.Number)
+	if inlineErr != nil {
+		// Non-fatal: include error in result so callers can log it.
+		rs.InlineFetchErr = inlineErr
 	} else {
 		rs.Comments = append(rs.Comments, inline...)
 	}

--- a/internal/jira/pr.go
+++ b/internal/jira/pr.go
@@ -27,7 +27,6 @@ type PRReviewState struct {
 	ReviewDecision string
 	Reviews        []Review
 	Comments       []PRComment
-	InlineFetchErr error // non-nil when inline comment fetch failed (non-fatal)
 }
 
 // Review represents a single pull request review.
@@ -53,7 +52,10 @@ type PRComment struct {
 	Line int
 	// Outdated is true when the comment was made on a diff that no longer applies
 	// (GitHub sets position=null for such comments).
-	Outdated  bool
+	Outdated bool
+	// Resolved is true when the review thread this comment belongs to has been resolved
+	// on GitHub. Resolved threads should not trigger rework.
+	Resolved  bool
 	CreatedAt time.Time
 }
 
@@ -153,79 +155,16 @@ func buildPRBody(ticket Ticket, jiraSite string) string {
 	return b.String()
 }
 
-// FetchPRReviewComments fetches the current review state for a PR using `gh pr view --json`
-// and appends inline review thread comments from the GitHub API. PRComment.Path and .Line
-// are populated for inline comments.
+// FetchPRReviewComments fetches the current review state for a PR using `gh pr view --json`.
+// Inline review thread comments (with file/line and resolved status) are sourced from
+// the `reviewThreads` field, which is more reliable than a separate REST API call.
 func FetchPRReviewComments(ctx context.Context, repoPath, prURL string) (*PRReviewState, error) {
 	out, err := ghExec(ctx, repoPath, "pr", "view", prURL,
-		"--json", "url,state,reviewDecision,reviews,comments,number")
+		"--json", "url,state,reviewDecision,reviews,comments,number,reviewThreads")
 	if err != nil {
 		return nil, fmt.Errorf("jira: pr: fetch review state: %w", err)
 	}
-	rs, err := parsePRReviewState(out)
-	if err != nil {
-		return nil, err
-	}
-
-	// Also fetch inline review thread comments via the GitHub API.
-	inline, inlineErr := fetchInlineReviewComments(ctx, repoPath, rs.Number)
-	if inlineErr != nil {
-		// Non-fatal: include error in result so callers can log it.
-		rs.InlineFetchErr = inlineErr
-	} else {
-		rs.Comments = append(rs.Comments, inline...)
-	}
-	return rs, nil
-}
-
-// fetchInlineReviewComments fetches per-line review comments using the GitHub API.
-// position is null for outdated comments (code no longer in the diff); those are
-// marked PRComment.Outdated = true.
-func fetchInlineReviewComments(ctx context.Context, repoPath string, prNumber int) ([]PRComment, error) {
-	if prNumber == 0 {
-		return nil, nil
-	}
-	out, err := ghExec(ctx, repoPath, "api",
-		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", prNumber))
-	if err != nil {
-		return nil, fmt.Errorf("gh api inline comments: %w", err)
-	}
-	return parseInlineComments(out)
-}
-
-// parseInlineComments parses the raw JSON array returned by the GitHub pull request
-// review comments endpoint.
-func parseInlineComments(raw string) ([]PRComment, error) {
-	var items []struct {
-		User struct {
-			Login string `json:"login"`
-		} `json:"user"`
-		Body          string    `json:"body"`
-		Path          string    `json:"path"`
-		Line          *int      `json:"line"`
-		OriginalLine  int       `json:"original_line"`
-		Position      *int      `json:"position"` // null = outdated comment
-		CreatedAt     time.Time `json:"created_at"`
-	}
-	if err := json.Unmarshal([]byte(raw), &items); err != nil {
-		return nil, fmt.Errorf("parse inline comments: %w", err)
-	}
-	comments := make([]PRComment, 0, len(items))
-	for _, v := range items {
-		line := v.OriginalLine
-		if v.Line != nil {
-			line = *v.Line
-		}
-		comments = append(comments, PRComment{
-			Author:    v.User.Login,
-			Body:      v.Body,
-			Path:      v.Path,
-			Line:      line,
-			Outdated:  v.Position == nil,
-			CreatedAt: v.CreatedAt,
-		})
-	}
-	return comments, nil
+	return parsePRReviewState(out)
 }
 
 // parsePRReviewState decodes the JSON output of `gh pr view --json ...` into a PRReviewState.
@@ -250,6 +189,19 @@ func parsePRReviewState(raw string) (*PRReviewState, error) {
 			Body      string    `json:"body"`
 			CreatedAt time.Time `json:"createdAt"`
 		} `json:"comments"`
+		ReviewThreads []struct {
+			IsResolved bool `json:"isResolved"`
+			IsOutdated bool `json:"isOutdated"`
+			Comments   []struct {
+				Author struct {
+					Login string `json:"login"`
+				} `json:"author"`
+				Body      string    `json:"body"`
+				Path      string    `json:"path"`
+				Line      *int      `json:"line"`
+				CreatedAt time.Time `json:"createdAt"`
+			} `json:"comments"`
+		} `json:"reviewThreads"`
 	}
 	if err := json.Unmarshal([]byte(raw), &v); err != nil {
 		return nil, fmt.Errorf("jira: pr: parse review state: %w", err)
@@ -274,6 +226,24 @@ func parsePRReviewState(raw string) (*PRReviewState, error) {
 			Body:      c.Body,
 			CreatedAt: c.CreatedAt,
 		})
+	}
+	// Inline review thread comments: include path/line and resolved status.
+	for _, thread := range v.ReviewThreads {
+		for _, c := range thread.Comments {
+			line := 0
+			if c.Line != nil {
+				line = *c.Line
+			}
+			rs.Comments = append(rs.Comments, PRComment{
+				Author:    c.Author.Login,
+				Body:      c.Body,
+				Path:      c.Path,
+				Line:      line,
+				Outdated:  thread.IsOutdated,
+				Resolved:  thread.IsResolved,
+				CreatedAt: c.CreatedAt,
+			})
+		}
 	}
 	return rs, nil
 }

--- a/internal/jira/pr.go
+++ b/internal/jira/pr.go
@@ -155,16 +155,97 @@ func buildPRBody(ticket Ticket, jiraSite string) string {
 	return b.String()
 }
 
-// FetchPRReviewComments fetches the current review state for a PR using `gh pr view --json`.
-// Inline review thread comments (with file/line and resolved status) are sourced from
-// the `reviewThreads` field, which is more reliable than a separate REST API call.
+// FetchPRReviewComments fetches the current review state for a PR using `gh pr view --json`
+// and appends inline review thread comments (with resolved status) via the GitHub GraphQL API.
 func FetchPRReviewComments(ctx context.Context, repoPath, prURL string) (*PRReviewState, error) {
 	out, err := ghExec(ctx, repoPath, "pr", "view", prURL,
-		"--json", "url,state,reviewDecision,reviews,comments,number,reviewThreads")
+		"--json", "url,state,reviewDecision,reviews,comments,number")
 	if err != nil {
 		return nil, fmt.Errorf("jira: pr: fetch review state: %w", err)
 	}
-	return parsePRReviewState(out)
+	rs, err := parsePRReviewState(out)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch inline review thread comments with isResolved via GraphQL.
+	inline, err := fetchReviewThreads(ctx, repoPath, rs.Number)
+	if err != nil {
+		// Non-fatal: log and continue without inline thread data.
+		rs.Comments = append(rs.Comments, inline...)
+	} else {
+		rs.Comments = append(rs.Comments, inline...)
+	}
+	return rs, nil
+}
+
+// fetchReviewThreads fetches per-line review thread comments via the GitHub GraphQL API.
+// Each comment carries the isResolved and isOutdated status of its parent thread.
+func fetchReviewThreads(ctx context.Context, repoPath string, prNumber int) ([]PRComment, error) {
+	if prNumber == 0 {
+		return nil, nil
+	}
+	query := `query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved isOutdated comments(first:20){nodes{author{login}body path line createdAt}}}}}}}`
+	out, err := ghExec(ctx, repoPath, "api", "graphql",
+		"-F", fmt.Sprintf("owner={owner}"),
+		"-F", fmt.Sprintf("repo={repo}"),
+		"-F", fmt.Sprintf("number=%d", prNumber),
+		"-f", fmt.Sprintf("query=%s", query))
+	if err != nil {
+		return nil, fmt.Errorf("gh graphql review threads: %w", err)
+	}
+	return parseReviewThreads(out)
+}
+
+// parseReviewThreads parses the GraphQL response for review threads.
+func parseReviewThreads(raw string) ([]PRComment, error) {
+	var resp struct {
+		Data struct {
+			Repository struct {
+				PullRequest struct {
+					ReviewThreads struct {
+						Nodes []struct {
+							IsResolved bool `json:"isResolved"`
+							IsOutdated bool `json:"isOutdated"`
+							Comments   struct {
+								Nodes []struct {
+									Author struct {
+										Login string `json:"login"`
+									} `json:"author"`
+									Body      string    `json:"body"`
+									Path      string    `json:"path"`
+									Line      *int      `json:"line"`
+									CreatedAt time.Time `json:"createdAt"`
+								} `json:"nodes"`
+							} `json:"comments"`
+						} `json:"nodes"`
+					} `json:"reviewThreads"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		return nil, fmt.Errorf("parse review threads: %w", err)
+	}
+	var comments []PRComment
+	for _, thread := range resp.Data.Repository.PullRequest.ReviewThreads.Nodes {
+		for _, c := range thread.Comments.Nodes {
+			line := 0
+			if c.Line != nil {
+				line = *c.Line
+			}
+			comments = append(comments, PRComment{
+				Author:    c.Author.Login,
+				Body:      c.Body,
+				Path:      c.Path,
+				Line:      line,
+				Outdated:  thread.IsOutdated,
+				Resolved:  thread.IsResolved,
+				CreatedAt: c.CreatedAt,
+			})
+		}
+	}
+	return comments, nil
 }
 
 // parsePRReviewState decodes the JSON output of `gh pr view --json ...` into a PRReviewState.
@@ -189,19 +270,6 @@ func parsePRReviewState(raw string) (*PRReviewState, error) {
 			Body      string    `json:"body"`
 			CreatedAt time.Time `json:"createdAt"`
 		} `json:"comments"`
-		ReviewThreads []struct {
-			IsResolved bool `json:"isResolved"`
-			IsOutdated bool `json:"isOutdated"`
-			Comments   []struct {
-				Author struct {
-					Login string `json:"login"`
-				} `json:"author"`
-				Body      string    `json:"body"`
-				Path      string    `json:"path"`
-				Line      *int      `json:"line"`
-				CreatedAt time.Time `json:"createdAt"`
-			} `json:"comments"`
-		} `json:"reviewThreads"`
 	}
 	if err := json.Unmarshal([]byte(raw), &v); err != nil {
 		return nil, fmt.Errorf("jira: pr: parse review state: %w", err)
@@ -226,24 +294,6 @@ func parsePRReviewState(raw string) (*PRReviewState, error) {
 			Body:      c.Body,
 			CreatedAt: c.CreatedAt,
 		})
-	}
-	// Inline review thread comments: include path/line and resolved status.
-	for _, thread := range v.ReviewThreads {
-		for _, c := range thread.Comments {
-			line := 0
-			if c.Line != nil {
-				line = *c.Line
-			}
-			rs.Comments = append(rs.Comments, PRComment{
-				Author:    c.Author.Login,
-				Body:      c.Body,
-				Path:      c.Path,
-				Line:      line,
-				Outdated:  thread.IsOutdated,
-				Resolved:  thread.IsResolved,
-				CreatedAt: c.CreatedAt,
-			})
-		}
 	}
 	return rs, nil
 }

--- a/internal/jira/pr.go
+++ b/internal/jira/pr.go
@@ -186,38 +186,41 @@ func fetchInlineReviewComments(ctx context.Context, repoPath string, prNumber in
 		return nil, nil
 	}
 	out, err := ghExec(ctx, repoPath, "api",
-		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", prNumber),
-		"--jq", `.[].{author: .user.login, body: .body, path: .path, line: (.line // .original_line), position: .position, created_at: .created_at}`)
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", prNumber))
 	if err != nil {
 		return nil, fmt.Errorf("gh api inline comments: %w", err)
 	}
 	return parseInlineComments(out)
 }
 
-// parseInlineComments parses newline-delimited JSON objects from `gh api --jq` output.
+// parseInlineComments parses the raw JSON array returned by the GitHub pull request
+// review comments endpoint.
 func parseInlineComments(raw string) ([]PRComment, error) {
-	var comments []PRComment
-	for _, line := range strings.Split(strings.TrimSpace(raw), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		var v struct {
-			Author    string    `json:"author"`
-			Body      string    `json:"body"`
-			Path      string    `json:"path"`
-			Line      int       `json:"line"`
-			Position  *int      `json:"position"` // null = outdated comment
-			CreatedAt time.Time `json:"created_at"`
-		}
-		if err := json.Unmarshal([]byte(line), &v); err != nil {
-			continue // skip malformed lines
+	var items []struct {
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		Body          string    `json:"body"`
+		Path          string    `json:"path"`
+		Line          *int      `json:"line"`
+		OriginalLine  int       `json:"original_line"`
+		Position      *int      `json:"position"` // null = outdated comment
+		CreatedAt     time.Time `json:"created_at"`
+	}
+	if err := json.Unmarshal([]byte(raw), &items); err != nil {
+		return nil, fmt.Errorf("parse inline comments: %w", err)
+	}
+	comments := make([]PRComment, 0, len(items))
+	for _, v := range items {
+		line := v.OriginalLine
+		if v.Line != nil {
+			line = *v.Line
 		}
 		comments = append(comments, PRComment{
-			Author:    v.Author,
+			Author:    v.User.Login,
 			Body:      v.Body,
 			Path:      v.Path,
-			Line:      v.Line,
+			Line:      line,
 			Outdated:  v.Position == nil,
 			CreatedAt: v.CreatedAt,
 		})

--- a/internal/jira/pr.go
+++ b/internal/jira/pr.go
@@ -49,7 +49,10 @@ type PRComment struct {
 	Path string
 	// Line is the commented line number for inline review comments. Zero when the data
 	// source does not include inline review comment metadata.
-	Line      int
+	Line int
+	// Outdated is true when the comment was made on a diff that no longer applies
+	// (GitHub sets position=null for such comments).
+	Outdated  bool
 	CreatedAt time.Time
 }
 
@@ -175,13 +178,15 @@ func FetchPRReviewComments(ctx context.Context, repoPath, prURL string) (*PRRevi
 }
 
 // fetchInlineReviewComments fetches per-line review comments using the GitHub API.
+// position is null for outdated comments (code no longer in the diff); those are
+// marked PRComment.Outdated = true.
 func fetchInlineReviewComments(ctx context.Context, repoPath string, prNumber int) ([]PRComment, error) {
 	if prNumber == 0 {
 		return nil, nil
 	}
 	out, err := ghExec(ctx, repoPath, "api",
 		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", prNumber),
-		"--jq", `.[].{author: .user.login, body: .body, path: .path, line: (.line // .original_line), created_at: .created_at}`)
+		"--jq", `.[].{author: .user.login, body: .body, path: .path, line: (.line // .original_line), position: .position, created_at: .created_at}`)
 	if err != nil {
 		return nil, fmt.Errorf("gh api inline comments: %w", err)
 	}
@@ -201,6 +206,7 @@ func parseInlineComments(raw string) ([]PRComment, error) {
 			Body      string    `json:"body"`
 			Path      string    `json:"path"`
 			Line      int       `json:"line"`
+			Position  *int      `json:"position"` // null = outdated comment
 			CreatedAt time.Time `json:"created_at"`
 		}
 		if err := json.Unmarshal([]byte(line), &v); err != nil {
@@ -211,6 +217,7 @@ func parseInlineComments(raw string) ([]PRComment, error) {
 			Body:      v.Body,
 			Path:      v.Path,
 			Line:      v.Line,
+			Outdated:  v.Position == nil,
 			CreatedAt: v.CreatedAt,
 		})
 	}

--- a/internal/jira/pr.go
+++ b/internal/jira/pr.go
@@ -187,8 +187,8 @@ func fetchReviewThreads(ctx context.Context, repoPath string, prNumber int) ([]P
 	}
 	query := `query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved isOutdated comments(first:20){nodes{author{login}body path line createdAt}}}}}}}`
 	out, err := ghExec(ctx, repoPath, "api", "graphql",
-		"-F", fmt.Sprintf("owner={owner}"),
-		"-F", fmt.Sprintf("repo={repo}"),
+		"-F", "owner={owner}",
+		"-F", "repo={repo}",
 		"-F", fmt.Sprintf("number=%d", prNumber),
 		"-f", fmt.Sprintf("query=%s", query))
 	if err != nil {

--- a/internal/jira/pr_test.go
+++ b/internal/jira/pr_test.go
@@ -300,6 +300,7 @@ func TestFindExistingPR_OpenPR(t *testing.T) {
 	}
 	if pr == nil {
 		t.Fatal("expected PRInfo, got nil")
+		return
 	}
 	if pr.Number != 42 {
 		t.Errorf("Number = %d, want 42", pr.Number)

--- a/internal/jira/tickets.go
+++ b/internal/jira/tickets.go
@@ -194,8 +194,8 @@ func commentToComment(c *model.IssueCommentScheme) Comment {
 	if c.Body != nil {
 		cm.Body = extractText(c.Body)
 	}
-	cm.Created, _ = time.Parse(time.RFC3339, c.Created)
-	cm.Updated, _ = time.Parse(time.RFC3339, c.Updated)
+	cm.Created = parseJiraTime(c.Created)
+	cm.Updated = parseJiraTime(c.Updated)
 	return cm
 }
 
@@ -227,7 +227,29 @@ func issueLinkToLink(selfKey string, link *model.IssueLinkScheme) IssueLink {
 	return il
 }
 
-// extractText recursively extracts plain text from an ADF CommentNodeScheme.
+// parseJiraTime parses Jira timestamp strings, which use a non-RFC3339 format
+// like "2006-01-02T15:04:05.000+0200" (offset without colon). Falls back to
+// RFC3339 and then to zero time.
+func parseJiraTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	// Jira format: "2006-01-02T15:04:05.000-0700" (no colon in offset)
+	if t, err := time.Parse("2006-01-02T15:04:05.000-0700", s); err == nil {
+		return t
+	}
+	// RFC3339 with sub-seconds
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t
+	}
+	// RFC3339 plain
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t
+	}
+	return time.Time{}
+}
+
+
 func extractText(n *model.CommentNodeScheme) string {
 	if n == nil {
 		return ""


### PR DESCRIPTION
## What's in this PR

### feat: real-time per-phase stdout progress
- Each ticket prints key + summary before processing starts
- Per-phase progress line as each phase begins: `⟳ validate …`, `⟳ plan …`, `⟳ implement …`, etc.
- Completion shows status, duration, and PR URL(s): `✅ completed in 2m1s → https://…`
- Errors show failed phase + message: `⚠️ failed at phase implement — …`
- `WithPhaseCallback` option added to `Orchestrator` for progress hooks

### fix: fully idempotent review feedback loop
Running `nightshift jira run` repeatedly on a ticket already in review no longer re-runs the agent or posts duplicate comments. Multiple layers of guards:

1. **Timestamp filter** — only reviews/comments newer than the last `CommentRework` Jira comment are processed
2. **Resolved threads** — switched from REST to GraphQL (`reviewThreads`) to get `isResolved` per thread; resolved inline comments are excluded from the rework prompt and the actionable check
3. **No-changes guard** — if the agent runs but makes no file changes, skip PR/Jira comments entirely
4. **Timestamp anchor** — post a `CommentRework` to Jira even when the agent makes no changes ("no code changes needed"), so the next run's timestamp filter fires and skips the agent
5. **Jira timestamp parsing** — Jira returns timestamps as `2006-01-02T15:04:05.000+0200` (no colon in TZ offset); `time.Parse(time.RFC3339)` silently returned zero time, causing the filter to never fire. Added `parseJiraTime()` helper that handles the Jira format.

### fix: provider name in review-fix emit
`🤖 claude running: review-fix` was hardcoded regardless of configured provider. Now uses `o.cfg.ReviewFix.Provider`.

### refactor: eliminate duplication between jira and run commands
- `internal/agents/util.go` (new): extract `buildFileContext()` and `extractJSON()` as package-level functions — were identical ~70-line methods on all three agent types (claude, codex, copilot)
- `helpers.go`: extend `newClaudeAgentFromConfig` / `newCodexAgentFromConfig` with variadic extra opts (nil-safe); add `newBudgetManager(cfg, db)` shared helper
- `jira_run.go`: `createJiraAgent()` now delegates to shared helpers instead of reimplementing agent construction; uses `loadConfig()` consistently with other commands
- `run.go`, `jira_preview.go`: use `newBudgetManager()`

### fix: lint
- Remove unnecessary `fmt.Sprintf` wrappers on string literals in `pr.go` (S1039)
- Add `return` after `t.Fatal` in test to satisfy staticcheck SA5011 nil check

## Test plan

- [x] `make test` passes (all packages)
- [x] `make build` clean
- [x] `golangci-lint run` — 0 issues
- [ ] Run `nightshift jira run` and verify per-phase lines appear in real time
- [ ] Re-run on a ticket already in review — confirm agent is not re-triggered