### PR TITLE
[VC-54] extractAcceptanceCriteria: redundant boundary check obscures intent and risks future off-by-one

### DIFF
--- a/internal/jira/tickets.go
+++ b/internal/jira/tickets.go
@@ -324,7 +324,7 @@ func extractAcceptanceCriteria(description string) string {
 		body, ok := acceptanceCriteriaBodyFromLine(line)
 		if ok {
 			rest := body
-			if nextStart <= len(description) && nextStart < len(description) {
+			if nextStart < len(description) {
 				tail := description[nextStart:]
 				if tail != "" {
 					if rest != "" {


### PR DESCRIPTION
## VC-54 — extractAcceptanceCriteria: redundant boundary check obscures intent and risks future off-by-one

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-54

### Description

Problem
In internal/jira/tickets.go line 327, the condition reads:
if nextStart <= len(description) && nextStart < len(description) {
The first clause (nextStart <= len(description)) is always true whenever the second clause (nextStart < len(description)) is true, making it entirely redundant. This is confusing because it suggests the two conditions are meaningfully different, inviting future maintainers to change one while leaving the other, creating an actual off-by-one.
Root cause
Likely a typo or copy-paste artifact. The intended guard is nextStart < len(description) (to avoid an empty tail).
Impact
No current runtime impact — the redundant check is unreachable as a gate. However, the misleading double condition is a maintenance hazard and may mask a future regression if one clause is updated independently.
Acceptance criteria
Line 327 is simplified to if nextStart < len(description) {
All existing extractAcceptanceCriteria tests pass unchanged

### Acceptance Criteria

Line 327 is simplified to if nextStart < len(description) {
All existing extractAcceptanceCriteria tests pass unchanged

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
