### PR TITLE
fix(jira): ignore done blockers in dependency graph

### DIFF
--- a/internal/jira/dependencies.go
+++ b/internal/jira/dependencies.go
@@ -36,8 +36,11 @@ func BuildDependencyGraph(tickets []Ticket) *DependencyGraph {
 			if link.Direction == "outward" && link.OutwardKey != "" {
 				g.addEdge(t.Key, link.OutwardKey)
 			}
-			// Direction "inward": InwardKey blocks t.Key
+			// Direction "inward": InwardKey blocks t.Key — skip if the blocker is already done.
 			if link.Direction == "inward" && link.InwardKey != "" {
+				if link.BlockerStatusCategory == "done" {
+					continue
+				}
 				g.addEdge(link.InwardKey, t.Key)
 			}
 		}

--- a/internal/jira/dependencies_test.go
+++ b/internal/jira/dependencies_test.go
@@ -134,3 +134,25 @@ func TestBuildDependencyGraph_ExternalBlocker(t *testing.T) {
 	}
 	t.Error("expected A-2 to be ready")
 }
+
+func TestBuildDependencyGraph_DoneBlockerIgnored(t *testing.T) {
+	// A-1 is blocked by DONE-99 which has statusCategory="done" — should be treated as resolved.
+	tickets := []Ticket{
+		makeTicket("A-1", []IssueLink{{
+			Type:                 "Blocks",
+			InwardKey:            "DONE-99",
+			OutwardKey:           "A-1",
+			Direction:            "inward",
+			BlockerStatusCategory: "done",
+		}}),
+		makeTicket("A-2", nil),
+	}
+	g := BuildDependencyGraph(tickets)
+	ready, blocked := g.ResolveOrder()
+	if len(blocked) != 0 {
+		t.Fatalf("expected no blocked tickets, got %v", blocked)
+	}
+	if len(ready) != 2 {
+		t.Fatalf("expected both tickets ready, got %d ready", len(ready))
+	}
+}

--- a/internal/jira/tickets.go
+++ b/internal/jira/tickets.go
@@ -38,10 +38,11 @@ type Comment struct {
 
 // IssueLink represents a link between two Jira issues.
 type IssueLink struct {
-	Type       string // e.g. "Blocks"
-	InwardKey  string // the issue that blocks (inward side)
-	OutwardKey string // the issue that is being blocked (outward side)
-	Direction  string // "inward" or "outward" relative to this ticket
+	Type                 string // e.g. "Blocks"
+	InwardKey            string // the issue that blocks (inward side)
+	OutwardKey           string // the issue that is being blocked (outward side)
+	Direction            string // "inward" or "outward" relative to this ticket
+	BlockerStatusCategory string // status category key of the blocking issue (e.g. "done")
 }
 
 const searchPageSize = 50
@@ -232,6 +233,11 @@ func issueLinkToLink(selfKey string, link *model.IssueLinkScheme) IssueLink {
 	}
 	if link.InwardIssue != nil {
 		il.InwardKey = link.InwardIssue.Key
+		if f := link.InwardIssue.Fields; f != nil {
+			if s := f.Status; s != nil && s.StatusCategory != nil {
+				il.BlockerStatusCategory = s.StatusCategory.Key
+			}
+		}
 	}
 	if link.OutwardIssue != nil {
 		il.OutwardKey = link.OutwardIssue.Key


### PR DESCRIPTION
## Problem

Tickets blocked by a "done" issue (e.g. VC-49 blocked by VC-41) incorrectly showed as `⊘ blocked` in `nightshift jira preview` and were skipped during `nightshift jira run`.

**Root cause:** `BuildDependencyGraph` treats any blocker not in the fetched ticket set as an "external blocker". Since only TODO/in-progress tickets are fetched, a _done_ ticket like VC-41 is never in the set — so it always triggers a block, even though the dependency is resolved.

## Fix

1. `IssueLink` gains a `BlockerStatusCategory` field populated from `LinkedIssueScheme.Fields.Status.StatusCategory.Key` in the Jira API response.
2. `BuildDependencyGraph` skips `addEdge` when `BlockerStatusCategory == "done"`.
3. Test: `TestBuildDependencyGraph_DoneBlockerIgnored` covers this case.