### PR TITLE
fix(jira): resume in-progress tickets on rerun

### DIFF
--- a/cmd/nightshift/commands/jira_preview.go
+++ b/cmd/nightshift/commands/jira_preview.go
@@ -167,6 +167,15 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 					Reason: fmt.Sprintf("fetch todo tickets: %v", err),
 				})
 			} else {
+				inProgressTickets, ipErr := client.FetchInProgressTickets(ctx, statusMap)
+				if ipErr != nil {
+					result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
+						Key:    "*",
+						Reason: fmt.Sprintf("fetch in-progress tickets: %v", ipErr),
+					})
+				} else {
+					todoTickets = append(todoTickets, inProgressTickets...)
+				}
 				// Apply optional issue-type filter.
 				if typeFilter != "" {
 					filtered := todoTickets[:0]

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -141,9 +141,9 @@ func runJira(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("ticket %s not found in TODO or ON REVIEW lists", singleTicket)
 		}
 	} else {
-		// Phase A: TODO tickets.
+		// Phase A: TODO + in-progress tickets (resume failed runs).
 		if !reviewOnly {
-			if err := runTodoPhase(ctx, log, orch, client, cfg.Jira, &results); err != nil {
+			if err := runTodoPhase(ctx, log, orch, client, cfg.Jira, statusMap, &results); err != nil {
 				return err
 			}
 		}
@@ -181,12 +181,16 @@ func runSingleTicket(
 	if err != nil {
 		return false, fmt.Errorf("fetch tickets: %w", err)
 	}
+	inProgressTickets, err := client.FetchInProgressTickets(ctx, statusMap)
+	if err != nil {
+		return false, fmt.Errorf("fetch in-progress tickets: %w", err)
+	}
 	reviewTickets, err := client.FetchReviewTickets(ctx, statusMap)
 	if err != nil {
 		return false, fmt.Errorf("fetch review tickets: %w", err)
 	}
 
-	for _, t := range todoTickets {
+	for _, t := range append(todoTickets, inProgressTickets...) {
 		if t.Key != key {
 			continue
 		}
@@ -237,15 +241,21 @@ func runTodoPhase(
 	orch *jira.Orchestrator,
 	client *jira.Client,
 	jiracfg jira.JiraConfig,
+	statusMap *jira.StatusMap,
 	results *[]jira.TicketResult,
 ) error {
 	todoTickets, err := client.FetchTodoTickets(ctx)
 	if err != nil {
 		return fmt.Errorf("fetch todo tickets: %w", err)
 	}
-	log.Infof("todo tickets: %d found", len(todoTickets))
+	inProgressTickets, err := client.FetchInProgressTickets(ctx, statusMap)
+	if err != nil {
+		return fmt.Errorf("fetch in-progress tickets: %w", err)
+	}
+	allTickets := append(todoTickets, inProgressTickets...)
+	log.Infof("todo tickets: %d found (%d in-progress)", len(allTickets), len(inProgressTickets))
 
-	graph := jira.BuildDependencyGraph(todoTickets)
+	graph := jira.BuildDependencyGraph(allTickets)
 	ready, blocked := graph.ResolveOrder()
 	for _, b := range blocked {
 		log.Infof("ticket %s blocked by %v, skipping", b.Ticket.Key, b.Blockers)

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -326,7 +326,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	if !skip(PhasePlan) {
 		result.Phase = PhasePlan
 		o.notifyPhase(ticket.Key, PhasePlan, false)
-		o.emit("🤖 claude running: plan  (%s)", o.cfg.Plan.Model)
+		o.emit("🤖 %s running: plan  (%s)", o.cfg.Plan.Provider, o.cfg.Plan.Model)
 		planStart := time.Now()
 		planResult, err := o.implAgent.Execute(ctx, agents.ExecuteOptions{
 			Prompt:  o.buildPlanPrompt(ticket),
@@ -352,7 +352,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 		result.Phase = PhaseImplement
 		o.notifyPhase(ticket.Key, PhaseImplement, false)
 		timeout := parseTimeout(o.cfg.Implement.Timeout, 30*time.Minute)
-		o.emit("🤖 claude running: implement  (%s, timeout %s)", o.cfg.Implement.Model, timeout.Round(time.Minute))
+		o.emit("🤖 %s running: implement  (%s, timeout %s)", o.cfg.Implement.Provider, o.cfg.Implement.Model, timeout.Round(time.Minute))
 		implStart := time.Now()
 		workDir := ""
 		if ws != nil && len(ws.Repos) > 0 {

--- a/internal/jira/tickets.go
+++ b/internal/jira/tickets.go
@@ -59,6 +59,28 @@ func (c *Client) FetchTodoTickets(ctx context.Context) ([]Ticket, error) {
 	return c.fetchParentDescriptions(ctx, tickets), nil
 }
 
+// FetchInProgressTickets fetches issues that are in a non-review "indeterminate" status,
+// filtered by the configured label. These are tickets that were started by nightshift but
+// failed mid-run (e.g. during plan or implement) and need to be resumed.
+func (c *Client) FetchInProgressTickets(ctx context.Context, statusMap *StatusMap) ([]Ticket, error) {
+	if statusMap == nil || len(statusMap.InProgressStatuses) == 0 {
+		return nil, nil
+	}
+	names := make([]string, len(statusMap.InProgressStatuses))
+	for i, s := range statusMap.InProgressStatuses {
+		names[i] = fmt.Sprintf(`"%s"`, s.Name)
+	}
+	jql := fmt.Sprintf(
+		`project = "%s" AND status in (%s) AND labels = "%s" ORDER BY created ASC`,
+		c.cfg.Project, strings.Join(names, ", "), c.cfg.Label,
+	)
+	tickets, err := c.fetchTickets(ctx, jql)
+	if err != nil {
+		return nil, err
+	}
+	return c.fetchParentDescriptions(ctx, tickets), nil
+}
+
 // FetchReviewTickets fetches issues that are in a review status, filtered by the configured label.
 func (c *Client) FetchReviewTickets(ctx context.Context, statusMap *StatusMap) ([]Ticket, error) {
 	if statusMap == nil || len(statusMap.ReviewStatuses) == 0 {


### PR DESCRIPTION
## Problem

When a ticket fails mid-run (e.g. validation passes but plan fails due to a bad model name), it has already been transitioned to **In Progress** (`statusCategory = indeterminate`). On the next run, `FetchTodoTickets` only queries `statusCategory = "To Do"`, so the stuck ticket is never picked up again.

## Fix

- Added `FetchInProgressTickets` — queries non-review indeterminate statuses with the nightshift label
- `runTodoPhase` now merges todo + in-progress tickets before dependency resolution
- `runSingleTicket` also searches in-progress tickets when looking up a specific key
- `detectResumeState` already handles resumption correctly (reads nightshift comments to find the furthest completed phase and skips already-done phases)

## Test plan

- [ ] Fix bad model name, rerun — ticket resumes from the failed phase (plan) instead of being skipped
- [ ] Ticket that completed all phases is still skipped (alreadyDone guard in detectResumeState)
- [ ] `--ticket KEY` flag works for an in-progress ticket