### PR TITLE
[VC-38] --skip-validation flag is a no-op; validation always runs

### DIFF
--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -80,9 +80,13 @@ func runJira(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("discover statuses: %w", err)
 	}
 
-	validationAgent, err := createJiraAgent(cfg, cfg.Jira.Validation)
-	if err != nil {
-		return fmt.Errorf("validation agent: %w", err)
+	var validationAgent agents.Agent
+	if !skipValidation {
+		var err error
+		validationAgent, err = createJiraAgent(cfg, cfg.Jira.Validation)
+		if err != nil {
+			return fmt.Errorf("validation agent: %w", err)
+		}
 	}
 	implAgent, err := createJiraAgent(cfg, cfg.Jira.Implement)
 	if err != nil {
@@ -96,7 +100,6 @@ func runJira(cmd *cobra.Command, _ []string) error {
 	orchOpts := []jira.OrchestratorOption{
 		jira.WithImplAgent(implAgent),
 		jira.WithReviewFixAgent(reviewFixAgent),
-		jira.WithValidationAgent(validationAgent),
 		jira.WithPhaseCallback(func(ticketKey string, phase jira.Phase, done bool) {
 			if !done {
 				switch phase {
@@ -123,6 +126,8 @@ func runJira(cmd *cobra.Command, _ []string) error {
 	}
 	if skipValidation {
 		orchOpts = append(orchOpts, jira.WithSkipValidation())
+	} else {
+		orchOpts = append(orchOpts, jira.WithValidationAgent(validationAgent))
 	}
 	orch := jira.NewOrchestrator(client, cfg.Jira, orchOpts...)
 

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -104,7 +104,11 @@ func runJira(cmd *cobra.Command, _ []string) error {
 			if !done {
 				switch phase {
 				case jira.PhaseValidate:
-					fmt.Printf("    ⟳ validate      checking ticket quality…\n")
+					if skipValidation {
+						fmt.Printf("    ⟳ validate      skipped (validation disabled)…\n")
+					} else {
+						fmt.Printf("    ⟳ validate      checking ticket quality…\n")
+					}
 				case jira.PhasePlan:
 					fmt.Printf("    ⟳ plan          generating implementation plan…\n")
 				case jira.PhaseImplement:
@@ -131,7 +135,7 @@ func runJira(cmd *cobra.Command, _ []string) error {
 	}
 	orch := jira.NewOrchestrator(client, cfg.Jira, orchOpts...)
 
-	printJiraPreflightSummary(cfg.Jira, statusMap)
+	printJiraPreflightSummary(cfg.Jira, skipValidation, statusMap)
 
 	var results []jira.TicketResult
 	var feedbackResults []jira.FeedbackResult
@@ -402,13 +406,17 @@ func createJiraAgent(cfg *config.Config, phase jira.PhaseConfig) (agents.Agent, 
 	}
 }
 
-func printJiraPreflightSummary(cfg jira.JiraConfig, _ *jira.StatusMap) {
+func printJiraPreflightSummary(cfg jira.JiraConfig, skipValidation bool, _ *jira.StatusMap) {
 	fmt.Println("🌙 Nightshift Jira Run")
 	fmt.Println("──────────────────────────────")
 	fmt.Printf("  Site:         %s.atlassian.net\n", cfg.Site)
 	fmt.Printf("  Project:      %s\n", cfg.Project)
 	fmt.Printf("  Label:        %s\n", cfg.Label)
-	fmt.Printf("  Validation:   %s/%s\n", cfg.Validation.Provider, cfg.Validation.Model)
+	if skipValidation {
+		fmt.Printf("  Validation:   skipped\n")
+	} else {
+		fmt.Printf("  Validation:   %s/%s\n", cfg.Validation.Provider, cfg.Validation.Model)
+	}
 	fmt.Printf("  Implement:    %s/%s\n", cfg.Implement.Provider, cfg.Implement.Model)
 	fmt.Printf("  ReviewFix:    %s/%s\n", cfg.ReviewFix.Provider, cfg.ReviewFix.Model)
 	fmt.Printf("  Max tickets:  %d\n", cfg.MaxTickets)

--- a/cmd/nightshift/commands/jira_run_test.go
+++ b/cmd/nightshift/commands/jira_run_test.go
@@ -22,7 +22,7 @@ func TestPrintJiraPreflightSummary(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		printJiraPreflightSummary(cfg, nil)
+		printJiraPreflightSummary(cfg, false, nil)
 	})
 
 	checks := []string{
@@ -37,6 +37,23 @@ func TestPrintJiraPreflightSummary(t *testing.T) {
 		if !strings.Contains(out, s) {
 			t.Errorf("preflight summary missing %q\nfull output:\n%s", s, out)
 		}
+	}
+}
+
+func TestPrintJiraPreflightSummary_SkippedValidation(t *testing.T) {
+	cfg := jira.JiraConfig{
+		Site:       "testsite",
+		Project:    "PROJ",
+		Label:      "nightshift",
+		Validation: jira.PhaseConfig{Provider: "claude", Model: "claude-haiku-4.5"},
+	}
+
+	out := captureStdout(t, func() {
+		printJiraPreflightSummary(cfg, true, nil)
+	})
+
+	if !strings.Contains(out, "Validation:   skipped") {
+		t.Errorf("preflight summary should show skipped validation\nfull output:\n%s", out)
 	}
 }
 

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -244,8 +244,8 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	start := time.Now()
 	result := &TicketResult{TicketKey: ticket.Key}
 
-	if o.validationAgent == nil || o.implAgent == nil {
-		return nil, fmt.Errorf("jira: orchestrator: validation and impl agents are required")
+	if o.implAgent == nil || (!o.skipValidation && o.validationAgent == nil) {
+		return nil, fmt.Errorf("jira: orchestrator: impl agent is required; validation agent required when not skipping validation")
 	}
 
 	rs := detectResumeState(ticket)

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -34,15 +34,15 @@ const (
 
 // TicketResult holds the outcome of processing a single Jira ticket.
 type TicketResult struct {
-	TicketKey              string        `json:"ticket_key"`
-	Status                 TicketStatus  `json:"status"`
-	Phase                  Phase         `json:"phase"`
-	PRURLs                 []string      `json:"pr_urls,omitempty"`
-	Plan                   string        `json:"plan,omitempty"`
-	ImplementationSummary  string        `json:"implementation_summary,omitempty"`
-	Summary                string        `json:"summary,omitempty"`
-	Error                  string        `json:"error,omitempty"`
-	Duration               time.Duration `json:"duration"`
+	TicketKey             string        `json:"ticket_key"`
+	Status                TicketStatus  `json:"status"`
+	Phase                 Phase         `json:"phase"`
+	PRURLs                []string      `json:"pr_urls,omitempty"`
+	Plan                  string        `json:"plan,omitempty"`
+	ImplementationSummary string        `json:"implementation_summary,omitempty"`
+	Summary               string        `json:"summary,omitempty"`
+	Error                 string        `json:"error,omitempty"`
+	Duration              time.Duration `json:"duration"`
 }
 
 // jiraClient defines the Jira operations needed by the orchestrator.
@@ -244,8 +244,11 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	start := time.Now()
 	result := &TicketResult{TicketKey: ticket.Key}
 
-	if o.implAgent == nil || (!o.skipValidation && o.validationAgent == nil) {
-		return nil, fmt.Errorf("jira: orchestrator: impl agent is required; validation agent required when not skipping validation")
+	if o.implAgent == nil {
+		return nil, fmt.Errorf("jira: orchestrator: impl agent is required")
+	}
+	if !o.skipValidation && o.validationAgent == nil {
+		return nil, fmt.Errorf("jira: orchestrator: validation agent is required when not skipping validation")
 	}
 
 	rs := detectResumeState(ticket)

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -62,13 +62,25 @@ func TestNewOrchestrator_Options(t *testing.T) {
 // ── ProcessTicket ─────────────────────────────────────────────────────────────
 
 func TestProcessTicket_NilAgents(t *testing.T) {
-	sc := &stubJiraClient{}
-	o := &Orchestrator{client: sc, cfg: JiraConfig{}}
+	t.Run("missing impl", func(t *testing.T) {
+		sc := &stubJiraClient{}
+		o := &Orchestrator{client: sc, cfg: JiraConfig{}, validationAgent: &stubAgent{name: "validator"}}
 
-	_, err := o.ProcessTicket(context.Background(), Ticket{Key: "X-1"}, &Workspace{})
-	if err == nil {
-		t.Fatal("expected error for nil agents")
-	}
+		_, err := o.ProcessTicket(context.Background(), Ticket{Key: "X-1"}, &Workspace{})
+		if err == nil || err.Error() != "jira: orchestrator: impl agent is required" {
+			t.Fatalf("error = %v, want impl agent missing error", err)
+		}
+	})
+
+	t.Run("missing validation", func(t *testing.T) {
+		sc := &stubJiraClient{}
+		o := &Orchestrator{client: sc, cfg: JiraConfig{}, implAgent: &stubAgent{name: "impl"}}
+
+		_, err := o.ProcessTicket(context.Background(), Ticket{Key: "X-2"}, &Workspace{})
+		if err == nil || err.Error() != "jira: orchestrator: validation agent is required when not skipping validation" {
+			t.Fatalf("error = %v, want validation agent missing error", err)
+		}
+	})
 }
 
 func TestProcessTicket_SkipValidation_NilAgent(t *testing.T) {
@@ -606,7 +618,8 @@ func TestProcessTicket_CommitPhase_NoChanges(t *testing.T) {
 	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
 	o.fnCommitAndPush = func(_ context.Context, _, _ string) error { t.Error("CommitAndPush called unexpectedly"); return nil }
 	o.fnCreatePR = func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
-		t.Error("CreateOrUpdatePR called unexpectedly"); return nil, nil
+		t.Error("CreateOrUpdatePR called unexpectedly")
+		return nil, nil
 	}
 
 	result, err := o.ProcessTicket(context.Background(), Ticket{Key: "T-1", Summary: "Test"}, ws)
@@ -804,7 +817,6 @@ func (a *callCountAgent) Execute(_ context.Context, _ agents.ExecuteOptions) (*a
 	return &agents.ExecuteResult{Output: ""}, nil
 }
 
-
 // ── detectResumeState ─────────────────────────────────────────────────────────
 
 func nightshiftComment(ct CommentType, body string) Comment {
@@ -901,7 +913,9 @@ func TestProcessTicket_AlreadyComplete_EarlyExit(t *testing.T) {
 		implAgent:       implAgent,
 		fnHasChanges:    func(_ context.Context, _ string) (bool, error) { return false, nil },
 		fnCommitAndPush: func(_ context.Context, _, _ string) error { return nil },
-		fnCreatePR:      func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) { return &PRInfo{URL: "u"}, nil },
+		fnCreatePR: func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+			return &PRInfo{URL: "u"}, nil
+		},
 		fnFindPR:        func(_ context.Context, _, _ string) (*PRInfo, error) { return nil, nil },
 		fnFetchReviews:  func(_ context.Context, _, _ string) (*PRReviewState, error) { return nil, nil },
 		fnPostPRComment: func(_ context.Context, _, _, _ string) error { return nil },
@@ -956,7 +970,9 @@ func TestProcessTicket_SkipsValidationWhenAlreadyValidated(t *testing.T) {
 		implAgent:       implAgent,
 		fnHasChanges:    func(_ context.Context, _ string) (bool, error) { return false, nil },
 		fnCommitAndPush: func(_ context.Context, _, _ string) error { return nil },
-		fnCreatePR:      func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) { return &PRInfo{URL: "u"}, nil },
+		fnCreatePR: func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+			return &PRInfo{URL: "u"}, nil
+		},
 		fnFindPR:        func(_ context.Context, _, _ string) (*PRInfo, error) { return nil, nil },
 		fnFetchReviews:  func(_ context.Context, _, _ string) (*PRReviewState, error) { return nil, nil },
 		fnPostPRComment: func(_ context.Context, _, _, _ string) error { return nil },

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -71,6 +71,41 @@ func TestProcessTicket_NilAgents(t *testing.T) {
 	}
 }
 
+func TestProcessTicket_SkipValidation_NilAgent(t *testing.T) {
+	sc := &stubJiraClient{}
+	ia := &stubAgent{name: "impl", output: "implementation done"}
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		skipValidation:  true,
+		validationAgent: nil,
+		implAgent:       ia,
+	}
+
+	ticket := Ticket{Key: "TEST-SV", Summary: "Skip validation test", Description: "Do the thing."}
+	ws := &Workspace{TicketKey: "TEST-SV"} // no repos — skips commit/PR
+
+	result, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("unexpected error with nil validation agent when skipValidation=true: %v", err)
+	}
+	if result.Status != TicketCompleted {
+		t.Errorf("Status = %q, want %q", result.Status, TicketCompleted)
+	}
+
+	// Ensure no validation comment was posted.
+	for _, c := range sc.postCommentCalls {
+		if c.Type == CommentValidation {
+			t.Error("unexpected CommentValidation posted when skipValidation=true")
+		}
+	}
+
+	// Ensure impl agent was called (plan + implement phases ran).
+	if ia.capturedOpts.Prompt == "" {
+		t.Error("expected impl agent to be called, but capturedOpts.Prompt is empty")
+	}
+}
+
 func TestProcessTicket_HappyPath(t *testing.T) {
 	sc := &stubJiraClient{}
 	va := &stubAgent{

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -108,7 +108,7 @@ nightshift jira preview --plain         # No TUI pager
 | `--ticket` | Process a single ticket by key |
 | `--max-tickets` | Max tickets to process (default from config) |
 | `--label` | Jira label filter (overrides config, default `nightshift`) |
-| `--skip-validation` | Accepted for compatibility; validation is still performed |
+| `--skip-validation` | Skip LLM ticket validation step (saves tokens) |
 | `--todo-only` | Only process TODO-status tickets |
 | `--review-only` | Only process review-feedback tickets |
 

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -108,7 +108,7 @@ nightshift jira preview --plain         # No TUI pager
 | `--ticket` | Process a single ticket by key |
 | `--max-tickets` | Max tickets to process (default from config) |
 | `--label` | Jira label filter (overrides config, default `nightshift`) |
-| `--skip-validation` | Skip LLM ticket validation step (saves tokens) |
+| `--skip-validation` | Skip LLM ticket validation step (saves tokens; preflight and progress output show validation as skipped) |
 | `--todo-only` | Only process TODO-status tickets |
 | `--review-only` | Only process review-feedback tickets |
 


### PR DESCRIPTION
## VC-38 — --skip-validation flag is a no-op; validation always runs

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-38

### Description

Both branches of the skipValidation if/else in jira_run.go:98-102 call orchOpts = append(orchOpts, jira.WithValidationAgent(validationAgent)) identically. The orchestrator only skips validation when validationAgent == nil, but it is always set. The flag is accepted and logs a misleading message, but validation always runs and consumes tokens regardless.\n\nFile: cmd/nightshift/commands/jira_run.go:98-102\n\nFix: Only append WithValidationAgent when !skipValidation. When skipping, do not set the validation agent so the orchestrator nil-check gates it correctly (or add explicit skip support in ProcessTicket).

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
