### PR TITLE
[VC-41] Orchestrator nil guard does not initialise fnFindPR, fnFetchReviews, fnPostPRComment

### DIFF
--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -34,15 +34,15 @@ const (
 
 // TicketResult holds the outcome of processing a single Jira ticket.
 type TicketResult struct {
-	TicketKey              string        `json:"ticket_key"`
-	Status                 TicketStatus  `json:"status"`
-	Phase                  Phase         `json:"phase"`
-	PRURLs                 []string      `json:"pr_urls,omitempty"`
-	Plan                   string        `json:"plan,omitempty"`
-	ImplementationSummary  string        `json:"implementation_summary,omitempty"`
-	Summary                string        `json:"summary,omitempty"`
-	Error                  string        `json:"error,omitempty"`
-	Duration               time.Duration `json:"duration"`
+	TicketKey             string        `json:"ticket_key"`
+	Status                TicketStatus  `json:"status"`
+	Phase                 Phase         `json:"phase"`
+	PRURLs                []string      `json:"pr_urls,omitempty"`
+	Plan                  string        `json:"plan,omitempty"`
+	ImplementationSummary string        `json:"implementation_summary,omitempty"`
+	Summary               string        `json:"summary,omitempty"`
+	Error                 string        `json:"error,omitempty"`
+	Duration              time.Duration `json:"duration"`
 }
 
 // jiraClient defines the Jira operations needed by the orchestrator.
@@ -231,11 +231,19 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	}
 	if o.fnHasChanges == nil {
 		o.fnHasChanges = HasChanges
+	}
+	if o.fnCommitAndPush == nil {
 		o.fnCommitAndPush = CommitAndPush
+	}
+	if o.fnCreatePR == nil {
 		o.fnCreatePR = CreateOrUpdatePR
+	}
+	if o.fnFindPR == nil {
 		o.fnFindPR = func(ctx context.Context, repoPath, branch string) (*PRInfo, error) {
 			return findExistingPR(ctx, repoPath, branch)
 		}
+	}
+	if o.fnFetchReviews == nil {
 		o.fnFetchReviews = FetchPRReviewComments
 	}
 	if o.fnPostPRComment == nil {

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -233,6 +233,10 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 		o.fnHasChanges = HasChanges
 		o.fnCommitAndPush = CommitAndPush
 		o.fnCreatePR = CreateOrUpdatePR
+		o.fnFindPR = func(ctx context.Context, repoPath, branch string) (*PRInfo, error) {
+			return findExistingPR(ctx, repoPath, branch)
+		}
+		o.fnFetchReviews = FetchPRReviewComments
 	}
 	if o.fnPostPRComment == nil {
 		o.fnPostPRComment = func(ctx context.Context, repoPath, prURL, body string) error {

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -571,7 +571,8 @@ func TestProcessTicket_CommitPhase_NoChanges(t *testing.T) {
 	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
 	o.fnCommitAndPush = func(_ context.Context, _, _ string) error { t.Error("CommitAndPush called unexpectedly"); return nil }
 	o.fnCreatePR = func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
-		t.Error("CreateOrUpdatePR called unexpectedly"); return nil, nil
+		t.Error("CreateOrUpdatePR called unexpectedly")
+		return nil, nil
 	}
 
 	result, err := o.ProcessTicket(context.Background(), Ticket{Key: "T-1", Summary: "Test"}, ws)
@@ -769,7 +770,6 @@ func (a *callCountAgent) Execute(_ context.Context, _ agents.ExecuteOptions) (*a
 	return &agents.ExecuteResult{Output: ""}, nil
 }
 
-
 // ── detectResumeState ─────────────────────────────────────────────────────────
 
 func nightshiftComment(ct CommentType, body string) Comment {
@@ -866,7 +866,9 @@ func TestProcessTicket_AlreadyComplete_EarlyExit(t *testing.T) {
 		implAgent:       implAgent,
 		fnHasChanges:    func(_ context.Context, _ string) (bool, error) { return false, nil },
 		fnCommitAndPush: func(_ context.Context, _, _ string) error { return nil },
-		fnCreatePR:      func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) { return &PRInfo{URL: "u"}, nil },
+		fnCreatePR: func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+			return &PRInfo{URL: "u"}, nil
+		},
 		fnFindPR:        func(_ context.Context, _, _ string) (*PRInfo, error) { return nil, nil },
 		fnFetchReviews:  func(_ context.Context, _, _ string) (*PRReviewState, error) { return nil, nil },
 		fnPostPRComment: func(_ context.Context, _, _, _ string) error { return nil },
@@ -897,6 +899,44 @@ func TestProcessTicket_AlreadyComplete_EarlyExit(t *testing.T) {
 	}
 }
 
+func TestProcessTicket_DefaultInjectablesWhenFnHasChangesSet(t *testing.T) {
+	client := &stubJiraClient{}
+	validationAgent := &stubAgent{output: `{"score": 9, "valid": true, "reasoning": "ok"}`}
+	implAgent := &stubAgent{output: "plan"}
+	o := &Orchestrator{
+		client:          client,
+		validationAgent: validationAgent,
+		implAgent:       implAgent,
+		fnHasChanges:    func(_ context.Context, _ string) (bool, error) { return false, nil },
+	}
+	ticket := Ticket{
+		Key: "T-100",
+		Comments: []Comment{
+			nightshiftComment(CommentValidation, "ok"),
+			nightshiftComment(CommentPlan, "plan"),
+			nightshiftComment(CommentImplement, "done"),
+			nightshiftComment(CommentPR, "PRs created:\nhttps://github.com/org/repo/pull/1"),
+		},
+	}
+	ws := &Workspace{
+		Repos: []RepoWorkspace{{Name: "repo", Path: "/tmp", Branch: "feature/T-100", BaseBranch: "main"}},
+	}
+
+	result, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != TicketCompleted {
+		t.Errorf("Status = %q, want %q", result.Status, TicketCompleted)
+	}
+	if o.fnFindPR == nil {
+		t.Error("fnFindPR should be initialized independently")
+	}
+	if o.fnFetchReviews == nil {
+		t.Error("fnFetchReviews should be initialized independently")
+	}
+}
+
 func TestParsePRURLsFromComment(t *testing.T) {
 	body := "PRs created:\nhttps://github.com/org/repo/pull/42\nhttps://github.com/org/repo/pull/43\nsome other line"
 	urls := parsePRURLsFromComment(body)
@@ -921,7 +961,9 @@ func TestProcessTicket_SkipsValidationWhenAlreadyValidated(t *testing.T) {
 		implAgent:       implAgent,
 		fnHasChanges:    func(_ context.Context, _ string) (bool, error) { return false, nil },
 		fnCommitAndPush: func(_ context.Context, _, _ string) error { return nil },
-		fnCreatePR:      func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) { return &PRInfo{URL: "u"}, nil },
+		fnCreatePR: func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+			return &PRInfo{URL: "u"}, nil
+		},
 		fnFindPR:        func(_ context.Context, _, _ string) (*PRInfo, error) { return nil, nil },
 		fnFetchReviews:  func(_ context.Context, _, _ string) (*PRReviewState, error) { return nil, nil },
 		fnPostPRComment: func(_ context.Context, _, _, _ string) error { return nil },


### PR DESCRIPTION
## VC-41 — Orchestrator nil guard does not initialise fnFindPR, fnFetchReviews, fnPostPRComment

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-41

### Description

The nil guard in orchestrator.go:124-128 initialises fnHasChanges, fnCommitAndPush, and fnCreatePR when nil, but does not cover fnFindPR, fnFetchReviews, or fnPostPRComment. Any Orchestrator constructed directly (e.g. in tests without NewOrchestrator) will nil-panic when ProcessFeedback calls those three functions.\n\nFile: internal/jira/orchestrator.go:124-128\n\nFix: Add the three missing assignments to the nil guard, mirroring the pattern used for the other injectable functions.

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
