### PR TITLE
feat(jira): enforce lint and test checks in implement and review-fix agent prompts

### DIFF
--- a/docs/guides/jira-pipeline.md
+++ b/docs/guides/jira-pipeline.md
@@ -101,6 +101,8 @@ jira:
     - name: myrepo
       url: git@github.com:org/repo.git   # Use SSH to avoid interactive auth
       base_branch: main
+      lint_command: golangci-lint run ./...  # optional: defaults to "golangci-lint run ./..."
+      test_command: go test ./...            # optional: defaults to "go test ./..."
   validation:
     provider: claude
     model: claude-haiku-4-5-20251001

--- a/internal/jira/config.go
+++ b/internal/jira/config.go
@@ -42,9 +42,11 @@ type JiraConfig struct {
 
 // RepoConfig defines a repository to work on.
 type RepoConfig struct {
-	Name       string `mapstructure:"name"`        // subdirectory name
-	URL        string `mapstructure:"url"`         // git clone URL
-	BaseBranch string `mapstructure:"base_branch"` // default: "main"
+	Name        string `mapstructure:"name"`         // subdirectory name
+	URL         string `mapstructure:"url"`          // git clone URL
+	BaseBranch  string `mapstructure:"base_branch"`  // default: "main"
+	LintCommand string `mapstructure:"lint_command"` // optional: command to run linter (e.g. "golangci-lint run ./...")
+	TestCommand string `mapstructure:"test_command"` // optional: command to run tests (e.g. "go test ./...")
 }
 
 // PhaseConfig specifies provider/model for a specific phase.

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -260,6 +260,19 @@ func buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace)
 	b.WriteString("1. Make the requested change\n")
 	b.WriteString("2. If you disagree, explain why in a code comment\n")
 	b.WriteString("3. Do not modify code unrelated to the review feedback\n")
+	lintCmd := repo.LintCommand
+	if lintCmd == "" {
+		lintCmd = "golangci-lint run ./..."
+	}
+	testCmd := repo.TestCommand
+	if testCmd == "" {
+		testCmd = "go test ./..."
+	}
+	b.WriteString("\n### Quality Checks (REQUIRED before finishing)\n")
+	b.WriteString("After addressing all feedback, run the following commands and fix ALL failures:\n\n")
+	fmt.Fprintf(&b, "- Lint: `%s`\n", lintCmd)
+	fmt.Fprintf(&b, "- Test: `%s`\n\n", testCmd)
+	b.WriteString("Do not finish until both commands exit with code 0. Do not commit or push — that will be handled separately.\n")
 	return b.String()
 }
 

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -585,15 +585,30 @@ func (o *Orchestrator) buildImplementPrompt(ticket Ticket, plan string, ws *Work
 	b.WriteString("\n## Instructions\n")
 	b.WriteString("1. Implement the plan step by step — complete EVERY step before stopping\n")
 	b.WriteString("2. Make all necessary code changes\n")
-	b.WriteString("3. Run tests and fix all failures before stopping\n")
-	b.WriteString("4. Verify ALL acceptance criteria are met before stopping\n")
-	b.WriteString("5. Do not commit or push — that will be handled separately\n")
-	b.WriteString("6. If you encounter ambiguity, make a reasonable assumption and document it in a comment\n")
-	b.WriteString("7. Do NOT stop early — continue until the entire plan is implemented and tests pass\n")
+	b.WriteString("3. Verify ALL acceptance criteria are met\n")
+	b.WriteString("4. Do not commit or push — that will be handled separately\n")
+	b.WriteString("5. If you encounter ambiguity, make a reasonable assumption and document it in a comment\n")
+	b.WriteString("6. Do NOT stop early — continue until the entire plan is implemented, lint passes, and tests pass\n")
+	if ws != nil && len(ws.Repos) > 0 {
+		b.WriteString("\n## Quality Checks (REQUIRED before finishing)\n")
+		b.WriteString("For each repo above, run the following commands and fix ALL failures before stopping:\n\n")
+		for _, repo := range ws.Repos {
+			lintCmd := repo.LintCommand
+			if lintCmd == "" {
+				lintCmd = "golangci-lint run ./..."
+			}
+			testCmd := repo.TestCommand
+			if testCmd == "" {
+				testCmd = "go test ./..."
+			}
+			fmt.Fprintf(&b, "**%s** (`%s`):\n", repo.Name, repo.Path)
+			fmt.Fprintf(&b, "  - Lint: `%s`\n", lintCmd)
+			fmt.Fprintf(&b, "  - Test: `%s`\n\n", testCmd)
+		}
+		b.WriteString("Do not finish until all lint and test commands exit with code 0.\n")
+	}
 	return b.String()
 }
-
-// buildPRImplementationComment builds the GitHub PR comment body with the agent's
 // implementation summary so reviewers have full context inline.
 func buildPRImplementationComment(ticket Ticket, summary, jiraSite string) string {
 	var b strings.Builder

--- a/internal/jira/workspace.go
+++ b/internal/jira/workspace.go
@@ -21,12 +21,14 @@ type Workspace struct {
 
 // RepoWorkspace holds the state of one repository inside a Workspace.
 type RepoWorkspace struct {
-	Name       string
-	Path       string
-	URL        string
-	Branch     string
-	BaseBranch string
-	IsNew      bool
+	Name        string
+	Path        string
+	URL         string
+	Branch      string
+	BaseBranch  string
+	IsNew       bool
+	LintCommand string // empty means auto-discover
+	TestCommand string // empty means auto-discover
 }
 
 // SetupWorkspace creates (or reuses) an isolated workspace for ticketKey.
@@ -71,12 +73,14 @@ func SetupWorkspace(ctx context.Context, cfg JiraConfig, ticketKey string) (*Wor
 			return nil, fmt.Errorf("branch %s in %s: %w", branch, r.Name, err)
 		}
 		repos = append(repos, RepoWorkspace{
-			Name:       r.Name,
-			Path:       repoPath,
-			URL:        r.URL,
-			Branch:     branch,
-			BaseBranch: baseBranch,
-			IsNew:      isNew,
+			Name:        r.Name,
+			Path:        repoPath,
+			URL:         r.URL,
+			Branch:      branch,
+			BaseBranch:  baseBranch,
+			IsNew:       isNew,
+			LintCommand: r.LintCommand,
+			TestCommand: r.TestCommand,
 		})
 	}
 	return &Workspace{TicketKey: ticketKey, Root: wsRoot, Repos: repos}, nil


### PR DESCRIPTION
## What

Both the implement and review-fix agent prompts now include a mandatory **Quality Checks** section that instructs agents to run lint and tests — and fix all failures — before declaring the work done.

## Changes

### `RepoConfig` + `RepoWorkspace`
Added two optional fields:
- `lint_command` — linter command (default: `golangci-lint run ./...`)
- `test_command` — test command (default: `go test ./...`)

### `buildImplementPrompt` (`orchestrator.go`)
- New **Quality Checks (REQUIRED before finishing)** section appended after Instructions
- Lists lint and test commands per repo (using configured or default values)
- Agent is told: *do not finish until all commands exit with code 0*

### `buildReworkPrompt` (`feedback.go`)
- Same Quality Checks section added after the feedback instructions
- Explicitly says: *do not commit or push — that will be handled separately*

### Docs
Updated `docs/guides/jira-pipeline.md` config example with `lint_command` / `test_command`.

## Why

During real-world runs agents committed code that failed `golangci-lint` (e.g. unused const, wrong imports). The rework agent also made changes without verifying they compiled or passed tests.