### PR TITLE
fix(jira): detect agent self-commits and fail on no changes after implement

### DIFF
--- a/internal/jira/branch.go
+++ b/internal/jira/branch.go
@@ -91,6 +91,41 @@ func setupBranch(ctx context.Context, repoPath, branchName, baseBranch string) (
 	return true, nil
 }
 
+// PushBranch pushes the current local branch to origin without committing.
+func PushBranch(ctx context.Context, repoPath string) error {
+	branch, err := gitExec(ctx, repoPath, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return err
+	}
+	if _, err := gitExec(ctx, repoPath, "push", "origin", branch); err != nil {
+		return err
+	}
+	return nil
+}
+
+// LocalBranchAheadOfBase reports whether the local HEAD has commits ahead of origin/base.
+// This detects the case where an agent committed locally but never pushed.
+// Returns (false, nil) when origin/base does not exist.
+func LocalBranchAheadOfBase(ctx context.Context, repoPath, base string) (bool, error) {
+	baseRef := "refs/remotes/origin/" + base
+	baseExists, err := remoteRefExists(ctx, repoPath, baseRef)
+	if err != nil {
+		return false, err
+	}
+	if !baseExists {
+		return false, nil
+	}
+	out, err := gitExec(ctx, repoPath, "rev-list", "--count", baseRef+"..HEAD")
+	if err != nil {
+		return false, err
+	}
+	count, err := strconv.Atoi(out)
+	if err != nil {
+		return false, fmt.Errorf("parse git rev-list count %q: %w", out, err)
+	}
+	return count > 0, nil
+}
+
 // BranchAheadOfBase reports whether branch has commits ahead of origin/base on the remote.
 // Returns (false, nil) when the remote ref for branch does not exist (branch not yet pushed)
 // or when there are no commits ahead. Returns an error for missing base refs or unexpected

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -73,7 +73,9 @@ type Orchestrator struct {
 	fnFindPR            func(ctx context.Context, repoPath, branch string) (*PRInfo, error)
 	fnFetchReviews      func(ctx context.Context, repoPath, prURL string) (*PRReviewState, error)
 	fnPostPRComment     func(ctx context.Context, repoPath, prURL, body string) error
-	fnBranchAheadOfBase func(ctx context.Context, repoPath, branch, base string) (bool, error)
+	fnBranchAheadOfBase      func(ctx context.Context, repoPath, branch, base string) (bool, error)
+	fnLocalBranchAheadOfBase func(ctx context.Context, repoPath, base string) (bool, error)
+	fnPushBranch             func(ctx context.Context, repoPath string) error
 }
 
 // OrchestratorOption configures an Orchestrator.
@@ -130,7 +132,9 @@ func NewOrchestrator(client *Client, cfg JiraConfig, opts ...OrchestratorOption)
 			_, err := ghExec(ctx, repoPath, "pr", "comment", prURL, "--body", body)
 			return err
 		},
-		fnBranchAheadOfBase: BranchAheadOfBase,
+		fnBranchAheadOfBase:      BranchAheadOfBase,
+		fnLocalBranchAheadOfBase: LocalBranchAheadOfBase,
+		fnPushBranch:             PushBranch,
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -256,6 +260,12 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	}
 	if o.fnBranchAheadOfBase == nil {
 		o.fnBranchAheadOfBase = BranchAheadOfBase
+	}
+	if o.fnLocalBranchAheadOfBase == nil {
+		o.fnLocalBranchAheadOfBase = LocalBranchAheadOfBase
+	}
+	if o.fnPushBranch == nil {
+		o.fnPushBranch = PushBranch
 	}
 
 	start := time.Now()
@@ -424,6 +434,29 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 					return result, nil
 				}
 				if !changed {
+					// Agent may have committed locally but not pushed. Check local HEAD vs origin/base.
+					localAhead, err := o.fnLocalBranchAheadOfBase(ctx, repo.Path, repo.BaseBranch)
+					if err != nil {
+						o.postErrorComment(ctx, ticket.Key, PhaseCommit, err)
+						result.Status = TicketFailed
+						result.Error = err.Error()
+						result.Duration = time.Since(start)
+						o.notifyPhase(ticket.Key, PhaseCommit, true)
+						return result, nil
+					}
+					if localAhead {
+						o.emit("  agent committed in repo %s — pushing", repo.Name)
+						if err := o.fnPushBranch(ctx, repo.Path); err != nil {
+							o.postErrorComment(ctx, ticket.Key, PhaseCommit, err)
+							result.Status = TicketFailed
+							result.Error = err.Error()
+							result.Duration = time.Since(start)
+							o.notifyPhase(ticket.Key, PhaseCommit, true)
+							return result, nil
+						}
+						changedRepos = append(changedRepos, repo)
+						continue
+					}
 					o.emit("  no changes in repo %s — skipping commit", repo.Name)
 					// NOTE: If the agent only modified repo[0] but the ticket required
 					// changes in this repo too, we silently skip it here. Enforcement
@@ -466,6 +499,21 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				o.emit("  branch %s already pushed — recovering PR creation", repo.Branch)
 				recoveredRepos = append(recoveredRepos, repo)
 			}
