### PR TITLE
fix(jira): include HTTP status code and body in ping error message

### DIFF
--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -56,8 +56,15 @@ func NewClient(cfg JiraConfig) (*Client, error) {
 
 // Ping validates the connection by fetching the current user.
 func (c *Client) Ping(ctx context.Context) error {
-	_, _, err := c.jira.MySelf.Details(ctx, nil)
+	_, resp, err := c.jira.MySelf.Details(ctx, nil)
 	if err != nil {
+		if resp != nil {
+			body := strings.TrimSpace(resp.Bytes.String())
+			if body == "" {
+				body = "(empty)"
+			}
+			return fmt.Errorf("jira: ping failed: HTTP %d: %s", resp.Code, body)
+		}
 		return fmt.Errorf("jira: ping failed: %w", err)
 	}
 	return nil


### PR DESCRIPTION
The Jira ping error was showing the generic go-atlassian message `invalid http response status, please refer the response.body for more details` with no actionable detail.

Now shows: `jira: ping failed: HTTP 503: <body>`

The `ResponseScheme` returned by `MySelf.Details` has `Code int` and `Bytes bytes.Buffer` fields. When a non-nil response is present, we use those instead of wrapping the opaque library error.