### PR TITLE
[VC-45] Malformed percent-encoding in comment metadata silently stores empty string

### DIFF
--- a/internal/jira/comments.go
+++ b/internal/jira/comments.go
@@ -132,13 +132,21 @@ func parseCommentMeta(body string) (CommentType, map[string]string, bool) {
 	// extract key=value pairs from the nightshift:type line (provider, model, duration)
 	if tl := reTypeLine.FindStringSubmatch(body); tl != nil {
 		for _, kv := range reKV.FindAllStringSubmatch(tl[1], -1) {
-			meta[kv[1]], _ = url.QueryUnescape(kv[2])
+			if decoded, err := url.QueryUnescape(kv[2]); err == nil {
+				meta[kv[1]] = decoded
+			} else {
+				meta[kv[1]] = kv[2]
+			}
 		}
 	}
 	// extract additional key=value pairs from the nightshift:meta line
 	if mm := reMeta.FindStringSubmatch(body); mm != nil {
 		for _, kv := range reKV.FindAllStringSubmatch(mm[1], -1) {
-			meta[kv[1]], _ = url.QueryUnescape(kv[2])
+			if decoded, err := url.QueryUnescape(kv[2]); err == nil {
+				meta[kv[1]] = decoded
+			} else {
+				meta[kv[1]] = kv[2]
+			}
 		}
 	}
 	return ct, meta, true

--- a/internal/jira/comments_test.go
+++ b/internal/jira/comments_test.go
@@ -146,6 +146,21 @@ func TestParseCommentMeta_DecodesURLValues(t *testing.T) {
 	}
 }
 
+func TestParseCommentMeta_InvalidPercentEncoding(t *testing.T) {
+	// %ZZ is not valid percent-encoding; raw value must be preserved, not discarded
+	body := "<!-- nightshift:type=pr provider=%ZZclaude model=sonnet duration=1m -->\n<!-- nightshift:meta url=%ZZbad -->"
+	_, meta, ok := parseCommentMeta(body)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if meta["provider"] != "%ZZclaude" {
+		t.Errorf("meta[provider] = %q, want %q", meta["provider"], "%ZZclaude")
+	}
+	if meta["url"] != "%ZZbad" {
+		t.Errorf("meta[url] = %q, want %q", meta["url"], "%ZZbad")
+	}
+}
+
 func TestGetLastCommentOfType(t *testing.T) {
 	now := time.Now()
 	comments := []NightshiftComment{


### PR DESCRIPTION
## VC-45 — Malformed percent-encoding in comment metadata silently stores empty string

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-45

### Description

parseCommentMeta in comments.go:135 and 141 discards the error from url.QueryUnescape: meta[kv[1]], _ = url.QueryUnescape(kv[2]). Any metadata value with invalid percent-encoding (e.g. %ZZ) silently stores an empty string for that key. This causes provider, model, and duration metadata to be silently lost from parsed comments, breaking any logic that relies on them.\n\nFile: internal/jira/comments.go:135,141\n\nFix: Fall back to the raw (unescaped) value when url.QueryUnescape returns an error, rather than storing an empty string.

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
