### PR TITLE
[VC-40] Implement phase agent only runs in first repo for multi-repo tickets

### DIFF
--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -395,6 +395,10 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				}
 				if !changed {
 					o.emit("  no changes in repo %s — skipping commit", repo.Name)
+					// NOTE: If the agent only modified repo[0] but the ticket required
+					// changes in this repo too, we silently skip it here. Enforcement
+					// (fail-fast when expected repos are untouched) is deferred to a
+					// follow-up ticket.
 					continue
 				}
 				msg := CommitMessage(ticket.Key, "", ticket.Summary)
@@ -556,6 +560,11 @@ func (o *Orchestrator) buildImplementPrompt(ticket Ticket, plan string, ws *Work
 		for _, repo := range ws.Repos {
 			fmt.Fprintf(&b, "- %s: %s (branch: %s, base: %s)\n",
 				repo.Name, repo.Path, repo.Branch, repo.BaseBranch)
+		}
+		if len(ws.Repos) > 1 {
+			b.WriteString("\nYou are responsible for making changes across ALL repos listed above. ")
+			b.WriteString("Use their absolute paths to edit files in each repo. ")
+			b.WriteString("Do not limit your edits to your working directory.\n")
 		}
 	}
 	b.WriteString("\n## Instructions\n")

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -304,6 +304,50 @@ func TestBuildImplementPrompt_MultiRepo(t *testing.T) {
 	}
 }
 
