### PR TITLE
[VC-43] Acceptance criteria silently dropped when it appears at end of description

### DIFF
--- a/internal/jira/tickets.go
+++ b/internal/jira/tickets.go
@@ -249,7 +249,6 @@ func parseJiraTime(s string) time.Time {
 	return time.Time{}
 }
 
-
 func extractText(n *model.CommentNodeScheme) string {
 	if n == nil {
 		return ""
@@ -281,37 +280,72 @@ func isBlockNode(n *model.CommentNodeScheme) bool {
 }
 
 // extractAcceptanceCriteria extracts the acceptance criteria section from a description string.
-// It looks for a heading containing "acceptance criteria" (case-insensitive) and returns all
-// text until the next heading or end of string.
+// It looks for a heading line that starts with "acceptance criteria" (case-insensitive) and
+// returns all text until the next heading or end of string.
 func extractAcceptanceCriteria(description string) string {
-	lower := strings.ToLower(description)
-	idx := strings.Index(lower, "acceptance criteria")
-	if idx < 0 {
-		return ""
-	}
-	// Skip past the heading line
 	const acKeyword = "acceptance criteria"
-	start := strings.Index(description[idx:], "\n")
-	var rest string
-	if start < 0 {
-		// No newline after heading: treat any inline content after the keyword as the body
-		rest = strings.TrimSpace(description[idx+len(acKeyword):])
-		// Strip a leading ':' or whitespace that often follows inline headings (e.g. "Acceptance Criteria: ...")
-		rest = strings.TrimLeft(rest, ": \t")
-	} else {
-		start += idx + 1
-		rest = description[start:]
-	}
-	// Stop at the next section: a non-empty line that ends with ':' and contains no spaces
-	// (matches "SectionName:" style headings produced by extractText).
-	lines := strings.Split(rest, "\n")
-	var out []string
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if len(out) > 0 && trimmed != "" && strings.HasSuffix(trimmed, ":") && !strings.Contains(trimmed, " ") {
+	for start := 0; start <= len(description); {
+		end := strings.IndexByte(description[start:], '\n')
+		line := description[start:]
+		nextStart := len(description)
+		if end >= 0 {
+			line = description[start : start+end]
+			nextStart = start + end + 1
+		}
+
+		body, ok := acceptanceCriteriaBodyFromLine(line)
+		if ok {
+			rest := body
+			if nextStart <= len(description) && nextStart < len(description) {
+				tail := description[nextStart:]
+				if tail != "" {
+					if rest != "" {
+						rest += "\n" + tail
+					} else {
+						rest = tail
+					}
+				}
+			}
+			// Stop at the next section: a non-empty line that ends with ':' and contains no spaces
+			// (matches "SectionName:" style headings produced by extractText).
+			lines := strings.Split(rest, "\n")
+			var out []string
+			for _, line := range lines {
+				trimmed := strings.TrimSpace(line)
+				if len(out) > 0 && trimmed != "" && strings.HasSuffix(trimmed, ":") && !strings.Contains(trimmed, " ") {
+					break
+				}
+				out = append(out, line)
+			}
+			return strings.TrimSpace(strings.Join(out, "\n"))
+		}
+
+		if end < 0 {
 			break
 		}
-		out = append(out, line)
+		start = nextStart
 	}
-	return strings.TrimSpace(strings.Join(out, "\n"))
+	return ""
+}
+
+func acceptanceCriteriaBodyFromLine(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return "", false
+	}
+
+	for strings.HasPrefix(trimmed, "#") {
+		trimmed = strings.TrimLeft(trimmed, "#")
+		trimmed = strings.TrimLeft(trimmed, " \t")
+	}
+
+	if len(trimmed) < len("acceptance criteria") || !strings.EqualFold(trimmed[:len("acceptance criteria")], "acceptance criteria") {
+		return "", false
+	}
+
+	rest := strings.TrimLeft(trimmed[len("acceptance criteria"):], ": \t")
+	if rest == "" {
+		return "", true
+	}
+	return rest, true
 }

--- a/internal/jira/tickets.go
+++ b/internal/jira/tickets.go
@@ -46,6 +46,7 @@ type IssueLink struct {
 }
 
 const searchPageSize = 50
+const acKeyword = "acceptance criteria"
 
 // FetchTodoTickets fetches issues in the "To Do" status category filtered by the configured label.
 func (c *Client) FetchTodoTickets(ctx context.Context) ([]Ticket, error) {
@@ -311,7 +312,6 @@ func isBlockNode(n *model.CommentNodeScheme) bool {
 // It looks for a heading line that starts with "acceptance criteria" (case-insensitive) and
 // returns all text until the next heading or end of string.
 func extractAcceptanceCriteria(description string) string {
-	const acKeyword = "acceptance criteria"
 	for start := 0; start <= len(description); {
 		end := strings.IndexByte(description[start:], '\n')
 		line := description[start:]
@@ -367,11 +367,11 @@ func acceptanceCriteriaBodyFromLine(line string) (string, bool) {
 		trimmed = strings.TrimLeft(trimmed, " \t")
 	}
 
-	if len(trimmed) < len("acceptance criteria") || !strings.EqualFold(trimmed[:len("acceptance criteria")], "acceptance criteria") {
+	if len(trimmed) < len(acKeyword) || !strings.EqualFold(trimmed[:len(acKeyword)], acKeyword) {
 		return "", false
 	}
 
-	rest := strings.TrimLeft(trimmed[len("acceptance criteria"):], ": \t")
+	rest := strings.TrimLeft(trimmed[len(acKeyword):], ": \t")
 	if rest == "" {
 		return "", true
 	}

--- a/internal/jira/tickets.go
+++ b/internal/jira/tickets.go
@@ -290,12 +290,18 @@ func extractAcceptanceCriteria(description string) string {
 		return ""
 	}
 	// Skip past the heading line
+	const acKeyword = "acceptance criteria"
 	start := strings.Index(description[idx:], "\n")
+	var rest string
 	if start < 0 {
-		return ""
+		// No newline after heading: treat any inline content after the keyword as the body
+		rest = strings.TrimSpace(description[idx+len(acKeyword):])
+		// Strip a leading ':' or whitespace that often follows inline headings (e.g. "Acceptance Criteria: ...")
+		rest = strings.TrimLeft(rest, ": \t")
+	} else {
+		start += idx + 1
+		rest = description[start:]
 	}
-	start += idx + 1
-	rest := description[start:]
 	// Stop at the next section: a non-empty line that ends with ':' and contains no spaces
 	// (matches "SectionName:" style headings produced by extractText).
 	lines := strings.Split(rest, "\n")

--- a/internal/jira/tickets_test.go
+++ b/internal/jira/tickets_test.go
@@ -111,10 +111,28 @@ func TestExtractAcceptanceCriteria_StopsAtNextSection(t *testing.T) {
 }
 
 func TestExtractAcceptanceCriteria_NoNewlineAfterHeading(t *testing.T) {
-	// "acceptance criteria" with no newline after — returns empty
+	// "acceptance criteria" keyword only, no content after → still empty
 	got := extractAcceptanceCriteria("acceptance criteria")
 	if got != "" {
-		t.Errorf("expected empty when no newline, got %q", got)
+		t.Errorf("expected empty when heading only with no content, got %q", got)
+	}
+}
+
+func TestExtractAcceptanceCriteria_ContentAfterHeadingNoNewline(t *testing.T) {
+	// Heading with inline content and no trailing newline — this was the silent-drop bug
+	desc := "Acceptance Criteria: must pass all checks"
+	got := extractAcceptanceCriteria(desc)
+	if !strings.Contains(got, "must pass all checks") {
+		t.Errorf("expected body content, got %q", got)
+	}
+}
+
+func TestExtractAcceptanceCriteria_HeadingAtEndNoTrailingNewline(t *testing.T) {
+	// Heading followed by items but no trailing newline — regression guard
+	desc := "Do the thing.\n\nAcceptance Criteria\n- item1\n- item2"
+	got := extractAcceptanceCriteria(desc)
+	if !strings.Contains(got, "item1") || !strings.Contains(got, "item2") {
+		t.Errorf("expected items, got %q", got)
 	}
 }
 

--- a/internal/jira/tickets_test.go
+++ b/internal/jira/tickets_test.go
@@ -127,12 +127,32 @@ func TestExtractAcceptanceCriteria_ContentAfterHeadingNoNewline(t *testing.T) {
 	}
 }
 
+func TestExtractAcceptanceCriteria_ContentAfterHeadingWithNewline(t *testing.T) {
+	// Heading with inline content followed by newline content — preserve both parts.
+	desc := "Acceptance Criteria: must pass\n- item"
+	got := extractAcceptanceCriteria(desc)
+	if !strings.Contains(got, "must pass") {
+		t.Errorf("expected inline content to be preserved, got %q", got)
+	}
+	if !strings.Contains(got, "item") {
+		t.Errorf("expected following newline content to be preserved, got %q", got)
+	}
+}
+
 func TestExtractAcceptanceCriteria_HeadingAtEndNoTrailingNewline(t *testing.T) {
 	// Heading followed by items but no trailing newline — regression guard
 	desc := "Do the thing.\n\nAcceptance Criteria\n- item1\n- item2"
 	got := extractAcceptanceCriteria(desc)
 	if !strings.Contains(got, "item1") || !strings.Contains(got, "item2") {
 		t.Errorf("expected items, got %q", got)
+	}
+}
+
+func TestExtractAcceptanceCriteria_RejectsSentenceMention(t *testing.T) {
+	desc := "We discussed acceptance criteria yesterday"
+	got := extractAcceptanceCriteria(desc)
+	if got != "" {
+		t.Errorf("expected empty for non-heading mention, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## VC-43 — Acceptance criteria silently dropped when it appears at end of description

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-43

### Description

extractAcceptanceCriteria in tickets.go:221-224 searches for a newline after the "Acceptance Criteria" heading. If the heading is the last line of the description with no trailing newline, strings.Index returns -1 and the function returns "" — the entire acceptance criteria section is discarded with no error or warning. This causes the agent to proceed without acceptance criteria, silently reducing implementation quality.\n\nFile: internal/jira/tickets.go:221-224\n\nFix: When no newline is found after the heading, treat the remainder of the string as the acceptance criteria body rather than returning empty.

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
