### PR TITLE
[VC-49] Fix: PR creation skipped when resuming jira run at PhaseCommit with no uncommitted changes

### DIFF
--- a/internal/jira/branch.go
+++ b/internal/jira/branch.go
@@ -89,6 +89,23 @@ func setupBranch(ctx context.Context, repoPath, branchName, baseBranch string) (
 	return true, nil
 }
 
+// BranchAheadOfBase reports whether branch has commits ahead of origin/base on the remote.
+// Returns (false, nil) when the remote ref for branch does not exist (branch not yet pushed)
+// or when there are no commits ahead. Only returns an error for unexpected git failures.
+func BranchAheadOfBase(ctx context.Context, repoPath, branch, base string) (bool, error) {
+	out, err := gitExec(ctx, repoPath, "log", "origin/"+base+"..origin/"+branch, "--oneline")
+	if err != nil {
+		msg := err.Error()
+		// Treat a missing remote ref as "not ahead" rather than an error.
+		if strings.Contains(msg, "unknown revision") || strings.Contains(msg, "bad revision") ||
+			strings.Contains(msg, "ambiguous argument") {
+			return false, nil
+		}
+		return false, err
+	}
+	return len(out) > 0, nil
+}
+
 // gitExec runs a git command in repoPath and returns trimmed combined output.
 func gitExec(ctx context.Context, repoPath string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)

--- a/internal/jira/branch.go
+++ b/internal/jira/branch.go
@@ -2,8 +2,10 @@ package jira
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -91,19 +93,49 @@ func setupBranch(ctx context.Context, repoPath, branchName, baseBranch string) (
 
 // BranchAheadOfBase reports whether branch has commits ahead of origin/base on the remote.
 // Returns (false, nil) when the remote ref for branch does not exist (branch not yet pushed)
-// or when there are no commits ahead. Only returns an error for unexpected git failures.
+// or when there are no commits ahead. Returns an error for missing base refs or unexpected
+// git failures.
 func BranchAheadOfBase(ctx context.Context, repoPath, branch, base string) (bool, error) {
-	out, err := gitExec(ctx, repoPath, "log", "origin/"+base+"..origin/"+branch, "--oneline")
+	branchRef := "refs/remotes/origin/" + branch
+	baseRef := "refs/remotes/origin/" + base
+
+	branchExists, err := remoteRefExists(ctx, repoPath, branchRef)
 	if err != nil {
-		msg := err.Error()
-		// Treat a missing remote ref as "not ahead" rather than an error.
-		if strings.Contains(msg, "unknown revision") || strings.Contains(msg, "bad revision") ||
-			strings.Contains(msg, "ambiguous argument") {
+		return false, err
+	}
+	if !branchExists {
+		return false, nil
+	}
+
+	baseExists, err := remoteRefExists(ctx, repoPath, baseRef)
+	if err != nil {
+		return false, err
+	}
+	if !baseExists {
+		return false, fmt.Errorf("git remote ref %s not found", baseRef)
+	}
+
+	out, err := gitExec(ctx, repoPath, "rev-list", "--count", baseRef+".."+branchRef)
+	if err != nil {
+		return false, err
+	}
+	count, err := strconv.Atoi(out)
+	if err != nil {
+		return false, fmt.Errorf("parse git rev-list count %q: %w", out, err)
+	}
+	return count > 0, nil
+}
+
+func remoteRefExists(ctx context.Context, repoPath, ref string) (bool, error) {
+	_, err := gitExec(ctx, repoPath, "rev-parse", "--verify", "--quiet", ref)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 			return false, nil
 		}
 		return false, err
 	}
-	return len(out) > 0, nil
+	return true, nil
 }
 
 // gitExec runs a git command in repoPath and returns trimmed combined output.

--- a/internal/jira/branch_test.go
+++ b/internal/jira/branch_test.go
@@ -1,6 +1,11 @@
 package jira
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -57,5 +62,99 @@ func TestPRTitleConventional(t *testing.T) {
 			t.Errorf("PRTitle(%q, %q, %q) = %q, want %q",
 				tt.ticketKey, tt.scope, tt.description, got, tt.want)
 		}
