### PR TITLE
[VC-46] Comment type-line metadata not URL-encoded but decoded with QueryUnescape

### DIFF
--- a/internal/jira/comments.go
+++ b/internal/jira/comments.go
@@ -177,7 +177,10 @@ func formatComment(c NightshiftComment) string {
 		c.Provider, c.Model, c.Duration.Round(time.Second))
 	b.WriteString(c.Body)
 	fmt.Fprintf(&b, "\n\n<!-- nightshift:type=%s provider=%s model=%s duration=%s -->\n",
-		c.Type, c.Provider, c.Model, c.Duration.Round(time.Second))
+		c.Type,
+		url.QueryEscape(c.Provider),
+		url.QueryEscape(c.Model),
+		url.QueryEscape(c.Duration.Round(time.Second).String()))
 	if len(c.Metadata) > 0 {
 		b.WriteString("<!-- nightshift:meta")
 		for k, v := range c.Metadata {

--- a/internal/jira/comments_test.go
+++ b/internal/jira/comments_test.go
@@ -193,6 +193,50 @@ func TestExtractBody(t *testing.T) {
 	}
 }
 
+func TestFormatComment_TypeLineURLEncoded(t *testing.T) {
+	c := NightshiftComment{
+		Type:     CommentPlan,
+		Provider: "acme%corp",
+		Model:    "model/v2",
+		Duration: 5 * time.Minute,
+		Body:     "body",
+	}
+	body := formatComment(c)
+	if strings.Contains(body, "provider=acme%corp ") || strings.Contains(body, "provider=acme%corp -") {
+		t.Error("provider with raw % must be URL-encoded in type line")
+	}
+	if strings.Contains(body, "model=model/v2") {
+		t.Error("model with / must be URL-encoded in type line")
+	}
+	if !strings.Contains(body, "provider=acme%25corp") {
+		t.Errorf("provider %% must be encoded as %%25 in type line")
+	}
+	if !strings.Contains(body, "model=model%2Fv2") {
+		t.Errorf("model / must be encoded as %%2F in type line")
+	}
+}
+
+func TestFormatComment_TypeLineRoundTrip(t *testing.T) {
+	c := NightshiftComment{
+		Type:     CommentPlan,
+		Provider: "acme%corp",
+		Model:    "claude-3/sonnet",
+		Duration: 2 * time.Minute,
+		Body:     "body",
+	}
+	body := formatComment(c)
+	_, meta, ok := parseCommentMeta(body)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if meta["provider"] != "acme%corp" {
+		t.Errorf("provider = %q, want %q", meta["provider"], "acme%corp")
+	}
+	if meta["model"] != "claude-3/sonnet" {
+		t.Errorf("model = %q, want %q", meta["model"], "claude-3/sonnet")
+	}
+}
+
 func TestParseNightshiftComments(t *testing.T) {
 	now := time.Now()
 	raw := []Comment{


### PR DESCRIPTION
## VC-46 — Comment type-line metadata not URL-encoded but decoded with QueryUnescape

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-46

### Description

formatComment in comments.go:171-172 writes provider, model, and duration into the nightshift:type HTML comment as raw strings without url.QueryEscape. The nightshift:meta line on 175-177 correctly URL-encodes its values. Both lines are decoded with url.QueryUnescape in parseCommentMeta. If any type-line value contains a % character (e.g. a model name or a future field), url.QueryUnescape will misinterpret it and corrupt or error on the value.\n\nFile: internal/jira/comments.go:171-172 and parseCommentMeta:133-136\n\nFix: Apply url.QueryEscape to provider, model, and duration values when writing the nightshift:type line, making encoding consistent with the meta line.

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
