### PR TITLE
[VC-53] WithPhaseCallback contract broken — done=true never called, phase-end notifications never fire

### DIFF
--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -308,6 +308,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				result.Error = err.Error()
 				result.Duration = time.Since(start)
 				o.log.Errorf("ticket %s: validation failed: %v", ticket.Key, err)
+				o.notifyPhase(ticket.Key, PhaseValidate, true)
 				return result, nil
 			}
 			if !vr.Valid {
@@ -318,6 +319,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				result.Summary = fmt.Sprintf("rejected: score %d/10", vr.Score)
 				result.Duration = time.Since(start)
 				o.log.Infof("ticket %s rejected (score %d/10)", ticket.Key, vr.Score)
+				o.notifyPhase(ticket.Key, PhaseValidate, true)
 				return result, nil
 			}
 			o.postPhaseComment(ctx, ticket.Key, CommentValidation,
@@ -333,8 +335,10 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			result.Status = TicketFailed
 			result.Error = err.Error()
 			result.Duration = time.Since(start)
+			o.notifyPhase(ticket.Key, PhaseValidate, true)
 			return result, nil
 		}
+		o.notifyPhase(ticket.Key, PhaseValidate, true)
 	}
 
 	// Phase 2: Plan
@@ -354,12 +358,14 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			result.Error = err.Error()
 			result.Duration = time.Since(start)
 			o.log.Errorf("ticket %s: plan failed: %v", ticket.Key, err)
+			o.notifyPhase(ticket.Key, PhasePlan, true)
 			return result, nil
 		}
 		result.Plan = planResult.Output
 		o.emit("📝 posting plan to Jira %s", ticket.Key)
 		o.postPhaseComment(ctx, ticket.Key, CommentPlan, planResult.Output, time.Since(planStart))
 		o.log.Infof("ticket %s: plan complete", ticket.Key)
+		o.notifyPhase(ticket.Key, PhasePlan, true)
 	}
 
 	// Phase 3: Implement
@@ -385,12 +391,14 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			result.Error = err.Error()
 			result.Duration = time.Since(start)
 			o.log.Errorf("ticket %s: implement failed: %v", ticket.Key, err)
+			o.notifyPhase(ticket.Key, PhaseImplement, true)
 			return result, nil
 		}
 		result.ImplementationSummary = implResult.Output
 		o.emit("📝 posting implementation summary to Jira %s", ticket.Key)
 		o.postPhaseComment(ctx, ticket.Key, CommentImplement, implResult.Output, time.Since(implStart))
 		o.log.Infof("ticket %s: implementation complete", ticket.Key)
+		o.notifyPhase(ticket.Key, PhaseImplement, true)
 	}
 
 	// Phase 4: Commit
@@ -406,6 +414,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 					result.Status = TicketFailed
 					result.Error = err.Error()
 					result.Duration = time.Since(start)
+					o.notifyPhase(ticket.Key, PhaseCommit, true)
 					return result, nil
 				}
 				if !changed {
@@ -423,11 +432,13 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 					result.Status = TicketFailed
 					result.Error = err.Error()
 					result.Duration = time.Since(start)
+					o.notifyPhase(ticket.Key, PhaseCommit, true)
 					return result, nil
 				}
 				changedRepos = append(changedRepos, repo)
 			}
 		}
+		o.notifyPhase(ticket.Key, PhaseCommit, true)
 
 		// Phase 5: PR
 		result.Phase = PhasePR
@@ -446,6 +457,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				result.Status = TicketFailed
 				result.Error = err.Error()
 				result.Duration = time.Since(start)
+				o.notifyPhase(ticket.Key, PhasePR, true)
 				return result, nil
 			}
 			o.emit("  ✓ PR created: %s", prInfo.URL)
@@ -468,6 +480,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				}
 			}
 		}
+		o.notifyPhase(ticket.Key, PhasePR, true)
 	} else if skip(PhaseCommit) && !skip(PhaseStatus) {
 		// Resuming at PhaseStatus: scan workspace repos for open PRs and merge with
 		// any URLs recovered from comments, deduplicating to avoid duplicates when
@@ -500,8 +513,10 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			result.Status = TicketFailed
 			result.Error = err.Error()
 			result.Duration = time.Since(start)
+			o.notifyPhase(ticket.Key, PhaseStatus, true)
 			return result, nil
 		}