+	}
+}
+
+func TestBranchAheadOfBase(t *testing.T) {
+	t.Run("missing remote branch is not ahead", func(t *testing.T) {
+		workDir := setupRemoteRepoWithMain(t)
+
+		ahead, err := BranchAheadOfBase(context.Background(), workDir, "feature/VC-49", "main")
+		if err != nil {
+			t.Fatalf("BranchAheadOfBase returned error: %v", err)
+		}
+		if ahead {
+			t.Fatal("BranchAheadOfBase returned true for a missing remote branch")
+		}
+	})
+
+	t.Run("pushed branch ahead of base", func(t *testing.T) {
+		workDir := setupRemoteRepoWithMain(t)
+		runGit(t, workDir, "checkout", "-b", "feature/VC-49")
+		writeFile(t, workDir, "feature.txt", "feature commit\n")
+		runGit(t, workDir, "add", "feature.txt")
+		runGit(t, workDir, "commit", "-m", "feature commit")
+		runGit(t, workDir, "push", "-u", "origin", "feature/VC-49")
+
+		ahead, err := BranchAheadOfBase(context.Background(), workDir, "feature/VC-49", "main")
+		if err != nil {
+			t.Fatalf("BranchAheadOfBase returned error: %v", err)
+		}
+		if !ahead {
+			t.Fatal("BranchAheadOfBase returned false for a pushed branch ahead of base")
+		}
+	})
+}
+
+func TestBranchAheadOfBase_MissingBaseRefErrors(t *testing.T) {
+	remoteDir := t.TempDir()
+	runGit(t, remoteDir, "init", "--bare")
+
+	workDir := t.TempDir()
+	runGit(t, workDir, "init")
+	runGit(t, workDir, "config", "user.email", "test@example.com")
+	runGit(t, workDir, "config", "user.name", "Test User")
+	runGit(t, workDir, "remote", "add", "origin", remoteDir)
+	runGit(t, workDir, "checkout", "-b", "feature/VC-49")
+	writeFile(t, workDir, "feature.txt", "feature commit\n")
+	runGit(t, workDir, "add", "feature.txt")
+	runGit(t, workDir, "commit", "-m", "feature commit")
+	runGit(t, workDir, "push", "-u", "origin", "feature/VC-49")
+
+	ahead, err := BranchAheadOfBase(context.Background(), workDir, "feature/VC-49", "main")
+	if err == nil {
+		t.Fatal("BranchAheadOfBase returned nil error for a missing base ref")
+	}
+	if ahead {
+		t.Fatal("BranchAheadOfBase returned true when the base ref was missing")
+	}
+}
+
+func setupRemoteRepoWithMain(t *testing.T) string {
+	t.Helper()
+
+	remoteDir := t.TempDir()
+	runGit(t, remoteDir, "init", "--bare")
+
+	workDir := t.TempDir()
+	runGit(t, workDir, "init")
+	runGit(t, workDir, "config", "user.email", "test@example.com")
+	runGit(t, workDir, "config", "user.name", "Test User")
+	runGit(t, workDir, "remote", "add", "origin", remoteDir)
+	runGit(t, workDir, "checkout", "-b", "main")
+	writeFile(t, workDir, "README.md", "base commit\n")
+	runGit(t, workDir, "add", "README.md")
+	runGit(t, workDir, "commit", "-m", "base commit")
+	runGit(t, workDir, "push", "-u", "origin", "main")
+
+	return workDir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+}
+
+func writeFile(t *testing.T, dir, name, contents string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o644); err != nil {
+		t.Fatalf("write file %s: %v", name, err)
 	}
 }

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -444,10 +444,12 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 		for _, repo := range skippedRepos {
 			ahead, err := o.fnBranchAheadOfBase(ctx, repo.Path, repo.Branch, repo.BaseBranch)
 			if err != nil {
-				// Non-fatal: log and skip PR recovery for this repo rather than failing
-				// the ticket. This covers cases such as the remote branch not existing yet.
-				o.log.Errorf("ticket %s: branch-ahead check for %s: %v (skipping PR recovery)", ticket.Key, repo.Name, err)
-				continue
+				o.postErrorComment(ctx, ticket.Key, PhaseCommit, err)
+				result.Status = TicketFailed
+				result.Error = err.Error()
+				result.Duration = time.Since(start)
+				o.log.Errorf("ticket %s: branch-ahead check for %s: %v", ticket.Key, repo.Name, err)
+				return result, nil
 			}
 			if ahead {
 				o.emit("  branch %s already pushed — recovering PR creation", repo.Branch)

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -67,12 +67,13 @@ type Orchestrator struct {
 	log             *logging.Logger
 
 	// ops are injectable for testing; set to real functions by NewOrchestrator.
-	fnHasChanges    func(ctx context.Context, repoPath string) (bool, error)
-	fnCommitAndPush func(ctx context.Context, repoPath, message string) error
-	fnCreatePR      func(ctx context.Context, repo RepoWorkspace, ticket Ticket, jiraSite string) (*PRInfo, error)
-	fnFindPR        func(ctx context.Context, repoPath, branch string) (*PRInfo, error)
-	fnFetchReviews  func(ctx context.Context, repoPath, prURL string) (*PRReviewState, error)
-	fnPostPRComment func(ctx context.Context, repoPath, prURL, body string) error
+	fnHasChanges        func(ctx context.Context, repoPath string) (bool, error)
+	fnCommitAndPush     func(ctx context.Context, repoPath, message string) error
+	fnCreatePR          func(ctx context.Context, repo RepoWorkspace, ticket Ticket, jiraSite string) (*PRInfo, error)
+	fnFindPR            func(ctx context.Context, repoPath, branch string) (*PRInfo, error)
+	fnFetchReviews      func(ctx context.Context, repoPath, prURL string) (*PRReviewState, error)
+	fnPostPRComment     func(ctx context.Context, repoPath, prURL, body string) error
+	fnBranchAheadOfBase func(ctx context.Context, repoPath, branch, base string) (bool, error)
 }
 
 // OrchestratorOption configures an Orchestrator.
@@ -129,6 +130,7 @@ func NewOrchestrator(client *Client, cfg JiraConfig, opts ...OrchestratorOption)
 			_, err := ghExec(ctx, repoPath, "pr", "comment", prURL, "--body", body)
 			return err
 		},
+		fnBranchAheadOfBase: BranchAheadOfBase,
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -251,6 +253,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			_, err := ghExec(ctx, repoPath, "pr", "comment", prURL, "--body", body)
 			return err
 		}
