### PR TITLE
[VC-51] fetchReviewThreads error silently swallowed — inline review comments lost without any log

### DIFF
--- a/internal/jira/pr.go
+++ b/internal/jira/pr.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/marcus/nightshift/internal/logging"
 )
 
 // PRInfo describes a GitHub pull request created or updated for a Jira ticket.
@@ -171,8 +173,7 @@ func FetchPRReviewComments(ctx context.Context, repoPath, prURL string) (*PRRevi
 	// Fetch inline review thread comments with isResolved via GraphQL.
 	inline, err := fetchReviewThreads(ctx, repoPath, rs.Number)
 	if err != nil {
-		// Non-fatal: log and continue without inline thread data.
-		rs.Comments = append(rs.Comments, inline...)
+		logging.Get().Warnf("jira: pr: fetch review threads: %v", err)
 	} else {
 		rs.Comments = append(rs.Comments, inline...)
 	}

--- a/internal/jira/pr.go
+++ b/internal/jira/pr.go
@@ -173,8 +173,9 @@ func FetchPRReviewComments(ctx context.Context, repoPath, prURL string) (*PRRevi
 	// Fetch inline review thread comments with isResolved via GraphQL.
 	inline, err := fetchReviewThreads(ctx, repoPath, rs.Number)
 	if err != nil {
-		logging.Get().Warnf("jira: pr: fetch review threads: %v", err)
-	} else {
+		logging.Get().Warnf("jira: pr: fetch review threads for PR #%d (%s) in repo %s: %v", rs.Number, prURL, repoPath, err)
+	}
+	if err == nil {
 		rs.Comments = append(rs.Comments, inline...)
 	}
 	return rs, nil

--- a/internal/jira/pr_test.go
+++ b/internal/jira/pr_test.go
@@ -1,8 +1,11 @@
 package jira
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -378,9 +381,27 @@ func TestFetchPRReviewComments_ReviewThreadsError(t *testing.T) {
 		return "", fmt.Errorf("graphql unavailable")
 	}
 
-	rs, err := FetchPRReviewComments(context.Background(), "/repo", "https://github.com/org/repo/pull/7")
+	// Capture stderr so we can assert the warning is logged.
+	// logging.Get() with no global logger creates a default logger writing to os.Stderr.
+	r, w, err := os.Pipe()
 	if err != nil {
-		t.Fatalf("FetchPRReviewComments should not return error on graphql failure, got: %v", err)
+		t.Fatal(err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+
+	rs, fetchErr := FetchPRReviewComments(context.Background(), "/repo", "https://github.com/org/repo/pull/7")
+
+	w.Close()
+	os.Stderr = origStderr
+	var logBuf bytes.Buffer
+	if _, err := io.Copy(&logBuf, r); err != nil {
+		t.Fatal(err)
+	}
+	r.Close()
+
+	if fetchErr != nil {
+		t.Fatalf("FetchPRReviewComments should not return error on graphql failure, got: %v", fetchErr)
 	}
 	// The top-level comment from pr view should still be present.
 	if len(rs.Comments) != 1 {
@@ -388,5 +409,13 @@ func TestFetchPRReviewComments_ReviewThreadsError(t *testing.T) {
 	}
 	if rs.Comments[0].Author != "alice" {
 		t.Errorf("Comments[0].Author = %q, want alice", rs.Comments[0].Author)
+	}
+	// Verify a warning was emitted with the error and PR identity.
+	logOutput := logBuf.String()
+	if !strings.Contains(logOutput, "graphql unavailable") {
+		t.Errorf("expected warning log containing error message, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "#7") {
+		t.Errorf("expected warning log containing PR number, got: %s", logOutput)
 	}
 }

--- a/internal/jira/pr_test.go
+++ b/internal/jira/pr_test.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -348,5 +349,44 @@ func TestFindExistingPR_StateOpenFlagPassed(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected --state open in gh pr list args, got: %v", capturedArgs)
+	}
+}
+
+// ── FetchPRReviewComments ─────────────────────────────────────────────────────
+
+func TestFetchPRReviewComments_ReviewThreadsError(t *testing.T) {
+	orig := ghExec
+	defer func() { ghExec = orig }()
+
+	prViewJSON := `{
+		"url": "https://github.com/org/repo/pull/7",
+		"state": "OPEN",
+		"reviewDecision": "",
+		"number": 7,
+		"reviews": [],
+		"comments": [
+			{"author": {"login": "alice"}, "body": "top-level comment", "createdAt": "2026-04-07T10:00:00Z"}
+		]
+	}`
+
+	call := 0
+	ghExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		call++
+		if call == 1 {
+			return prViewJSON, nil
+		}
+		return "", fmt.Errorf("graphql unavailable")
+	}
+
+	rs, err := FetchPRReviewComments(context.Background(), "/repo", "https://github.com/org/repo/pull/7")
+	if err != nil {
+		t.Fatalf("FetchPRReviewComments should not return error on graphql failure, got: %v", err)
+	}
+	// The top-level comment from pr view should still be present.
+	if len(rs.Comments) != 1 {
+		t.Errorf("len(Comments) = %d, want 1 (inline threads must not be appended on error)", len(rs.Comments))
+	}
+	if rs.Comments[0].Author != "alice" {
+		t.Errorf("Comments[0].Author = %q, want alice", rs.Comments[0].Author)
 	}
 }


### PR DESCRIPTION
## VC-51 — fetchReviewThreads error silently swallowed — inline review comments lost without any log

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-51

### Description

Problem
FetchPRReviewComments in internal/jira/pr.go (lines 172–178) calls fetchReviewThreads then branches on the error, but both branches do the exact same thing:
inline, err := fetchReviewThreads(ctx, repoPath, rs.Number)
if err != nil {
    // Non-fatal: log and continue without inline thread data.
    rs.Comments = append(rs.Comments, inline...)   // inline is nil on error → no-op
} else {
    rs.Comments = append(rs.Comments, inline...)   // correct path
}
When fetchReviewThreads returns an error, inline is nil (the function returns nil, err). So the error branch is a silent no-op. The comment says "log and continue" but no log call exists — the error disappears completely. The review feedback loop then proceeds as if there are no inline comments, potentially skipping actionable review threads.
Root cause
The if/else branches are identical. The error is neither logged nor surfaced. A failing GraphQL call (network error, old gh CLI version, rate limit) silently degrades the quality of review data fed to the rework agent.
Impact
Inline PR review thread comments (the most precise reviewer feedback) are silently dropped when the GraphQL call fails
The rework agent receives only top-level PR comments, not inline code comments
No log entry is produced, making debugging impossible
Acceptance criteria
When fetchReviewThreads returns an error, a log.Warnf (or similar) is emitted with the error
The code simplifies to if err == nil { rs.Comments = append(...) } — only appending on success
Existing tests pass; a new test covers the error case (comments remain unchanged, warning logged)

### Acceptance Criteria

When fetchReviewThreads returns an error, a log.Warnf (or similar) is emitted with the error
The code simplifies to if err == nil { rs.Comments = append(...) } — only appending on success
Existing tests pass; a new test covers the error case (comments remain unchanged, warning logged)

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
