### PR TITLE
[VC-52] ProcessFeedback: fnCommitAndPush nested inside fnHasChanges nil guard — nil panic if only fnHasChanges is overridden

### DIFF
--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -33,6 +33,8 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 	}
 	if o.fnHasChanges == nil {
 		o.fnHasChanges = HasChanges
+	}
+	if o.fnCommitAndPush == nil {
 		o.fnCommitAndPush = CommitAndPush
 	}
 	if o.fnFindPR == nil {

--- a/internal/jira/feedback_test.go
+++ b/internal/jira/feedback_test.go
@@ -441,3 +441,38 @@ func TestProcessFeedback_FindPRError(t *testing.T) {
 		t.Errorf("error should mention 'find pr', got: %v", err)
 	}
 }
+
+// TestProcessFeedback_OnlyFnHasChangesSet_NoPanic reproduces VC-52: if fnHasChanges is
+// overridden but fnCommitAndPush is left nil, ProcessFeedback must not panic.
+func TestProcessFeedback_OnlyFnHasChangesSet_NoPanic(t *testing.T) {
+	sc := &stubJiraClient{}
+	ra := &stubAgent{name: "fix", output: "done"}
+	o := &Orchestrator{
+		client:         sc,
+		cfg:            JiraConfig{},
+		reviewFixAgent: ra,
+		fnHasChanges: func(_ context.Context, _ string) (bool, error) {
+			return true, nil
+		},
+		// fnCommitAndPush intentionally left nil — this was the panic path before the fix.
+		fnFindPR: func(_ context.Context, _, _ string) (*PRInfo, error) {
+			return &PRInfo{URL: "https://github.com/org/repo/pull/1", Number: 1}, nil
+		},
+		fnFetchReviews: func(_ context.Context, _, _ string) (*PRReviewState, error) {
+			return &PRReviewState{
+				ReviewDecision: "CHANGES_REQUESTED",
+				Reviews:        []Review{{Author: "alice", State: "CHANGES_REQUESTED", Body: "fix it"}},
+			}, nil
+		},
+		fnPostPRComment: func(_ context.Context, _, _, _ string) error { return nil },
+	}
+
+	ws := &Workspace{
+		TicketKey: "X-1",
+		Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp/repo", Branch: "feature/X-1"}},
+	}
+
+	// Must not panic. CommitAndPush will fail because /tmp/repo is not a git repo — that is
+	// acceptable; the test only verifies the nil guard fires before the call site.
+	_, _ = o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, ws)
+}

--- a/internal/jira/feedback_test.go
+++ b/internal/jira/feedback_test.go
@@ -467,12 +467,21 @@ func TestProcessFeedback_OnlyFnHasChangesSet_NoPanic(t *testing.T) {
 		fnPostPRComment: func(_ context.Context, _, _, _ string) error { return nil },
 	}
 
+	repoPath := t.TempDir() // owned temp dir: isolated from real repos on the host
+
 	ws := &Workspace{
 		TicketKey: "X-1",
-		Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp/repo", Branch: "feature/X-1"}},
+		Repos:     []RepoWorkspace{{Name: "repo", Path: repoPath, Branch: "feature/X-1"}},
 	}
 
-	// Must not panic. CommitAndPush will fail because /tmp/repo is not a git repo — that is
-	// acceptable; the test only verifies the nil guard fires before the call site.
-	_, _ = o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, ws)
+	// The nil guard must initialize fnCommitAndPush to CommitAndPush before the call site.
+	// CommitAndPush fails on a non-git dir, so we expect an error that mentions "push fixes",
+	// confirming the commit path was reached (i.e., no nil-pointer panic occurred first).
+	_, err := o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, ws)
+	if err == nil {
+		t.Fatal("expected an error from the commit/push path, got nil")
+	}
+	if !strings.Contains(err.Error(), "push fixes") {
+		t.Errorf("expected error to mention 'push fixes' (commit path reached), got: %v", err)
+	}
 }

--- a/internal/jira/pr_test.go
+++ b/internal/jira/pr_test.go
@@ -392,13 +392,13 @@ func TestFetchPRReviewComments_ReviewThreadsError(t *testing.T) {
 
 	rs, fetchErr := FetchPRReviewComments(context.Background(), "/repo", "https://github.com/org/repo/pull/7")
 
-	w.Close()
+	_ = w.Close()
 	os.Stderr = origStderr
 	var logBuf bytes.Buffer
 	if _, err := io.Copy(&logBuf, r); err != nil {
 		t.Fatal(err)
 	}
-	r.Close()
+	_ = r.Close()
 
 	if fetchErr != nil {
 		t.Fatalf("FetchPRReviewComments should not return error on graphql failure, got: %v", fetchErr)


### PR DESCRIPTION
## VC-52 — ProcessFeedback: fnCommitAndPush nested inside fnHasChanges nil guard — nil panic if only fnHasChanges is overridden

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-52

### Description

Problem
In internal/jira/feedback.go lines 34–36, fnCommitAndPush is initialized inside the fnHasChanges nil guard:
if o.fnHasChanges == nil {
    o.fnHasChanges = HasChanges
    o.fnCommitAndPush = CommitAndPush   // ← only set if fnHasChanges was nil
}
If o.fnHasChanges has already been set (e.g. injected via a test or a future option) but o.fnCommitAndPush has not, the guard is skipped entirely and o.fnCommitAndPush remains nil. When ProcessFeedback later calls it (line ~181), the program panics with a nil pointer dereference.
Root cause
Inconsistency with the initialization pattern used everywhere else. In ProcessTicket (orchestrator.go lines 232–250), each function pointer has its own independent nil guard:
if o.fnHasChanges == nil    { o.fnHasChanges = HasChanges }
if o.fnCommitAndPush == nil { o.fnCommitAndPush = CommitAndPush }
if o.fnCreatePR == nil      { ... }
// etc.
ProcessFeedback should follow the same pattern.
Impact
Any test that sets o.fnHasChanges as a mock but relies on the default fnCommitAndPush will panic
Any future caller that sets only fnHasChanges on the struct will silently get a nil fnCommitAndPush
The bug is latent in production (NewOrchestrator always sets both), but will bite the next person writing a test for ProcessFeedback
Acceptance criteria
fnCommitAndPush in ProcessFeedback has its own independent if o.fnCommitAndPush == nil guard
All other fn fields in ProcessFeedback are audited to ensure they follow the same independent-guard pattern
A test that overrides only fnHasChanges and calls ProcessFeedback does not panic

### Acceptance Criteria

fnCommitAndPush in ProcessFeedback has its own independent if o.fnCommitAndPush == nil guard
All other fn fields in ProcessFeedback are audited to ensure they follow the same independent-guard pattern
A test that overrides only fnHasChanges and calls ProcessFeedback does not panic

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