+	}
+	if o.fnBranchAheadOfBase == nil {
+		o.fnBranchAheadOfBase = BranchAheadOfBase
 	}
 
 	start := time.Now()
@@ -398,6 +403,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 		result.Phase = PhaseCommit
 		o.notifyPhase(ticket.Key, PhaseCommit, false)
 		var changedRepos []RepoWorkspace
+		var skippedRepos []RepoWorkspace // repos with no uncommitted changes
 		if ws != nil {
 			for _, repo := range ws.Repos {
 				changed, err := o.fnHasChanges(ctx, repo.Path)
@@ -414,6 +420,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 					// changes in this repo too, we silently skip it here. Enforcement
 					// (fail-fast when expected repos are untouched) is deferred to a
 					// follow-up ticket.
+					skippedRepos = append(skippedRepos, repo)
 					continue
 				}
 				msg := CommitMessage(ticket.Key, "", ticket.Summary)
@@ -429,6 +436,25 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			}
 		}
 
+		// Recovery pass: a repo with no uncommitted changes may have been committed and pushed
+		// in a prior run that crashed before the CommentPR was posted. If the branch is ahead
+		// of its base on the remote, treat it as if it was committed in this run so the PR
+		// creation loop can create or recover the PR.
+		var recoveredRepos []RepoWorkspace
+		for _, repo := range skippedRepos {
+			ahead, err := o.fnBranchAheadOfBase(ctx, repo.Path, repo.Branch, repo.BaseBranch)
+			if err != nil {
+				// Non-fatal: log and skip PR recovery for this repo rather than failing
+				// the ticket. This covers cases such as the remote branch not existing yet.
+				o.log.Errorf("ticket %s: branch-ahead check for %s: %v (skipping PR recovery)", ticket.Key, repo.Name, err)
+				continue
+			}
+			if ahead {
+				o.emit("  branch %s already pushed — recovering PR creation", repo.Branch)
+				recoveredRepos = append(recoveredRepos, repo)
+			}
+		}
+
 		// Phase 5: PR
 		result.Phase = PhasePR
 		o.notifyPhase(ticket.Key, PhasePR, false)
@@ -438,6 +464,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			url  string
 		}
 		var repoPRs []repoPR
+
+		// Repos committed in this run: create or update the PR via fnCreatePR (which
+		// already handles deduplication internally via findExistingPR).
 		for _, repo := range changedRepos {
 			o.emit("  creating PR for %s (%s → %s)", repo.Name, repo.Branch, repo.BaseBranch)
 			prInfo, err := o.fnCreatePR(ctx, repo, ticket, o.cfg.Site)
@@ -452,6 +481,37 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			result.PRURLs = append(result.PRURLs, prInfo.URL)
 			repoPRs = append(repoPRs, repoPR{repo: repo, url: prInfo.URL})
 		}