+		o.notifyPhase(ticket.Key, PhaseStatus, true)
 	}
 
 	result.Status = TicketCompleted

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -1309,9 +1309,8 @@ func TestPhaseCallback_PlanError(t *testing.T) {
 	cb, calls := collectPhaseCalls()
 	sc := &stubJiraClient{}
 	va := &stubAgent{output: `{"valid": true, "score": 8, "issues": [], "missing": [], "suggestions": []}`}
-	callCount := 0
+	// implAgent always errors, so the plan phase fails immediately
 	ia := &stubAgent{name: "impl", err: errors.New("plan failed")}
-	// Override with a function that fails on first call (plan), second call would be impl
 	o := &Orchestrator{
 		client:          sc,
 		cfg:             JiraConfig{},
@@ -1319,7 +1318,6 @@ func TestPhaseCallback_PlanError(t *testing.T) {
 		implAgent:       ia,
 		onPhase:         cb,
 	}
-	_ = callCount
 
 	_, err := o.ProcessTicket(context.Background(), Ticket{Key: "T-CB5"}, &Workspace{})
 	if err != nil {

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -3,6 +3,7 @@ package jira
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -1170,4 +1171,376 @@ func TestValidationCommentMetadataMatchesPhase(t *testing.T) {
 			t.Errorf("comment[%d] metadata = %s/%s, want claude/claude-haiku-4.5", i, c.Provider, c.Model)
 		}
 	}
+}
+
+// ── WithPhaseCallback contract tests ──────────────────────────────────────────
+
+type phaseCall struct {
+	phase Phase
+	done  bool
+}
+
+func collectPhaseCalls() (func(string, Phase, bool), *[]phaseCall) {
+	var calls []phaseCall
+	return func(_ string, p Phase, d bool) {
+		calls = append(calls, phaseCall{p, d})
+	}, &calls
+}
+
+func assertPhaseCallPairs(t *testing.T, got []phaseCall, wantPhases []Phase) {
+	t.Helper()
+	var want []phaseCall
+	for _, p := range wantPhases {
+		want = append(want, phaseCall{p, false}, phaseCall{p, true})
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("phase callbacks\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func newPhaseCallbackOrchestrator(cb func(string, Phase, bool)) *Orchestrator {
+	sc := &stubJiraClient{}
+	va := &stubAgent{
+		name:   "validator",
+		output: `{"valid": true, "score": 8, "issues": [], "missing": [], "suggestions": []}`,
+	}
+	ia := &stubAgent{name: "impl", output: "output"}
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		validationAgent: va,
+		implAgent:       ia,
+		onPhase:         cb,
+	}
+	return o
+}
+
+func TestPhaseCallback_HappyPath(t *testing.T) {
+	cb, calls := collectPhaseCalls()
+	o := newPhaseCallbackOrchestrator(cb)
+	ticket := Ticket{Key: "T-CB1", Summary: "cb test"}
+	ws := &Workspace{TicketKey: "T-CB1"} // no repos — Commit/PR still fire but do no work
+
+	_, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// All 6 phases fire even with no repos; Commit/PR have nothing to commit/push/create.
+	assertPhaseCallPairs(t, *calls, []Phase{PhaseValidate, PhasePlan, PhaseImplement, PhaseCommit, PhasePR, PhaseStatus})
+}
+
+func TestPhaseCallback_HappyPath_WithCommitAndPR(t *testing.T) {
+	cb, calls := collectPhaseCalls()
+	sc := &stubJiraClient{}
+	va := &stubAgent{output: `{"valid": true, "score": 8, "issues": [], "missing": [], "suggestions": []}`}
+	ia := &stubAgent{name: "impl", output: "output"}
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		validationAgent: va,
+		implAgent:       ia,
+		onPhase:         cb,
+		fnHasChanges:    func(_ context.Context, _ string) (bool, error) { return true, nil },
+		fnCommitAndPush: func(_ context.Context, _, _ string) error { return nil },
+		fnCreatePR: func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+			return &PRInfo{URL: "https://github.com/org/repo/pull/1"}, nil
+		},
+		fnFindPR:        func(_ context.Context, _, _ string) (*PRInfo, error) { return nil, nil },
+		fnFetchReviews:  func(_ context.Context, _, _ string) (*PRReviewState, error) { return nil, nil },
+		fnPostPRComment: func(_ context.Context, _, _, _ string) error { return nil },
+	}
+	ticket := Ticket{Key: "T-CB2", Summary: "with commit and PR"}
+	ws := &Workspace{
+		TicketKey: "T-CB2",
+		Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp", Branch: "feature/T-CB2", BaseBranch: "main"}},
+	}
+
+	_, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertPhaseCallPairs(t, *calls, []Phase{PhaseValidate, PhasePlan, PhaseImplement, PhaseCommit, PhasePR, PhaseStatus})
+}
+
+func TestPhaseCallback_ValidationError(t *testing.T) {
+	cb, calls := collectPhaseCalls()
+	sc := &stubJiraClient{}
+	va := &stubAgent{name: "validator", err: errors.New("agent timeout")}
+	ia := &stubAgent{name: "impl"}
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		validationAgent: va,
+		implAgent:       ia,
+		onPhase:         cb,
+	}
+
+	_, err := o.ProcessTicket(context.Background(), Ticket{Key: "T-CB3"}, &Workspace{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertPhaseCallPairs(t, *calls, []Phase{PhaseValidate})
+}
+
+func TestPhaseCallback_ValidationReject(t *testing.T) {
+	cb, calls := collectPhaseCalls()
+	sc := &stubJiraClient{}
+	va := &stubAgent{
+		name:   "validator",
+		output: `{"valid": false, "score": 3, "issues": ["no AC"], "missing": [], "suggestions": []}`,
+	}
+	ia := &stubAgent{name: "impl"}
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		validationAgent: va,
+		implAgent:       ia,
+		onPhase:         cb,
+	}
+
+	_, err := o.ProcessTicket(context.Background(), Ticket{Key: "T-CB4"}, &Workspace{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertPhaseCallPairs(t, *calls, []Phase{PhaseValidate})
+}
+
+func TestPhaseCallback_PlanError(t *testing.T) {
+	cb, calls := collectPhaseCalls()
+	sc := &stubJiraClient{}
+	va := &stubAgent{output: `{"valid": true, "score": 8, "issues": [], "missing": [], "suggestions": []}`}
+	callCount := 0
+	ia := &stubAgent{name: "impl", err: errors.New("plan failed")}
+	// Override with a function that fails on first call (plan), second call would be impl
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		validationAgent: va,
+		implAgent:       ia,
+		onPhase:         cb,
+	}
+	_ = callCount
+
+	_, err := o.ProcessTicket(context.Background(), Ticket{Key: "T-CB5"}, &Workspace{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertPhaseCallPairs(t, *calls, []Phase{PhaseValidate, PhasePlan})
+}
+
+func TestPhaseCallback_ImplementError(t *testing.T) {
+	cb, calls := collectPhaseCalls()
+	sc := &stubJiraClient{}
+	va := &stubAgent{output: `{"valid": true, "score": 8, "issues": [], "missing": [], "suggestions": []}`}
+
+	callCount := 0
+	ia := &stubAgentFunc{
+		fn: func(opts agents.ExecuteOptions) (*agents.ExecuteResult, error) {
+			callCount++
+			if callCount == 1 {
+				// plan phase succeeds
+				return &agents.ExecuteResult{Output: "plan output"}, nil
+			}
+			// implement phase fails
+			return nil, errors.New("impl failed")
+		},
+	}
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		validationAgent: va,
+		implAgent:       ia,
+		onPhase:         cb,
+	}
+
+	_, err := o.ProcessTicket(context.Background(), Ticket{Key: "T-CB6"}, &Workspace{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertPhaseCallPairs(t, *calls, []Phase{PhaseValidate, PhasePlan, PhaseImplement})
+}
+
+func TestPhaseCallback_CommitError(t *testing.T) {
+	cb, calls := collectPhaseCalls()
+	sc := &stubJiraClient{}
+	va := &stubAgent{output: `{"valid": true, "score": 8, "issues": [], "missing": [], "suggestions": []}`}
+	ia := &stubAgent{name: "impl", output: "output"}
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		validationAgent: va,
+		implAgent:       ia,
+		onPhase:         cb,
+		fnHasChanges:    func(_ context.Context, _ string) (bool, error) { return false, errors.New("git error") },
+		fnCommitAndPush: func(_ context.Context, _, _ string) error { return nil },
+		fnCreatePR: func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+			return &PRInfo{URL: "u"}, nil
+		},
+		fnFindPR:        func(_ context.Context, _, _ string) (*PRInfo, error) { return nil, nil },
+		fnFetchReviews:  func(_ context.Context, _, _ string) (*PRReviewState, error) { return nil, nil },
+		fnPostPRComment: func(_ context.Context, _, _, _ string) error { return nil },
+	}
+	ticket := Ticket{Key: "T-CB7", Summary: "commit error"}
+	ws := &Workspace{
+		TicketKey: "T-CB7",
+		Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp", Branch: "feature/T-CB7", BaseBranch: "main"}},
+	}
+
+	_, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertPhaseCallPairs(t, *calls, []Phase{PhaseValidate, PhasePlan, PhaseImplement, PhaseCommit})
+}
+
+func TestPhaseCallback_PRError(t *testing.T) {
+	cb, calls := collectPhaseCalls()
+	sc := &stubJiraClient{}
+	va := &stubAgent{output: `{"valid": true, "score": 8, "issues": [], "missing": [], "suggestions": []}`}
+	ia := &stubAgent{name: "impl", output: "output"}
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		validationAgent: va,
+		implAgent:       ia,
+		onPhase:         cb,
+		fnHasChanges:    func(_ context.Context, _ string) (bool, error) { return true, nil },
+		fnCommitAndPush: func(_ context.Context, _, _ string) error { return nil },
+		fnCreatePR: func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+			return nil, errors.New("PR creation failed")
+		},
+		fnFindPR:        func(_ context.Context, _, _ string) (*PRInfo, error) { return nil, nil },
+		fnFetchReviews:  func(_ context.Context, _, _ string) (*PRReviewState, error) { return nil, nil },
+		fnPostPRComment: func(_ context.Context, _, _, _ string) error { return nil },
+	}
+	ticket := Ticket{Key: "T-CB8", Summary: "PR error"}
+	ws := &Workspace{
+		TicketKey: "T-CB8",
+		Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp", Branch: "feature/T-CB8", BaseBranch: "main"}},
+	}
+
+	_, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertPhaseCallPairs(t, *calls, []Phase{PhaseValidate, PhasePlan, PhaseImplement, PhaseCommit, PhasePR})
+}
+
+func TestPhaseCallback_StatusError(t *testing.T) {
+	cb, calls := collectPhaseCalls()
+	sc := &stubJiraClient{transitionErr: errors.New("transition failed")}
+	va := &stubAgent{output: `{"valid": true, "score": 8, "issues": [], "missing": [], "suggestions": []}`}
+	ia := &stubAgent{name: "impl", output: "output"}
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		validationAgent: va,
+		implAgent:       ia,
+		onPhase:         cb,
+	}
+	ticket := Ticket{Key: "T-CB9"}
+	ws := &Workspace{TicketKey: "T-CB9"} // no repos
+
+	_, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// transitionErr affects both TransitionToInProgress (PhaseValidate) and TransitionToReview (PhaseStatus).
+	// PhaseValidate will fail, so only Validate fires.
+	assertPhaseCallPairs(t, *calls, []Phase{PhaseValidate})
+}
+
+func TestPhaseCallback_StatusError_OnlyStatus(t *testing.T) {
+	cb, calls := collectPhaseCalls()
+	// Use a client where only TransitionToReview fails.
+	sc := &stubJiraClientSelectiveErr{reviewErr: errors.New("review transition failed")}
+	va := &stubAgent{output: `{"valid": true, "score": 8, "issues": [], "missing": [], "suggestions": []}`}
+	ia := &stubAgent{name: "impl", output: "output"}
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		validationAgent: va,
+		implAgent:       ia,
+		onPhase:         cb,
+	}
+	ticket := Ticket{Key: "T-CB10"}
+	ws := &Workspace{TicketKey: "T-CB10"} // no repos
+
+	_, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// All 6 phases fire; Status fails but still emits done=true before returning.
+	assertPhaseCallPairs(t, *calls, []Phase{PhaseValidate, PhasePlan, PhaseImplement, PhaseCommit, PhasePR, PhaseStatus})
+}
+
+func TestPhaseCallback_ResumeSkipsPhases(t *testing.T) {
+	cb, calls := collectPhaseCalls()
+	sc := &stubJiraClient{}
+	ia := &stubAgent{name: "impl", output: "output"}
+	o := &Orchestrator{
+		client:          sc,
+		cfg:             JiraConfig{},
+		validationAgent: &stubAgent{output: `{"valid": true, "score": 8}`},
+		implAgent:       ia,
+		onPhase:         cb,
+	}
+	// Ticket already has validation and plan comments → resume starts at Implement.
+	ticket := Ticket{
+		Key: "T-CB11",
+		Comments: []Comment{
+			nightshiftComment(CommentValidation, "validated"),
+			nightshiftComment(CommentPlan, "the plan"),
+		},
+	}
+	ws := &Workspace{TicketKey: "T-CB11"} // no repos
+
+	_, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Validate and Plan are skipped (no callbacks); Implement, Commit, PR, Status run.
+	assertPhaseCallPairs(t, *calls, []Phase{PhaseImplement, PhaseCommit, PhasePR, PhaseStatus})
+}
+
+// stubAgentFunc is a stub that delegates Execute to a function, for per-call
+// control over success/failure.
+type stubAgentFunc struct {
+	fn func(opts agents.ExecuteOptions) (*agents.ExecuteResult, error)
+}
+
+func (s *stubAgentFunc) Execute(_ context.Context, opts agents.ExecuteOptions) (*agents.ExecuteResult, error) {
+	return s.fn(opts)
+}
+
+func (s *stubAgentFunc) Name() string { return "stubAgentFunc" }
+
+// stubJiraClientSelectiveErr allows specifying errors for each transition independently.
+type stubJiraClientSelectiveErr struct {
+	postCommentCalls   []NightshiftComment
+	handleInvalidCalls []string
+	transitionCalls    []string
+
+	inProgressErr error
+	reviewErr     error
+}
+
+func (s *stubJiraClientSelectiveErr) PostComment(_ context.Context, _ string, comment NightshiftComment) error {
+	s.postCommentCalls = append(s.postCommentCalls, comment)
+	return nil
+}
+
+func (s *stubJiraClientSelectiveErr) HandleInvalidTicket(_ context.Context, ticketKey string, _ *ValidationResult) error {
+	s.handleInvalidCalls = append(s.handleInvalidCalls, ticketKey)
+	return nil
+}
+
+func (s *stubJiraClientSelectiveErr) TransitionToInProgress(_ context.Context, issueKey string) error {
+	s.transitionCalls = append(s.transitionCalls, "inprogress:"+issueKey)
+	return s.inProgressErr
+}
+
+func (s *stubJiraClientSelectiveErr) TransitionToReview(_ context.Context, issueKey string) error {
+	s.transitionCalls = append(s.transitionCalls, "review:"+issueKey)
+	return s.reviewErr
 }