+		}
+
+		// Fail the ticket when the implementation produced no changes at all.
+		// This prevents silently moving a ticket to review with zero PRs.
+		// Only applies when repos are configured — ws with no repos is valid for
+		// tickets that don't require code changes (e.g. documentation-only work).
+		if ws != nil && len(ws.Repos) > 0 && len(changedRepos) == 0 && len(recoveredRepos) == 0 {
+			implErr := fmt.Errorf("implementation produced no file changes — agent did not modify any repository")
+			o.postErrorComment(ctx, ticket.Key, PhaseCommit, implErr)
+			result.Status = TicketFailed
+			result.Error = implErr.Error()
+			result.Duration = time.Since(start)
+			o.log.Errorf("ticket %s: %v", ticket.Key, implErr)
+			o.notifyPhase(ticket.Key, PhaseCommit, true)
+			return result, nil
 		}
 
 		// Phase 5: PR

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -661,6 +661,7 @@ func TestProcessTicket_CommitPhase_NoChanges(t *testing.T) {
 	sc := &stubJiraClient{}
 	o, ws := makeOrchestratorWithRepo(sc)
 	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
+	o.fnLocalBranchAheadOfBase = func(_ context.Context, _, _ string) (bool, error) { return false, nil }
 	o.fnBranchAheadOfBase = func(_ context.Context, _, _, _ string) (bool, error) { return false, nil }
 	o.fnCommitAndPush = func(_ context.Context, _, _ string) error { t.Error("CommitAndPush called unexpectedly"); return nil }
 	o.fnCreatePR = func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
@@ -672,11 +673,56 @@ func TestProcessTicket_CommitPhase_NoChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.Status != TicketCompleted {
-		t.Errorf("Status = %q, want %q", result.Status, TicketCompleted)
+	if result.Status != TicketFailed {
+		t.Errorf("Status = %q, want %q", result.Status, TicketFailed)
+	}
+	if result.Phase != PhaseCommit {
+		t.Errorf("Phase = %q, want %q", result.Phase, PhaseCommit)
 	}
 	if len(result.PRURLs) != 0 {
 		t.Errorf("expected no PRURLs when no changes, got %v", result.PRURLs)
+	}
+}
+
+// TestProcessTicket_CommitPhase_AgentSelfCommitted covers the case where the agent
+// committed changes locally but did not push. The orchestrator must detect the local
+// commit via fnLocalBranchAheadOfBase and push it via fnPushBranch.
+func TestProcessTicket_CommitPhase_AgentSelfCommitted(t *testing.T) {
+	sc := &stubJiraClient{}
+	o, ws := makeOrchestratorWithRepo(sc)
+
+	pushed := false
+	prCreated := false
+
+	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
+	o.fnLocalBranchAheadOfBase = func(_ context.Context, _, _ string) (bool, error) { return true, nil }
+	o.fnPushBranch = func(_ context.Context, _ string) error { pushed = true; return nil }
+	o.fnCommitAndPush = func(_ context.Context, _, _ string) error {
+		t.Error("CommitAndPush should not be called when agent self-committed")
+		return nil
+	}
+	o.fnBranchAheadOfBase = func(_ context.Context, _, _, _ string) (bool, error) { return true, nil }
+	o.fnFindPR = func(_ context.Context, _, _ string) (*PRInfo, error) { return nil, nil }
+	o.fnCreatePR = func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+		prCreated = true
+		return &PRInfo{URL: "https://github.com/org/repo/pull/99"}, nil
+	}
+
+	result, err := o.ProcessTicket(context.Background(), Ticket{Key: "T-1", Summary: "Test"}, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != TicketCompleted {
+		t.Errorf("Status = %q, want %q", result.Status, TicketCompleted)
+	}
+	if !pushed {
+		t.Error("expected PushBranch to be called for local commit")
+	}
+	if !prCreated {
+		t.Error("expected PR to be created after push")
+	}
+	if len(result.PRURLs) == 0 {
+		t.Error("expected PRURLs to be populated")
 	}
 }
 
@@ -844,6 +890,7 @@ func TestProcessTicket_ResumeAtPhaseCommit_BranchAhead_PRCreated(t *testing.T) {
 	o, ws, ticket := makeResumeAtCommitOrchestrator(sc)
 
 	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
+	o.fnLocalBranchAheadOfBase = func(_ context.Context, _, _ string) (bool, error) { return false, nil }
 	o.fnBranchAheadOfBase = func(_ context.Context, _, _, _ string) (bool, error) { return true, nil }
 	o.fnFindPR = func(_ context.Context, _, _ string) (*PRInfo, error) { return nil, nil }
 	createPRCalls := 0
@@ -887,6 +934,7 @@ func TestProcessTicket_ResumeAtPhaseCommit_BranchAhead_ExistingPR(t *testing.T) 
 	o, ws, ticket := makeResumeAtCommitOrchestrator(sc)
 
 	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
+	o.fnLocalBranchAheadOfBase = func(_ context.Context, _, _ string) (bool, error) { return false, nil }
 	o.fnBranchAheadOfBase = func(_ context.Context, _, _, _ string) (bool, error) { return true, nil }
 	o.fnFindPR = func(_ context.Context, _, _ string) (*PRInfo, error) {
 		return &PRInfo{URL: "https://github.com/org/repo/pull/42", Number: 42}, nil
@@ -921,13 +969,15 @@ func TestProcessTicket_ResumeAtPhaseCommit_BranchAhead_ExistingPR(t *testing.T) 
 	}
 }
 
-// TestProcessTicket_ResumeAtPhaseCommit_BranchNotAhead_NoPR verifies the genuine no-op case:
-// when HasChanges=false and the branch is not ahead of base, no PR is created.
+// TestProcessTicket_ResumeAtPhaseCommit_BranchNotAhead_NoPR verifies that when resuming
+// at PhaseCommit with no uncommitted changes and no pushed commits, the ticket fails
+// because the implementation produced no actual output.
 func TestProcessTicket_ResumeAtPhaseCommit_BranchNotAhead_NoPR(t *testing.T) {
 	sc := &stubJiraClient{}
 	o, ws, ticket := makeResumeAtCommitOrchestrator(sc)
 
 	o.fnHasChanges = func(_ context.Context, _ string) (bool, error) { return false, nil }
+	o.fnLocalBranchAheadOfBase = func(_ context.Context, _, _ string) (bool, error) { return false, nil }
 	o.fnBranchAheadOfBase = func(_ context.Context, _, _, _ string) (bool, error) { return false, nil }
 	o.fnFindPR = func(_ context.Context, _, _ string) (*PRInfo, error) {
 		t.Error("fnFindPR must not be called when branch is not ahead")
@@ -946,16 +996,14 @@ func TestProcessTicket_ResumeAtPhaseCommit_BranchNotAhead_NoPR(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.Status != TicketCompleted {
-		t.Errorf("Status = %q, want %q", result.Status, TicketCompleted)
+	if result.Status != TicketFailed {
+		t.Errorf("Status = %q, want %q", result.Status, TicketFailed)
+	}
+	if result.Phase != PhaseCommit {
+		t.Errorf("Phase = %q, want %q", result.Phase, PhaseCommit)
 	}
 	if len(result.PRURLs) != 0 {
-		t.Errorf("PRURLs = %v, want empty (genuine no-op)", result.PRURLs)
-	}
-	for _, c := range sc.postCommentCalls {
-		if c.Type == CommentPR {
-			t.Error("CommentPR should not be posted when no PRs were created")
-		}
+		t.Errorf("PRURLs = %v, want empty", result.PRURLs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two bugs discovered during a live VC-55 run where the implement agent ran for 17 minutes, committed locally but never pushed, and the orchestrator moved the ticket to review with 0 PRs.

### Bug 1: Agent self-commits not detected

`HasChanges` only checks uncommitted changes (`git status --porcelain`). If the agent committed but didn't push, working tree is clean → `false` returned → repo skipped.

**Fix**: Added `LocalBranchAheadOfBase()` (compares `origin/{base}..HEAD`) and `PushBranch()`. In PhaseCommit, when `HasChanges=false` but local branch is ahead, push the existing commit.

### Bug 2: Zero-change run transitions to review

After the commit/recovery pass with no changes and no PRs, the ticket fell through to PhaseStatus and was transitioned to review unconditionally.

**Fix**: After the pass, if workspace has repos but none produced changes → fail with `TicketFailed` at `PhaseCommit`.

### Tests
- Fixed 3 `ResumeAtPhaseCommit` tests missing `fnLocalBranchAheadOfBase` stub
- `ResumeAtPhaseCommit_BranchNotAhead_NoPR` now expects `TicketFailed`
- Added `TestProcessTicket_CommitPhase_AgentSelfCommitted`

Refs: VC-52