+
+		// Recovered repos: check for an existing open PR first to avoid duplicates.
+		for _, repo := range recoveredRepos {
+			existing, err := o.fnFindPR(ctx, repo.Path, repo.Branch)
+			if err != nil {
+				o.postErrorComment(ctx, ticket.Key, PhasePR, err)
+				result.Status = TicketFailed
+				result.Error = err.Error()
+				result.Duration = time.Since(start)
+				return result, nil
+			}
+			if existing != nil {
+				o.emit("  PR already exists for %s: %s", repo.Name, existing.URL)
+				result.PRURLs = append(result.PRURLs, existing.URL)
+				repoPRs = append(repoPRs, repoPR{repo: repo, url: existing.URL})
+			} else {
+				o.emit("  creating PR for %s (%s → %s)", repo.Name, repo.Branch, repo.BaseBranch)
+				prInfo, err := o.fnCreatePR(ctx, repo, ticket, o.cfg.Site)
+				if err != nil {
+					o.postErrorComment(ctx, ticket.Key, PhasePR, err)
+					result.Status = TicketFailed
+					result.Error = err.Error()
+					result.Duration = time.Since(start)
+					return result, nil
+				}
+				o.emit("  ✓ PR created: %s", prInfo.URL)
+				result.PRURLs = append(result.PRURLs, prInfo.URL)
+				repoPRs = append(repoPRs, repoPR{repo: repo, url: prInfo.URL})
+			}
+		}
+
 		if len(result.PRURLs) > 0 {
 			o.emit("📝 posting PR links to Jira %s", ticket.Key)
 			o.postPhaseComment(ctx, ticket.Key, CommentPR,

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -660,6 +660,7 @@ func TestProcessTicket_CommitPhase_NoChanges(t *testing.T) {
 	sc := &stubJiraClient{}
 	o, ws := makeOrchestratorWithRepo(sc)
 	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
+	o.fnBranchAheadOfBase = func(_ context.Context, _, _, _ string) (bool, error) { return false, nil }
 	o.fnCommitAndPush = func(_ context.Context, _, _ string) error { t.Error("CommitAndPush called unexpectedly"); return nil }
 	o.fnCreatePR = func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
 		t.Error("CreateOrUpdatePR called unexpectedly")
@@ -768,6 +769,159 @@ func TestProcessTicket_PRPhase_Success(t *testing.T) {
 	}
 	if !hasPRComment {
 		t.Error("expected PR comment to be posted")
+	}
+}
+
+// ── PhaseCommit resume tests ──────────────────────────────────────────────────
+
+// makeResumeAtCommitOrchestrator builds a minimal Orchestrator and Workspace configured
+// to resume at PhaseCommit (ticket already has CommentImplement). The caller should set
+// fnHasChanges, fnBranchAheadOfBase, fnFindPR, and fnCreatePR as needed.
+func makeResumeAtCommitOrchestrator(sc jiraClient) (*Orchestrator, *Workspace, Ticket) {
+	ticket := Ticket{
+		Key:     "RC-1",
+		Summary: "Resume commit test",
+		Comments: []Comment{
+			nightshiftComment(CommentValidation, "Ticket validated (score 8/10)."),
+			nightshiftComment(CommentPlan, "Step 1: do the thing."),
+			nightshiftComment(CommentImplement, "Implementation complete."),
+		},
+	}
+	ws := &Workspace{
+		TicketKey: "RC-1",
+		Repos:     []RepoWorkspace{{Name: "repo", Path: "/fake/repo", Branch: "feature/RC-1", BaseBranch: "main"}},
+	}
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		implAgent:       &stubAgent{name: "impl", output: "impl output"},
+		validationAgent: &stubAgent{name: "va", output: `{"valid": true, "score": 8}`},
+		fnPostPRComment: func(_ context.Context, _, _, _ string) error { return nil },
+		fnFetchReviews:  func(_ context.Context, _, _ string) (*PRReviewState, error) { return nil, nil },
+	}
+	return o, ws, ticket
+}
+
+// TestProcessTicket_ResumeAtPhaseCommit_BranchAhead_PRCreated verifies that when resuming
+// at PhaseCommit with no uncommitted changes but a branch already ahead of base on the remote,
+// a new PR is created and the CommentPR is posted to Jira.
+func TestProcessTicket_ResumeAtPhaseCommit_BranchAhead_PRCreated(t *testing.T) {
+	sc := &stubJiraClient{}
+	o, ws, ticket := makeResumeAtCommitOrchestrator(sc)
+
+	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
+	o.fnBranchAheadOfBase = func(_ context.Context, _, _, _ string) (bool, error) { return true, nil }
+	o.fnFindPR = func(_ context.Context, _, _ string) (*PRInfo, error) { return nil, nil }
+	createPRCalls := 0
+	o.fnCreatePR = func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+		createPRCalls++
+		return &PRInfo{URL: "https://github.com/org/repo/pull/42", Number: 42, IsNew: true}, nil
+	}
+	o.fnCommitAndPush = func(_ context.Context, _, _ string) error {
+		t.Error("CommitAndPush should not be called when HasChanges=false")
+		return nil
+	}
+
+	result, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != TicketCompleted {
+		t.Errorf("Status = %q, want %q", result.Status, TicketCompleted)
+	}
+	if len(result.PRURLs) != 1 || result.PRURLs[0] != "https://github.com/org/repo/pull/42" {
+		t.Errorf("PRURLs = %v, want one URL", result.PRURLs)
+	}
+	if createPRCalls != 1 {
+		t.Errorf("fnCreatePR called %d times, want 1", createPRCalls)
+	}
+	hasPRComment := false
+	for _, c := range sc.postCommentCalls {
+		if c.Type == CommentPR {
+			hasPRComment = true
+		}
+	}
+	if !hasPRComment {
+		t.Error("expected CommentPR to be posted to Jira")
+	}
+}
+
+// TestProcessTicket_ResumeAtPhaseCommit_BranchAhead_ExistingPR verifies that when an open PR
+// already exists for the branch, its URL is recorded without calling fnCreatePR.
+func TestProcessTicket_ResumeAtPhaseCommit_BranchAhead_ExistingPR(t *testing.T) {
+	sc := &stubJiraClient{}
+	o, ws, ticket := makeResumeAtCommitOrchestrator(sc)
+
+	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
+	o.fnBranchAheadOfBase = func(_ context.Context, _, _, _ string) (bool, error) { return true, nil }
+	o.fnFindPR = func(_ context.Context, _, _ string) (*PRInfo, error) {
+		return &PRInfo{URL: "https://github.com/org/repo/pull/42", Number: 42}, nil
+	}
+	o.fnCreatePR = func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+		t.Error("fnCreatePR must not be called when open PR already exists")
+		return nil, nil
+	}
+	o.fnCommitAndPush = func(_ context.Context, _, _ string) error {
+		t.Error("CommitAndPush should not be called when HasChanges=false")
+		return nil
+	}
+
+	result, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != TicketCompleted {
+		t.Errorf("Status = %q, want %q", result.Status, TicketCompleted)
+	}
+	if len(result.PRURLs) != 1 || result.PRURLs[0] != "https://github.com/org/repo/pull/42" {
+		t.Errorf("PRURLs = %v, want existing PR URL", result.PRURLs)
+	}
+	hasPRComment := false
+	for _, c := range sc.postCommentCalls {
+		if c.Type == CommentPR {
+			hasPRComment = true
+		}
+	}
+	if !hasPRComment {
+		t.Error("expected CommentPR to be posted to Jira")
+	}
+}
+
+// TestProcessTicket_ResumeAtPhaseCommit_BranchNotAhead_NoPR verifies the genuine no-op case:
+// when HasChanges=false and the branch is not ahead of base, no PR is created.
+func TestProcessTicket_ResumeAtPhaseCommit_BranchNotAhead_NoPR(t *testing.T) {
+	sc := &stubJiraClient{}
+	o, ws, ticket := makeResumeAtCommitOrchestrator(sc)
+
+	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
+	o.fnBranchAheadOfBase = func(_ context.Context, _, _, _ string) (bool, error) { return false, nil }
+	o.fnFindPR = func(_ context.Context, _, _ string) (*PRInfo, error) {
+		t.Error("fnFindPR must not be called when branch is not ahead")
+		return nil, nil
+	}
+	o.fnCreatePR = func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+		t.Error("fnCreatePR must not be called when branch is not ahead")
+		return nil, nil
+	}
+	o.fnCommitAndPush = func(_ context.Context, _, _ string) error {
+		t.Error("CommitAndPush should not be called when HasChanges=false")
+		return nil
+	}
+
+	result, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != TicketCompleted {
+		t.Errorf("Status = %q, want %q", result.Status, TicketCompleted)
+	}
+	if len(result.PRURLs) != 0 {
+		t.Errorf("PRURLs = %v, want empty (genuine no-op)", result.PRURLs)
+	}
+	for _, c := range sc.postCommentCalls {
+		if c.Type == CommentPR {
+			t.Error("CommentPR should not be posted when no PRs were created")
+		}
 	}
 }
 

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -698,6 +698,39 @@ func TestProcessTicket_CommitPhase_HasChangesError(t *testing.T) {
 	}
 }
 