+func TestBuildImplementPrompt_MultiRepo_CrossRepoInstruction(t *testing.T) {
+	o := &Orchestrator{cfg: JiraConfig{}}
+	ticket := Ticket{Key: "X-1", Description: "Multi-repo work."}
+	ws := &Workspace{
+		Repos: []RepoWorkspace{
+			{Name: "frontend", Path: "/ws/frontend", Branch: "feat/X-1", BaseBranch: "main"},
+			{Name: "backend", Path: "/ws/backend", Branch: "feat/X-1", BaseBranch: "main"},
+		},
+	}
+
+	prompt := o.buildImplementPrompt(ticket, "plan", ws)
+
+	for _, path := range []string{"/ws/frontend", "/ws/backend"} {
+		if !strings.Contains(prompt, path) {
+			t.Errorf("prompt missing repo path %q", path)
+		}
+	}
+	if !strings.Contains(prompt, "ALL repos") {
+		t.Error("prompt missing cross-repo instruction")
+	}
+	if !strings.Contains(prompt, "absolute paths") {
+		t.Error("prompt missing absolute paths instruction")
+	}
+	if !strings.Contains(prompt, "working directory") {
+		t.Error("prompt missing working-directory scope warning")
+	}
+}
+
+func TestBuildImplementPrompt_SingleRepo_NoCrossRepoInstruction(t *testing.T) {
+	o := &Orchestrator{cfg: JiraConfig{}}
+	ticket := Ticket{Key: "X-2", Description: "Single repo."}
+	ws := &Workspace{
+		Repos: []RepoWorkspace{
+			{Name: "api", Path: "/ws/api", Branch: "feat/X-2", BaseBranch: "main"},
+		},
+	}
+
+	prompt := o.buildImplementPrompt(ticket, "plan", ws)
+
+	if strings.Contains(prompt, "ALL repos") {
+		t.Error("single-repo prompt must not contain cross-repo instruction")
+	}
+}
+
 // ── buildPlanPrompt ───────────────────────────────────────────────────────────
 
 func TestBuildPlanPrompt(t *testing.T) {


### PR DESCRIPTION
## VC-40 — Implement phase agent only runs in first repo for multi-repo tickets

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-40

### Description

Bug
In internal/jira/orchestrator.go (Phase 3 — Implement), workDir is hardcoded to ws.Repos[0].Path. The agent is spawned once, rooted in the first repo, regardless of how many repos are configured in the workspace. The Commit and PR phases correctly iterate over all repos, but since the agent never ran in repos 1–N, there are no changes to commit there. Multi-repo tickets silently produce incomplete implementations.
File: internal/jira/orchestrator.go — Phase 3 Implement block
workDir := ""
if ws != nil && len(ws.Repos) > 0 {
    workDir = ws.Repos[0].Path  // ← always first repo only
}
implResult, err := o.implAgent.Execute(ctx, agents.ExecuteOptions{
    WorkDir: workDir,
    ...
})

Chosen Fix: Single pass, cross-repo (Option 2)
Keep a single implAgent.Execute call. The prompt already includes all repo paths via buildImplementPrompt (the Workspace section lists every repo name, path, branch, and base branch). The agent must use those absolute paths to make changes across repos from within a single working directory.
The workDir should be set to the first repo path as the agent's launch directory (no change there), but the prompt must make it unambiguous that the agent is responsible for editing files in all listed repos, not just the one it is launched from.
No orchestration fan-out is needed. The agent already receives all the context — the fix is purely in making the prompt explicit about cross-repo responsibility.

Acceptance Criteria
[ ] When a workspace has 2+ repos and both require changes, the agent modifies files in all relevant repo worktrees during the single implement pass.
[ ] The Commit phase detects changes in all repos (it already iterates ws.Repos) and commits each changed repo independently.
[ ] The PR phase creates one PR per changed repo.
[ ] If a repo requires no changes, the implement pass leaves it untouched and the Commit phase skips it with a log line (no changes in repo X — skipping commit), which already exists.
[ ] If the agent only modifies repo[0] but the ticket description implies repo[1] also needed changes, the Commit phase must not silently succeed — this is acceptable behavior for now (no enforcement added), but must be documented in a code comment.
[ ] The implement prompt (buildImplementPrompt) explicitly instructs the agent to make changes in all listed repos using their absolute paths, not just the working directory.
[ ] All existing orchestrator tests pass.
[ ] A test is added for the multi-repo implement prompt: verify that when ws.Repos has 2 entries, the prompt contains both repo paths and an explicit cross-repo instruction.

Implementation Notes
Only buildImplementPrompt needs to change: add an explicit instruction such as "You are responsible for making changes across ALL repos listed in the Workspace section. Use their absolute paths. Do not limit your edits to your working directory."
No changes needed to ProcessTicket orchestration logic.
No changes needed to Commit or PR phases — they already iterate all repos.
Backward compatible: single-repo workspaces are unaffected.

Out of Scope
Fan-out orchestration (running a separate agent per repo) — not chosen.
Fail-fast enforcement when the agent misses a repo — deferred to a follow-up ticket.
Changes to commit message attribution or PR title format per repo.

### Acceptance Criteria

[ ] When a workspace has 2+ repos and both require changes, the agent modifies files in all relevant repo worktrees during the single implement pass.
[ ] The Commit phase detects changes in all repos (it already iterates ws.Repos) and commits each changed repo independently.
[ ] The PR phase creates one PR per changed repo.
[ ] If a repo requires no changes, the implement pass leaves it untouched and the Commit phase skips it with a log line (no changes in repo X — skipping commit), which already exists.
[ ] If the agent only modifies repo[0] but the ticket description implies repo[1] also needed changes, the Commit phase must not silently succeed — this is acceptable behavior for now (no enforcement added), but must be documented in a code comment.
[ ] The implement prompt (buildImplementPrompt) explicitly instructs the agent to make changes in all listed repos using their absolute paths, not just the working directory.
[ ] All existing orchestrator tests pass.
[ ] A test is added for the multi-repo implement prompt: verify that when ws.Repos has 2 entries, the prompt contains both repo paths and an explicit cross-repo instruction.

Implementation Notes
Only buildImplementPrompt needs to change: add an explicit instruction such as "You are responsible for making changes across ALL repos listed in the Workspace section. Use their absolute paths. Do not limit your edits to your working directory."
No changes needed to ProcessTicket orchestration logic.
No changes needed to Commit or PR phases — they already iterate all repos.
Backward compatible: single-repo workspaces are unaffected.

Out of Scope
Fan-out orchestration (running a separate agent per repo) — not chosen.
Fail-fast enforcement when the agent misses a repo — deferred to a follow-up ticket.
Changes to commit message attribution or PR title format per repo.

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