### PR DESCRIPTION
## VC-53 — WithPhaseCallback contract broken — done=true never called, phase-end notifications never fire

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-53

### Description

Problem
WithPhaseCallback is documented as:
"registered callback invoked at the start (done=false) and end (done=true) of each phase. Useful for real-time progress reporting."
But in ProcessTicket (internal/jira/orchestrator.go), every phase only calls the start notification:
o.notifyPhase(ticket.Key, PhaseValidate,   false)  // start — ok
// ... phase work ...
// ← no notifyPhase(..., true) after phase completes
o.notifyPhase(ticket.Key, PhasePlan,       false)  // start — ok
// ...
The done=true half of the contract is never fulfilled for any phase. The callback signature and documentation make an explicit promise that callers depend on.
Root cause
Six phase-start calls exist (lines 302, 343, 368, 399, 434, 496), zero phase-end calls. The omission appears accidental — the TUI (run_output.go) uses done to stop spinners and mark phases complete.
Impact
The TUI progress output cannot determine when a phase finishes — spinners or progress indicators that wait for done=true will hang indefinitely or never update
Any external tooling or monitoring that hooks WithPhaseCallback to track phase duration gets zero end-time data
Phase timing metrics are unavailable
Acceptance criteria
After each phase in ProcessTicket completes (success or failure), o.notifyPhase(ticketKey, phase, true) is called before proceeding to the next phase
On early-exit (error), the phase-end notification is still fired for the phase that failed
Tests verify that for each phase, the callback receives exactly one done=false and one done=true call in that order

### Acceptance Criteria

After each phase in ProcessTicket completes (success or failure), o.notifyPhase(ticketKey, phase, true) is called before proceeding to the next phase
On early-exit (error), the phase-end notification is still fired for the phase that failed
Tests verify that for each phase, the callback receives exactly one done=false and one done=true call in that order

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