+func TestProcessTicket_CommitPhase_BranchAheadError(t *testing.T) {
+	sc := &stubJiraClient{}
+	o, ws := makeOrchestratorWithRepo(sc)
+	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
+	o.fnBranchAheadOfBase = func(_ context.Context, _, _, _ string) (bool, error) {
+		return false, errors.New("git branch-ahead check failed")
+	}
+	o.fnCommitAndPush = func(_ context.Context, _, _ string) error {
+		t.Error("CommitAndPush should not be called when HasChanges=false")
+		return nil
+	}
+
+	result, err := o.ProcessTicket(context.Background(), Ticket{Key: "T-1", Summary: "Test"}, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != TicketFailed {
+		t.Errorf("Status = %q, want %q", result.Status, TicketFailed)
+	}
+	if result.Phase != PhaseCommit {
+		t.Errorf("Phase = %q, want %q", result.Phase, PhaseCommit)
+	}
+	hasErrorComment := false
+	for _, c := range sc.postCommentCalls {
+		if c.Type == CommentError {
+			hasErrorComment = true
+		}
+	}
+	if !hasErrorComment {
+		t.Error("expected error comment to be posted")
+	}
+}
+
 func TestProcessTicket_CommitPhase_CommitAndPushError(t *testing.T) {
 	sc := &stubJiraClient{}
 	o, ws := makeOrchestratorWithRepo(sc)


### PR DESCRIPTION
## VC-49 — Fix: PR creation skipped when resuming jira run at PhaseCommit with no uncommitted changes

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-49

### Description

Problem
When the orchestrator crashes in the narrow window after fnCommitAndPush succeeds (branch pushed to origin) but before the CommentPR comment is posted to Jira, the ticket gets stuck: on the next run, PR creation is silently skipped and the ticket transitions to review with no PR.
Root Cause
detectResumeState sees hasImpl=true / hasPR=false → returns startPhase=PhaseCommit.
Inside the PhaseCommit block (orchestrator.go ~line 385):
HasChanges returns false (working tree is clean — commit already happened)
changedRepos stays empty
The PR creation loop iterates changedRepos (empty) → no PR is created, no CommentPR posted
Execution falls through to PhaseStatus → ticket transitions to "Revue en cours" with no PR
Fix Approach
In the PhaseCommit block, after the HasChanges + CommitAndPush loop, scan repos where HasChanges returned false. For each such repo, check whether the feature branch has commits ahead of its base branch (git log origin/<base>..<branch> --oneline). If commits exist, the branch was already pushed in a prior run and still needs a PR — append those repos to changedRepos so the PR creation loop handles them.
Use fnFindPR to avoid creating a duplicate if an open PR already exists for that branch — if one is found, record its URL directly without calling fnCreatePR.
Files
internal/jira/orchestrator.go — PhaseCommit block in ProcessTicket
internal/jira/branch.go — add BranchAheadOfBase(ctx, repoPath, branch, base string) (bool, error) helper using git log
internal/jira/orchestrator_test.go — two new tests:
resume at PhaseCommit, HasChanges=false, branch ahead of base → PR created
resume at PhaseCommit, HasChanges=false, branch ahead, open PR exists → URL recorded without duplicate creation
Acceptance Criteria
Resuming at PhaseCommit with no uncommitted changes but an already-pushed branch creates/updates the PR correctly
If an open PR already exists for the branch, its URL is recorded without creating a duplicate
If the branch has no commits ahead of base, no PR is created (genuine no-op)
Unit tests cover all three paths above
go test ./internal/jira/... passes

### Acceptance Criteria

Resuming at PhaseCommit with no uncommitted changes but an already-pushed branch creates/updates the PR correctly
If an open PR already exists for the branch, its URL is recorded without creating a duplicate
If the branch has no commits ahead of base, no PR is created (genuine no-op)
Unit tests cover all three paths above
go test ./internal/jira/... passes

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
