### PR TITLE
[VC-55] Support multiple Jira projects in nightshift jira config

### DIFF
--- a/cmd/nightshift/commands/jira_preview.go
+++ b/cmd/nightshift/commands/jira_preview.go
@@ -91,7 +91,7 @@ type jiraPreviewSkipped struct {
 }
 
 func runJiraPreview(cmd *cobra.Command, _ []string) error {
-	projectOverride, _ := cmd.Flags().GetString("project")
+	projectFilter, _ := cmd.Flags().GetString("project")
 	labelOverride, _ := cmd.Flags().GetString("label")
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 	plainOutput, _ := cmd.Flags().GetBool("plain")
@@ -105,11 +105,32 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 	}
 	cfg.Jira.Defaults()
 
-	if projectOverride != "" {
-		cfg.Jira.Project = projectOverride
-	}
+	// Apply --label override to all projects.
 	if labelOverride != "" {
-		cfg.Jira.Label = labelOverride
+		for i := range cfg.Jira.Projects {
+			cfg.Jira.Projects[i].Label = labelOverride
+		}
+	}
+
+	// Filter projects with --project flag.
+	projects := cfg.Jira.Projects
+	if projectFilter != "" {
+		var filtered []jira.ProjectConfig
+		for _, p := range projects {
+			if strings.EqualFold(p.Key, projectFilter) {
+				filtered = append(filtered, p)
+			}
+		}
+		if len(filtered) == 0 {
+			return fmt.Errorf("no project with key %q found in config", projectFilter)
+		}
+		projects = filtered
+	}
+
+	// Build comma-joined project keys for display/JSON.
+	keys := make([]string, len(projects))
+	for i, p := range projects {
+		keys[i] = p.Key
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -117,7 +138,7 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 
 	result := &jiraPreviewResult{
 		GeneratedAt: time.Now(),
-		JiraProject: cfg.Jira.Project,
+		JiraProject: strings.Join(keys, ", "),
 		Phases: []jiraPreviewPhase{
 			{Name: "validation", Provider: cfg.Jira.Validation.Provider, Model: cfg.Jira.Validation.Model, Timeout: cfg.Jira.Validation.Timeout},
 			{Name: "plan", Provider: cfg.Jira.Plan.Provider, Model: cfg.Jira.Plan.Model, Timeout: cfg.Jira.Plan.Timeout},
@@ -126,7 +147,7 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 		},
 	}
 
-	// Optionally prepare the validation agent up front.
+	// Optionally prepare the validation agent up front (uses global validation config).
 	var valAgent agents.Agent
 	if runValidate {
 		a, agentErr := createJiraAgent(cfg, cfg.Jira.Validation)
@@ -151,7 +172,7 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 		result.JiraUser = cfg.Jira.Email
 	}
 
-	// Fetch tickets if connection succeeded.
+	// Fetch tickets from each project if connection succeeded.
 	if result.ConnectionOK {
 		statusMap, err := client.DiscoverStatuses(ctx)
 		if err != nil {
@@ -160,17 +181,19 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 				Reason: fmt.Sprintf("discover statuses: %v", err),
 			})
 		} else {
-			todoTickets, err := client.FetchTodoTickets(ctx)
-			if err != nil {
-				result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
-					Key:    "*",
-					Reason: fmt.Sprintf("fetch todo tickets: %v", err),
-				})
-			} else {
-				inProgressTickets, ipErr := client.FetchInProgressTickets(ctx, statusMap)
+			for _, proj := range projects {
+				todoTickets, err := client.FetchTodoTickets(ctx, proj)
+				if err != nil {
+					result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
+						Key:    proj.Key + ":*",
+						Reason: fmt.Sprintf("fetch todo tickets: %v", err),
+					})
+					continue
+				}
+				inProgressTickets, ipErr := client.FetchInProgressTickets(ctx, proj, statusMap)
 				if ipErr != nil {
 					result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
-						Key:    "*",
+						Key:    proj.Key + ":*",
 						Reason: fmt.Sprintf("fetch in-progress tickets: %v", ipErr),
 					})
 				} else {
@@ -223,17 +246,17 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 						Blockers: bt.Blockers,
 					})
 				}
-			}
 
-			reviewTickets, err := client.FetchReviewTickets(ctx, statusMap)
-			if err != nil {
-				result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
-					Key:    "*review*",
-					Reason: fmt.Sprintf("fetch review tickets: %v", err),
-				})
-			} else {
-				for _, t := range reviewTickets {
-					result.ReviewTickets = append(result.ReviewTickets, buildJiraPreviewTicket(t))
+				reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap)
+				if err != nil {
+					result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
+						Key:    proj.Key + ":*review*",
+						Reason: fmt.Sprintf("fetch review tickets: %v", err),
+					})
+				} else {
+					for _, t := range reviewTickets {
+						result.ReviewTickets = append(result.ReviewTickets, buildJiraPreviewTicket(t))
+					}
 				}
 			}
 		}

--- a/cmd/nightshift/commands/jira_preview.go
+++ b/cmd/nightshift/commands/jira_preview.go
@@ -127,6 +127,12 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 		projects = filtered
 	}
 
+	// Validate the (potentially filtered) config.
+	cfg.Jira.Projects = projects
+	if err := cfg.Jira.Validate(); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
+
 	// Build comma-joined project keys for display/JSON.
 	keys := make([]string, len(projects))
 	for i, p := range projects {
@@ -136,29 +142,27 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
+	// Build phases using effective configs. When multiple projects are configured
+	// each may have different overrides; we show the first project's effective
+	// values as a representative (or global defaults when projects is empty).
+	buildPhases := func() []jiraPreviewPhase {
+		if len(projects) == 0 {
+			return nil
+		}
+		p := projects[0]
+		jc := cfg.Jira
+		return []jiraPreviewPhase{
+			{Name: "validation", Provider: jc.EffectiveValidation(p).Provider, Model: jc.EffectiveValidation(p).Model, Timeout: jc.EffectiveValidation(p).Timeout},
+			{Name: "plan", Provider: jc.EffectivePlan(p).Provider, Model: jc.EffectivePlan(p).Model, Timeout: jc.EffectivePlan(p).Timeout},
+			{Name: "implement", Provider: jc.EffectiveImplement(p).Provider, Model: jc.EffectiveImplement(p).Model, Timeout: jc.EffectiveImplement(p).Timeout},
+			{Name: "review_fix", Provider: jc.EffectiveReviewFix(p).Provider, Model: jc.EffectiveReviewFix(p).Model, Timeout: jc.EffectiveReviewFix(p).Timeout},
+		}
+	}
+
 	result := &jiraPreviewResult{
 		GeneratedAt: time.Now(),
 		JiraProject: strings.Join(keys, ", "),
-		Phases: []jiraPreviewPhase{
-			{Name: "validation", Provider: cfg.Jira.Validation.Provider, Model: cfg.Jira.Validation.Model, Timeout: cfg.Jira.Validation.Timeout},
-			{Name: "plan", Provider: cfg.Jira.Plan.Provider, Model: cfg.Jira.Plan.Model, Timeout: cfg.Jira.Plan.Timeout},
-			{Name: "implement", Provider: cfg.Jira.Implement.Provider, Model: cfg.Jira.Implement.Model, Timeout: cfg.Jira.Implement.Timeout},
-			{Name: "review_fix", Provider: cfg.Jira.ReviewFix.Provider, Model: cfg.Jira.ReviewFix.Model, Timeout: cfg.Jira.ReviewFix.Timeout},
-		},
-	}
-
-	// Optionally prepare the validation agent up front (uses global validation config).
-	var valAgent agents.Agent
-	if runValidate {
-		a, agentErr := createJiraAgent(cfg, cfg.Jira.Validation)
-		if agentErr != nil {
-			result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
-				Key:    "*",
-				Reason: fmt.Sprintf("create validation agent: %v", agentErr),
-			})
-		} else {
-			valAgent = a
-		}
+		Phases:      buildPhases(),
 	}
 
 	// Connect to Jira.
@@ -182,6 +186,20 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 			})
 		} else {
 			for _, proj := range projects {
+				// Optionally build a per-project validation agent using effective config.
+				var valAgent agents.Agent
+				if runValidate {
+					a, agentErr := createJiraAgent(cfg, cfg.Jira.EffectiveValidation(proj))
+					if agentErr != nil {
+						result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
+							Key:    proj.Key + ":*",
+							Reason: fmt.Sprintf("create validation agent: %v", agentErr),
+						})
+					} else {
+						valAgent = a
+					}
+				}
+
 				todoTickets, err := client.FetchTodoTickets(ctx, proj)
 				if err != nil {
 					result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -139,6 +139,10 @@ func buildOrchestrator(client *jira.Client, cfg *config.Config, proj jira.Projec
 			return nil, fmt.Errorf("validation agent: %w", err)
 		}
 	}
+	planAgent, err := createJiraAgent(cfg, jiracfg.EffectivePlan(proj))
+	if err != nil {
+		return nil, fmt.Errorf("plan agent: %w", err)
+	}
 	implAgent, err := createJiraAgent(cfg, jiracfg.EffectiveImplement(proj))
 	if err != nil {
 		return nil, fmt.Errorf("implement agent: %w", err)
@@ -149,6 +153,7 @@ func buildOrchestrator(client *jira.Client, cfg *config.Config, proj jira.Projec
 	}
 
 	orchOpts := []jira.OrchestratorOption{
+		jira.WithPlanAgent(planAgent),
 		jira.WithImplAgent(implAgent),
 		jira.WithReviewFixAgent(reviewFixAgent),
 		jira.WithPhaseCallback(func(ticketKey string, phase jira.Phase, done bool) {
@@ -199,7 +204,19 @@ func runSingleTicket(
 	feedbackResults *[]jira.FeedbackResult,
 ) (found bool, err error) {
 	jiracfg := cfg.Jira
+
+	// Parse the project key prefix (e.g. "VC" from "VC-123") to avoid fetching
+	// tickets from unrelated projects that may fail due to permissions or outages.
+	keyPrefix, _, validKey := strings.Cut(key, "-")
+	if !validKey {
+		return false, fmt.Errorf("invalid ticket key %q: expected format PROJECT-NUMBER", key)
+	}
+	keyPrefix = strings.ToUpper(keyPrefix)
+
 	for _, proj := range jiracfg.Projects {
+		if !strings.EqualFold(proj.Key, keyPrefix) {
+			continue
+		}
 		orch, err := buildOrchestrator(client, cfg, proj, skipValidation)
 		if err != nil {
 			return false, err
@@ -431,17 +448,21 @@ func printJiraPreflightSummary(cfg jira.JiraConfig, skipValidation bool, _ *jira
 	fmt.Println("🌙 Nightshift Jira Run")
 	fmt.Println("──────────────────────────────")
 	fmt.Printf("  Site:         %s.atlassian.net\n", cfg.Site)
-	if skipValidation {
-		fmt.Printf("  Validation:   skipped\n")
-	} else {
-		fmt.Printf("  Validation:   %s/%s\n", cfg.Validation.Provider, cfg.Validation.Model)
-	}
-	fmt.Printf("  Implement:    %s/%s\n", cfg.Implement.Provider, cfg.Implement.Model)
-	fmt.Printf("  ReviewFix:    %s/%s\n", cfg.ReviewFix.Provider, cfg.ReviewFix.Model)
 	fmt.Printf("  Max tickets:  %d\n", cfg.MaxTickets)
-	fmt.Printf("  Projects (%d):\n", len(cfg.Projects))
 	for _, p := range cfg.Projects {
-		fmt.Printf("    • %s  [label: %s]  %d repo(s)\n", p.Key, p.Label, len(p.Repos))
+		fmt.Printf("  Project: %s  [label: %s]\n", p.Key, p.Label)
+		if skipValidation {
+			fmt.Printf("    Validation:   skipped\n")
+		} else {
+			v := cfg.EffectiveValidation(p)
+			fmt.Printf("    Validation:   %s/%s\n", v.Provider, v.Model)
+		}
+		pl := cfg.EffectivePlan(p)
+		im := cfg.EffectiveImplement(p)
+		rv := cfg.EffectiveReviewFix(p)
+		fmt.Printf("    Plan:         %s/%s\n", pl.Provider, pl.Model)
+		fmt.Printf("    Implement:    %s/%s\n", im.Provider, im.Model)
+		fmt.Printf("    ReviewFix:    %s/%s\n", rv.Provider, rv.Model)
 	}
 }
 

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -52,8 +52,11 @@ func runJira(cmd *cobra.Command, _ []string) error {
 	if v, _ := cmd.Flags().GetInt("max-tickets"); v > 0 {
 		cfg.Jira.MaxTickets = v
 	}
+	// Apply --label override to all projects.
 	if v, _ := cmd.Flags().GetString("label"); v != "" {
-		cfg.Jira.Label = v
+		for i := range cfg.Jira.Projects {
+			cfg.Jira.Projects[i].Label = v
+		}
 	}
 	skipValidation, _ := cmd.Flags().GetBool("skip-validation")
 	todoOnly, _ := cmd.Flags().GetBool("todo-only")
@@ -80,21 +83,69 @@ func runJira(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("discover statuses: %w", err)
 	}
 
+	printJiraPreflightSummary(cfg.Jira, skipValidation, statusMap)
+
+	var results []jira.TicketResult
+	var feedbackResults []jira.FeedbackResult
+	start := time.Now()
+
+	if singleTicket != "" {
+		found, err := runSingleTicket(ctx, log, client, cfg, statusMap, singleTicket, skipValidation, &results, &feedbackResults)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("ticket %s not found in TODO or ON REVIEW lists", singleTicket)
+		}
+	} else {
+		for _, proj := range cfg.Jira.Projects {
+			orch, err := buildOrchestrator(client, cfg, proj, skipValidation)
+			if err != nil {
+				return err
+			}
+			if !reviewOnly {
+				if err := runTodoPhase(ctx, log, orch, client, cfg.Jira, proj, statusMap, &results); err != nil {
+					return err
+				}
+			}
+			if !todoOnly {
+				if err := runReviewPhase(ctx, log, orch, client, cfg.Jira, proj, statusMap, &feedbackResults); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	if n, err := jira.CleanupStaleWorkspaces(cfg.Jira); err != nil {
+		log.Errorf("workspace cleanup: %v", err)
+	} else if n > 0 {
+		log.Infof("cleaned up %d stale workspaces", n)
+	}
+
+	printJiraRunSummary(results, feedbackResults, time.Since(start))
+	return nil
+}
+
+// buildOrchestrator creates an Orchestrator for the given project,
+// constructing agents from the project's effective phase configs.
+func buildOrchestrator(client *jira.Client, cfg *config.Config, proj jira.ProjectConfig, skipValidation bool) (*jira.Orchestrator, error) {
+	jiracfg := cfg.Jira
+
 	var validationAgent agents.Agent
 	if !skipValidation {
 		var err error
-		validationAgent, err = createJiraAgent(cfg, cfg.Jira.Validation)
+		validationAgent, err = createJiraAgent(cfg, jiracfg.EffectiveValidation(proj))
 		if err != nil {
-			return fmt.Errorf("validation agent: %w", err)
+			return nil, fmt.Errorf("validation agent: %w", err)
 		}
 	}
-	implAgent, err := createJiraAgent(cfg, cfg.Jira.Implement)
+	implAgent, err := createJiraAgent(cfg, jiracfg.EffectiveImplement(proj))
 	if err != nil {
-		return fmt.Errorf("implement agent: %w", err)
+		return nil, fmt.Errorf("implement agent: %w", err)
 	}
-	reviewFixAgent, err := createJiraAgent(cfg, cfg.Jira.ReviewFix)
+	reviewFixAgent, err := createJiraAgent(cfg, jiracfg.EffectiveReviewFix(proj))
 	if err != nil {
-		return fmt.Errorf("review-fix agent: %w", err)
+		return nil, fmt.Errorf("review-fix agent: %w", err)
 	}
 
 	orchOpts := []jira.OrchestratorOption{
@@ -133,114 +184,82 @@ func runJira(cmd *cobra.Command, _ []string) error {
 	} else {
 		orchOpts = append(orchOpts, jira.WithValidationAgent(validationAgent))
 	}
-	orch := jira.NewOrchestrator(client, cfg.Jira, orchOpts...)
-
-	printJiraPreflightSummary(cfg.Jira, skipValidation, statusMap)
-
-	var results []jira.TicketResult
-	var feedbackResults []jira.FeedbackResult
-	start := time.Now()
-
-	if singleTicket != "" {
-		found, err := runSingleTicket(ctx, log, orch, client, cfg.Jira, statusMap, singleTicket, &results, &feedbackResults)
-		if err != nil {
-			return err
-		}
-		if !found {
-			return fmt.Errorf("ticket %s not found in TODO or ON REVIEW lists", singleTicket)
-		}
-	} else {
-		// Phase A: TODO + in-progress tickets (resume failed runs).
-		if !reviewOnly {
-			if err := runTodoPhase(ctx, log, orch, client, cfg.Jira, statusMap, &results); err != nil {
-				return err
-			}
-		}
-
-		// Phase B: ON REVIEW feedback.
-		if !todoOnly {
-			if err := runReviewPhase(ctx, log, orch, client, cfg.Jira, statusMap, &feedbackResults); err != nil {
-				return err
-			}
-		}
-	}
-
-	if n, err := jira.CleanupStaleWorkspaces(cfg.Jira); err != nil {
-		log.Errorf("workspace cleanup: %v", err)
-	} else if n > 0 {
-		log.Infof("cleaned up %d stale workspaces", n)
-	}
-
-	printJiraRunSummary(results, feedbackResults, time.Since(start))
-	return nil
+	return jira.NewOrchestrator(client, jiracfg, proj, orchOpts...), nil
 }
 
 func runSingleTicket(
 	ctx context.Context,
 	log *logging.Logger,
-	orch *jira.Orchestrator,
 	client *jira.Client,
-	jiracfg jira.JiraConfig,
+	cfg *config.Config,
 	statusMap *jira.StatusMap,
 	key string,
+	skipValidation bool,
 	results *[]jira.TicketResult,
 	feedbackResults *[]jira.FeedbackResult,
 ) (found bool, err error) {
-	todoTickets, err := client.FetchTodoTickets(ctx)
-	if err != nil {
-		return false, fmt.Errorf("fetch tickets: %w", err)
-	}
-	inProgressTickets, err := client.FetchInProgressTickets(ctx, statusMap)
-	if err != nil {
-		return false, fmt.Errorf("fetch in-progress tickets: %w", err)
-	}
-	reviewTickets, err := client.FetchReviewTickets(ctx, statusMap)
-	if err != nil {
-		return false, fmt.Errorf("fetch review tickets: %w", err)
-	}
-
-	for _, t := range append(todoTickets, inProgressTickets...) {
-		if t.Key != key {
-			continue
-		}
-		found = true
-		ws, err := jira.SetupWorkspace(ctx, jiracfg, t.Key)
+	jiracfg := cfg.Jira
+	for _, proj := range jiracfg.Projects {
+		orch, err := buildOrchestrator(client, cfg, proj, skipValidation)
 		if err != nil {
-			log.Errorf("workspace setup: %v", err)
-			*results = append(*results, jira.TicketResult{TicketKey: t.Key, Status: jira.TicketFailed, Error: err.Error()})
+			return false, err
+		}
+
+		todoTickets, err := client.FetchTodoTickets(ctx, proj)
+		if err != nil {
+			return false, fmt.Errorf("fetch tickets: %w", err)
+		}
+		inProgressTickets, err := client.FetchInProgressTickets(ctx, proj, statusMap)
+		if err != nil {
+			return false, fmt.Errorf("fetch in-progress tickets: %w", err)
+		}
+		reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap)
+		if err != nil {
+			return false, fmt.Errorf("fetch review tickets: %w", err)
+		}
+
+		for _, t := range append(todoTickets, inProgressTickets...) {
+			if t.Key != key {
+				continue
+			}
+			found = true
+			ws, err := jira.SetupWorkspace(ctx, jiracfg, proj, t.Key)
+			if err != nil {
+				log.Errorf("workspace setup: %v", err)
+				*results = append(*results, jira.TicketResult{TicketKey: t.Key, Status: jira.TicketFailed, Error: err.Error()})
+				return found, nil
+			}
+			result, err := orch.ProcessTicket(ctx, t, ws)
+			if err != nil {
+				log.Errorf("process ticket %s: %v", t.Key, err)
+			}
+			if result != nil {
+				*results = append(*results, *result)
+			}
 			return found, nil
 		}
-		result, err := orch.ProcessTicket(ctx, t, ws)
-		if err != nil {
-			log.Errorf("process ticket %s: %v", t.Key, err)
-		}
-		if result != nil {
-			*results = append(*results, *result)
-		}
-		return found, nil
-	}
 
-	for _, t := range reviewTickets {
-		if t.Key != key {
-			continue
-		}
-		found = true
-		ws, err := jira.SetupWorkspace(ctx, jiracfg, t.Key)
-		if err != nil {
-			log.Errorf("workspace setup: %v", err)
-			*feedbackResults = append(*feedbackResults, jira.FeedbackResult{TicketKey: t.Key, Error: err.Error()})
+		for _, t := range reviewTickets {
+			if t.Key != key {
+				continue
+			}
+			found = true
+			ws, err := jira.SetupWorkspace(ctx, jiracfg, proj, t.Key)
+			if err != nil {
+				log.Errorf("workspace setup: %v", err)
+				*feedbackResults = append(*feedbackResults, jira.FeedbackResult{TicketKey: t.Key, Error: err.Error()})
+				return found, nil
+			}
+			result, err := orch.ProcessFeedback(ctx, t, ws)
+			if err != nil {
+				log.Errorf("process feedback %s: %v", t.Key, err)
+			}
+			if result != nil {
+				*feedbackResults = append(*feedbackResults, *result)
+			}
 			return found, nil
 		}
-		result, err := orch.ProcessFeedback(ctx, t, ws)
-		if err != nil {
-			log.Errorf("process feedback %s: %v", t.Key, err)
-		}
-		if result != nil {
-			*feedbackResults = append(*feedbackResults, *result)
-		}
-		return found, nil
 	}
-
 	return false, nil
 }
 
@@ -250,19 +269,20 @@ func runTodoPhase(
 	orch *jira.Orchestrator,
 	client *jira.Client,
 	jiracfg jira.JiraConfig,
+	proj jira.ProjectConfig,
 	statusMap *jira.StatusMap,
 	results *[]jira.TicketResult,
 ) error {
-	todoTickets, err := client.FetchTodoTickets(ctx)
+	todoTickets, err := client.FetchTodoTickets(ctx, proj)
 	if err != nil {
 		return fmt.Errorf("fetch todo tickets: %w", err)
 	}
-	inProgressTickets, err := client.FetchInProgressTickets(ctx, statusMap)
+	inProgressTickets, err := client.FetchInProgressTickets(ctx, proj, statusMap)
 	if err != nil {
 		return fmt.Errorf("fetch in-progress tickets: %w", err)
 	}
 	allTickets := append(todoTickets, inProgressTickets...)
-	log.Infof("todo tickets: %d found (%d in-progress)", len(allTickets), len(inProgressTickets))
+	log.Infof("todo tickets [%s]: %d found (%d in-progress)", proj.Key, len(allTickets), len(inProgressTickets))
 
 	graph := jira.BuildDependencyGraph(allTickets)
 	ready, blocked := graph.ResolveOrder()
@@ -271,7 +291,7 @@ func runTodoPhase(
 		fmt.Printf("  ⏭  %s  blocked by %v\n", b.Ticket.Key, b.Blockers)
 	}
 	if len(ready) == 0 {
-		fmt.Println("  no tickets ready to process")
+		fmt.Printf("  no tickets ready to process [%s]\n", proj.Key)
 	}
 
 	count := 0
@@ -281,7 +301,7 @@ func runTodoPhase(
 		}
 		fmt.Printf("\n  ▶ %s  %s\n", ticket.Key, ticket.Summary)
 		fmt.Printf("    setting up workspace…\n")
-		ws, err := jira.SetupWorkspace(ctx, jiracfg, ticket.Key)
+		ws, err := jira.SetupWorkspace(ctx, jiracfg, proj, ticket.Key)
 		if err != nil {
 			log.Errorf("workspace %s: %v", ticket.Key, err)
 			fmt.Printf("    ✗ workspace setup failed: %v\n", err)
@@ -308,22 +328,23 @@ func runReviewPhase(
 	orch *jira.Orchestrator,
 	client *jira.Client,
 	jiracfg jira.JiraConfig,
+	proj jira.ProjectConfig,
 	statusMap *jira.StatusMap,
 	feedbackResults *[]jira.FeedbackResult,
 ) error {
-	reviewTickets, err := client.FetchReviewTickets(ctx, statusMap)
+	reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap)
 	if err != nil {
 		return fmt.Errorf("fetch review tickets: %w", err)
 	}
-	log.Infof("review tickets: %d found", len(reviewTickets))
+	log.Infof("review tickets [%s]: %d found", proj.Key, len(reviewTickets))
 
 	if len(reviewTickets) == 0 {
-		fmt.Println("  no tickets in review")
+		fmt.Printf("  no tickets in review [%s]\n", proj.Key)
 	}
 	for _, ticket := range reviewTickets {
 		fmt.Printf("\n  🔍 %s  %s\n", ticket.Key, ticket.Summary)
 		fmt.Printf("    setting up workspace…\n")
-		ws, err := jira.SetupWorkspace(ctx, jiracfg, ticket.Key)
+		ws, err := jira.SetupWorkspace(ctx, jiracfg, proj, ticket.Key)
 		if err != nil {
 			log.Errorf("workspace %s: %v", ticket.Key, err)
 			fmt.Printf("    ✗ workspace setup failed: %v\n", err)
@@ -410,8 +431,6 @@ func printJiraPreflightSummary(cfg jira.JiraConfig, skipValidation bool, _ *jira
 	fmt.Println("🌙 Nightshift Jira Run")
 	fmt.Println("──────────────────────────────")
 	fmt.Printf("  Site:         %s.atlassian.net\n", cfg.Site)
-	fmt.Printf("  Project:      %s\n", cfg.Project)
-	fmt.Printf("  Label:        %s\n", cfg.Label)
 	if skipValidation {
 		fmt.Printf("  Validation:   skipped\n")
 	} else {
@@ -420,6 +439,10 @@ func printJiraPreflightSummary(cfg jira.JiraConfig, skipValidation bool, _ *jira
 	fmt.Printf("  Implement:    %s/%s\n", cfg.Implement.Provider, cfg.Implement.Model)
 	fmt.Printf("  ReviewFix:    %s/%s\n", cfg.ReviewFix.Provider, cfg.ReviewFix.Model)
 	fmt.Printf("  Max tickets:  %d\n", cfg.MaxTickets)
+	fmt.Printf("  Projects (%d):\n", len(cfg.Projects))
+	for _, p := range cfg.Projects {
+		fmt.Printf("    • %s  [label: %s]  %d repo(s)\n", p.Key, p.Label, len(p.Repos))
+	}
 }
 
 func printTicketResult(r *jira.TicketResult) {

--- a/cmd/nightshift/commands/jira_run_test.go
+++ b/cmd/nightshift/commands/jira_run_test.go
@@ -13,12 +13,13 @@ import (
 func TestPrintJiraPreflightSummary(t *testing.T) {
 	cfg := jira.JiraConfig{
 		Site:       "testsite",
-		Project:    "PROJ",
-		Label:      "nightshift",
 		MaxTickets: 5,
 		Validation: jira.PhaseConfig{Provider: "claude", Model: "claude-haiku-4.5"},
 		Implement:  jira.PhaseConfig{Provider: "claude", Model: "claude-sonnet-4.5"},
 		ReviewFix:  jira.PhaseConfig{Provider: "claude", Model: "claude-sonnet-4.5"},
+		Projects: []jira.ProjectConfig{
+			{Key: "PROJ", Label: "nightshift", Repos: []jira.RepoConfig{{Name: "repo", URL: "git@github.com:org/repo.git"}}},
+		},
 	}
 
 	out := captureStdout(t, func() {
@@ -43,9 +44,10 @@ func TestPrintJiraPreflightSummary(t *testing.T) {
 func TestPrintJiraPreflightSummary_SkippedValidation(t *testing.T) {
 	cfg := jira.JiraConfig{
 		Site:       "testsite",
-		Project:    "PROJ",
-		Label:      "nightshift",
 		Validation: jira.PhaseConfig{Provider: "claude", Model: "claude-haiku-4.5"},
+		Projects: []jira.ProjectConfig{
+			{Key: "PROJ", Label: "nightshift", Repos: []jira.RepoConfig{{Name: "repo", URL: "git@github.com:org/repo.git"}}},
+		},
 	}
 
 	out := captureStdout(t, func() {

--- a/docs/guides/workspace-management.md
+++ b/docs/guides/workspace-management.md
@@ -22,8 +22,10 @@ WorkspaceRoot/               # cfg.jira.workspace_root (default: ~/.local/share/
 ## SetupWorkspace
 
 ```go
-func SetupWorkspace(ctx context.Context, cfg JiraConfig, ticketKey string) (*Workspace, error)
+func SetupWorkspace(ctx context.Context, cfg JiraConfig, proj ProjectConfig, ticketKey string) (*Workspace, error)
 ```
+
+`cfg` provides the workspace root and cleanup settings. `proj` supplies the list of repos to clone — each project has its own repo list, so different projects can operate on different codebases in isolation.
 
 ### Validation
 

--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -34,9 +34,6 @@ func NewClient(cfg JiraConfig) (*Client, error) {
 	if cfg.TokenEnv == "" {
 		return nil, fmt.Errorf("jira: token_env is required")
 	}
-	if cfg.Project == "" {
-		return nil, fmt.Errorf("jira: project key is required")
-	}
 	apiToken := os.Getenv(cfg.TokenEnv)
 	if apiToken == "" {
 		return nil, fmt.Errorf("jira: env var %s not set", cfg.TokenEnv)

--- a/internal/jira/client_test.go
+++ b/internal/jira/client_test.go
@@ -53,16 +53,6 @@ func TestNewClient(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "missing project",
-			cfg: func() JiraConfig {
-				c := validCfg()
-				c.Project = ""
-				return c
-			}(),
-			envVal:  "test-token",
-			wantErr: true,
-		},
-		{
 			name: "missing email",
 			cfg: func() JiraConfig {
 				c := validCfg()

--- a/internal/jira/config.go
+++ b/internal/jira/config.go
@@ -76,10 +76,13 @@ type PhaseConfig struct {
 
 // mergePhaseConfig returns the project-level override merged over the global default.
 // A non-empty field in override takes precedence over the corresponding global field.
+// When Provider is overridden, the inherited Model is cleared — a model name from a
+// different provider would be invalid. An explicit Model override can still set one.
 func mergePhaseConfig(global, override PhaseConfig) PhaseConfig {
 	result := global
 	if override.Provider != "" {
 		result.Provider = override.Provider
+		result.Model = "" // clear inherited model when switching provider
 	}
 	if override.Model != "" {
 		result.Model = override.Model

--- a/internal/jira/config.go
+++ b/internal/jira/config.go
@@ -7,6 +7,21 @@ import (
 	"path/filepath"
 )
 
+// ProjectConfig defines a single Jira project with its own key, label, repos,
+// and optional per-project phase overrides that take precedence over the global
+// phase configs on JiraConfig.
+type ProjectConfig struct {
+	Key   string       `mapstructure:"key"`   // Jira project key (e.g., "PROJ")
+	Label string       `mapstructure:"label"` // label filter (e.g., "nightshift")
+	Repos []RepoConfig `mapstructure:"repos"`
+
+	// Optional per-project phase overrides; zero-value means inherit global.
+	Validation PhaseConfig `mapstructure:"validation"`
+	Plan       PhaseConfig `mapstructure:"plan"`
+	Implement  PhaseConfig `mapstructure:"implement"`
+	ReviewFix  PhaseConfig `mapstructure:"review_fix"`
+}
+
 // JiraConfig holds all Jira-related configuration.
 type JiraConfig struct {
 	// Connection
@@ -14,14 +29,17 @@ type JiraConfig struct {
 	Email    string `mapstructure:"email"`     // Jira user email for auth
 	TokenEnv string `mapstructure:"token_env"` // env var name holding API token (default: JIRA_API_TOKEN)
 
-	// Project
-	Project string `mapstructure:"project"` // Jira project key (e.g., "PROJ")
-	Label   string `mapstructure:"label"`   // label filter (e.g., "nightshift")
+	// Multi-project list (preferred). Each project has its own key, label, repos.
+	Projects []ProjectConfig `mapstructure:"projects"`
 
-	// Repos (multi-repo support)
-	Repos []RepoConfig `mapstructure:"repos"`
+	// Deprecated flat single-project fields — kept for backward compatibility.
+	// When Projects is empty and Project is non-empty, Defaults() promotes them
+	// to Projects[0] automatically.
+	Project string       `mapstructure:"project"` // deprecated: use Projects[0].Key
+	Label   string       `mapstructure:"label"`   // deprecated: use Projects[0].Label
+	Repos   []RepoConfig `mapstructure:"repos"`   // deprecated: use Projects[0].Repos
 
-	// Per-phase provider selection
+	// Per-phase provider selection (global defaults, overridable per-project).
 	Validation PhaseConfig `mapstructure:"validation"`
 	Plan       PhaseConfig `mapstructure:"plan"`
 	Implement  PhaseConfig `mapstructure:"implement"`
@@ -56,7 +74,46 @@ type PhaseConfig struct {
 	Timeout  string `mapstructure:"timeout"`  // e.g., "30m", "2m"
 }
 
+// mergePhaseConfig returns the project-level override merged over the global default.
+// A non-empty field in override takes precedence over the corresponding global field.
+func mergePhaseConfig(global, override PhaseConfig) PhaseConfig {
+	result := global
+	if override.Provider != "" {
+		result.Provider = override.Provider
+	}
+	if override.Model != "" {
+		result.Model = override.Model
+	}
+	if override.Timeout != "" {
+		result.Timeout = override.Timeout
+	}
+	return result
+}
+
+// EffectiveValidation returns the effective validation PhaseConfig for the given project.
+// The project's override takes precedence over the global default when non-empty.
+func (c *JiraConfig) EffectiveValidation(proj ProjectConfig) PhaseConfig {
+	return mergePhaseConfig(c.Validation, proj.Validation)
+}
+
+// EffectivePlan returns the effective plan PhaseConfig for the given project.
+func (c *JiraConfig) EffectivePlan(proj ProjectConfig) PhaseConfig {
+	return mergePhaseConfig(c.Plan, proj.Plan)
+}
+
+// EffectiveImplement returns the effective implement PhaseConfig for the given project.
+func (c *JiraConfig) EffectiveImplement(proj ProjectConfig) PhaseConfig {
+	return mergePhaseConfig(c.Implement, proj.Implement)
+}
+
+// EffectiveReviewFix returns the effective review-fix PhaseConfig for the given project.
+func (c *JiraConfig) EffectiveReviewFix(proj ProjectConfig) PhaseConfig {
+	return mergePhaseConfig(c.ReviewFix, proj.ReviewFix)
+}
+
 // Validate checks that required config fields are set.
+// Defaults() must be called before Validate() so that old flat fields are
+// promoted to Projects when needed.
 func (c *JiraConfig) Validate() error {
 	if c.Site == "" {
 		return fmt.Errorf("jira.site is required")
@@ -64,18 +121,23 @@ func (c *JiraConfig) Validate() error {
 	if c.Email == "" {
 		return fmt.Errorf("jira.email is required")
 	}
-	if c.Project == "" {
-		return fmt.Errorf("jira.project is required")
+	if len(c.Projects) == 0 {
+		return fmt.Errorf("jira.projects: at least one project is required")
 	}
-	if len(c.Repos) == 0 {
-		return fmt.Errorf("jira.repos: at least one repo is required")
-	}
-	for i, r := range c.Repos {
-		if r.Name == "" {
-			return fmt.Errorf("jira.repos[%d].name is required", i)
+	for i, p := range c.Projects {
+		if p.Key == "" {
+			return fmt.Errorf("jira.projects[%d].key is required", i)
 		}
-		if r.URL == "" {
-			return fmt.Errorf("jira.repos[%d].url is required", i)
+		if len(p.Repos) == 0 {
+			return fmt.Errorf("jira.projects[%d].repos: at least one repo is required", i)
+		}
+		for j, r := range p.Repos {
+			if r.Name == "" {
+				return fmt.Errorf("jira.projects[%d].repos[%d].name is required", i, j)
+			}
+			if r.URL == "" {
+				return fmt.Errorf("jira.projects[%d].repos[%d].url is required", i, j)
+			}
 		}
 	}
 	return nil
@@ -103,12 +165,13 @@ func (c *JiraConfig) Defaults() {
 	if c.MaxTickets == 0 {
 		c.MaxTickets = 10
 	}
+	// Apply base-branch defaults to the legacy flat repos list.
 	for i := range c.Repos {
 		if c.Repos[i].BaseBranch == "" {
 			c.Repos[i].BaseBranch = "main"
 		}
 	}
-	// Phase defaults
+	// Phase defaults (global)
 	if c.Validation.Provider == "" {
 		c.Validation.Provider = "claude"
 	}
@@ -144,5 +207,33 @@ func (c *JiraConfig) Defaults() {
 	}
 	if c.ReviewFix.Timeout == "" {
 		c.ReviewFix.Timeout = "20m"
+	}
+
+	// Backward compat: if no projects are configured but the old flat fields are
+	// present, auto-promote them to Projects[0].
+	if len(c.Projects) == 0 && c.Project != "" {
+		label := c.Label
+		if label == "" {
+			label = "nightshift"
+		}
+		repos := make([]RepoConfig, len(c.Repos))
+		copy(repos, c.Repos)
+		c.Projects = []ProjectConfig{{
+			Key:   c.Project,
+			Label: label,
+			Repos: repos,
+		}}
+	}
+
+	// Apply defaults to each project's repos and label.
+	for i := range c.Projects {
+		if c.Projects[i].Label == "" {
+			c.Projects[i].Label = "nightshift"
+		}
+		for j := range c.Projects[i].Repos {
+			if c.Projects[i].Repos[j].BaseBranch == "" {
+				c.Projects[i].Repos[j].BaseBranch = "main"
+			}
+		}
 	}
 }

--- a/internal/jira/config_test.go
+++ b/internal/jira/config_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestJiraConfig_Validate(t *testing.T) {
+	validProject := ProjectConfig{Key: "P", Label: "nightshift", Repos: []RepoConfig{{Name: "r", URL: "u"}}}
 	tests := []struct {
 		name    string
 		cfg     JiraConfig
@@ -13,37 +14,37 @@ func TestJiraConfig_Validate(t *testing.T) {
 	}{
 		{
 			"valid full config",
-			JiraConfig{Site: "x", Email: "a@b", Project: "P", Repos: []RepoConfig{{Name: "r", URL: "u"}}},
+			JiraConfig{Site: "x", Email: "a@b", Projects: []ProjectConfig{validProject}},
 			"",
 		},
 		{
 			"missing site",
-			JiraConfig{Email: "a@b", Project: "P", Repos: []RepoConfig{{Name: "r", URL: "u"}}},
+			JiraConfig{Email: "a@b", Projects: []ProjectConfig{validProject}},
 			"jira.site is required",
 		},
 		{
 			"missing email",
-			JiraConfig{Site: "x", Project: "P", Repos: []RepoConfig{{Name: "r", URL: "u"}}},
+			JiraConfig{Site: "x", Projects: []ProjectConfig{validProject}},
 			"jira.email is required",
 		},
 		{
 			"missing project",
-			JiraConfig{Site: "x", Email: "a@b", Repos: []RepoConfig{{Name: "r", URL: "u"}}},
-			"jira.project is required",
+			JiraConfig{Site: "x", Email: "a@b", Projects: []ProjectConfig{}},
+			"at least one project is required",
 		},
 		{
 			"no repos",
-			JiraConfig{Site: "x", Email: "a@b", Project: "P"},
+			JiraConfig{Site: "x", Email: "a@b", Projects: []ProjectConfig{{Key: "P", Label: "nightshift"}}},
 			"at least one repo",
 		},
 		{
 			"repo missing url",
-			JiraConfig{Site: "x", Email: "a@b", Project: "P", Repos: []RepoConfig{{Name: "r"}}},
+			JiraConfig{Site: "x", Email: "a@b", Projects: []ProjectConfig{{Key: "P", Label: "nightshift", Repos: []RepoConfig{{Name: "r"}}}}},
 			"repos[0].url is required",
 		},
 		{
 			"repo missing name",
-			JiraConfig{Site: "x", Email: "a@b", Project: "P", Repos: []RepoConfig{{URL: "u"}}},
+			JiraConfig{Site: "x", Email: "a@b", Projects: []ProjectConfig{{Key: "P", Label: "nightshift", Repos: []RepoConfig{{URL: "u"}}}}},
 			"repos[0].name is required",
 		},
 	}
@@ -115,5 +116,83 @@ func TestJiraConfig_Defaults_NoOverwrite(t *testing.T) {
 	}
 	if cfg.Validation.Model != "my-model" {
 		t.Errorf("Validation.Model overwritten, got %q", cfg.Validation.Model)
+	}
+}
+
+func TestJiraConfig_BackwardCompatPromotion(t *testing.T) {
+	// Old flat config with Project+Label+Repos should be promoted to Projects[0] by Defaults().
+	cfg := JiraConfig{
+		Site:     "x",
+		Email:    "a@b",
+		Project:  "VC",
+		Label:    "nightshift",
+		TokenEnv: "MY_TOKEN",
+		Repos:    []RepoConfig{{Name: "repo", URL: "git@github.com:org/repo.git", BaseBranch: "main"}},
+	}
+	cfg.Defaults()
+
+	if len(cfg.Projects) != 1 {
+		t.Fatalf("expected 1 project after promotion, got %d", len(cfg.Projects))
+	}
+	if cfg.Projects[0].Key != "VC" {
+		t.Errorf("Projects[0].Key = %q, want VC", cfg.Projects[0].Key)
+	}
+	if cfg.Projects[0].Label != "nightshift" {
+		t.Errorf("Projects[0].Label = %q, want nightshift", cfg.Projects[0].Label)
+	}
+	if len(cfg.Projects[0].Repos) != 1 || cfg.Projects[0].Repos[0].Name != "repo" {
+		t.Errorf("Projects[0].Repos not promoted correctly: %+v", cfg.Projects[0].Repos)
+	}
+
+	// Should also validate without error.
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate after backward-compat promotion: %v", err)
+	}
+}
+
+func TestJiraConfig_MultiProject(t *testing.T) {
+	cfg := JiraConfig{
+		Site:  "x",
+		Email: "a@b",
+		// Global defaults
+		Implement: PhaseConfig{Provider: "copilot", Model: "claude-sonnet-4.6", Timeout: "30m"},
+		Projects: []ProjectConfig{
+			{
+				Key:   "VC",
+				Label: "nightshift",
+				Repos: []RepoConfig{{Name: "r", URL: "u"}},
+				// No per-project override — should inherit global
+			},
+			{
+				Key:   "INFRA",
+				Label: "nightshift",
+				Repos: []RepoConfig{{Name: "infra", URL: "git@github.com:org/infra.git"}},
+				// Per-project override for implement phase
+				Implement: PhaseConfig{Timeout: "45m"},
+			},
+		},
+	}
+	cfg.Defaults()
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	// VC project inherits global implement config.
+	effVC := cfg.EffectiveImplement(cfg.Projects[0])
+	if effVC.Model != "claude-sonnet-4.6" {
+		t.Errorf("VC EffectiveImplement.Model = %q, want claude-sonnet-4.6", effVC.Model)
+	}
+	if effVC.Timeout != "30m" {
+		t.Errorf("VC EffectiveImplement.Timeout = %q, want 30m", effVC.Timeout)
+	}
+
+	// INFRA project overrides timeout but inherits model.
+	effINFRA := cfg.EffectiveImplement(cfg.Projects[1])
+	if effINFRA.Model != "claude-sonnet-4.6" {
+		t.Errorf("INFRA EffectiveImplement.Model = %q, want claude-sonnet-4.6", effINFRA.Model)
+	}
+	if effINFRA.Timeout != "45m" {
+		t.Errorf("INFRA EffectiveImplement.Timeout = %q, want 45m", effINFRA.Timeout)
 	}
 }

--- a/internal/jira/e2e_test.go
+++ b/internal/jira/e2e_test.go
@@ -32,6 +32,19 @@ func e2eClient(t *testing.T) *Client {
 	return client
 }
 
+// e2eProject returns the VC ProjectConfig used by e2e tests.
+func e2eProject() ProjectConfig {
+	return ProjectConfig{
+		Key:   "VC",
+		Label: "nightshift",
+		Repos: []RepoConfig{{
+			Name:       "nightshift",
+			URL:        "git@github.com:cedricfarinazzo/nightshift.git",
+			BaseBranch: "main",
+		}},
+	}
+}
+
 func TestE2E_Ping(t *testing.T) {
 	client := e2eClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -65,7 +78,7 @@ func TestE2E_FetchTodoTickets(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	tickets, err := client.FetchTodoTickets(ctx)
+	tickets, err := client.FetchTodoTickets(ctx, e2eProject())
 	if err != nil {
 		t.Fatalf("FetchTodoTickets: %v", err)
 	}
@@ -90,7 +103,7 @@ func TestE2E_FetchReviewTickets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DiscoverStatuses: %v", err)
 	}
-	tickets, err := client.FetchReviewTickets(ctx, sm)
+	tickets, err := client.FetchReviewTickets(ctx, e2eProject(), sm)
 	if err != nil {
 		t.Fatalf("FetchReviewTickets: %v", err)
 	}
@@ -106,7 +119,7 @@ func TestE2E_FetchReviewTickets_NilStatusMap(t *testing.T) {
 	defer cancel()
 
 	// nil statusMap must not panic and must return (nil, nil)
-	tickets, err := client.FetchReviewTickets(ctx, nil)
+	tickets, err := client.FetchReviewTickets(ctx, e2eProject(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error with nil statusMap: %v", err)
 	}
@@ -120,7 +133,7 @@ func TestE2E_DependencyGraph(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	tickets, err := client.FetchTodoTickets(ctx)
+	tickets, err := client.FetchTodoTickets(ctx, e2eProject())
 	if err != nil {
 		t.Fatalf("FetchTodoTickets: %v", err)
 	}
@@ -326,7 +339,7 @@ func TestE2E_VC6_ValidateTicket_WithStubAgent(t *testing.T) {
 	defer cancel()
 
 	// Fetch a real ticket from Jira to validate the full pipeline.
-	tickets, err := client.FetchTodoTickets(ctx)
+	tickets, err := client.FetchTodoTickets(ctx, e2eProject())
 	if err != nil {
 		t.Fatalf("FetchTodoTickets: %v", err)
 	}
@@ -356,7 +369,7 @@ func TestE2E_VC6_ValidateTicket_RejectedFlow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	tickets, err := client.FetchTodoTickets(ctx)
+	tickets, err := client.FetchTodoTickets(ctx, e2eProject())
 	if err != nil {
 		t.Fatalf("FetchTodoTickets: %v", err)
 	}
@@ -424,7 +437,12 @@ func TestE2E_VC7_SetupWorkspace_InvalidKey(t *testing.T) {
 		CleanupAfterDays: 30,
 		Repos:            []RepoConfig{{Name: "repo", URL: "git@github.com:org/repo.git", BaseBranch: "main"}},
 	}
-	_, err := SetupWorkspace(context.Background(), cfg, "invalid-key")
+	proj := ProjectConfig{
+		Key:   "VC",
+		Label: "nightshift",
+		Repos: cfg.Repos,
+	}
+	_, err := SetupWorkspace(context.Background(), cfg, proj, "invalid-key")
 	if err == nil {
 		t.Error("SetupWorkspace with invalid key should return error")
 	}
@@ -562,7 +580,7 @@ func TestE2E_VC8_ProcessTicket_WithStubAgents(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	tickets, err := client.FetchTodoTickets(ctx)
+	tickets, err := client.FetchTodoTickets(ctx, e2eProject())
 	if err != nil {
 		t.Fatalf("FetchTodoTickets: %v", err)
 	}
@@ -627,7 +645,7 @@ func TestE2E_VC8_NewOrchestrator_Defaults(t *testing.T) {
 	va := &stubAgent{name: "va"}
 	ia := &stubAgent{name: "ia"}
 
-	o := NewOrchestrator(client, client.cfg,
+	o := NewOrchestrator(client, client.cfg, e2eProject(),
 		WithValidationAgent(va),
 		WithImplAgent(ia),
 	)
@@ -747,7 +765,7 @@ func TestE2E_VC10_BuildReworkPrompt_RealTicket(t *testing.T) {
 		t.Fatalf("DiscoverStatuses: %v", err)
 	}
 
-	tickets, err := client.FetchReviewTickets(ctx, sm)
+	tickets, err := client.FetchReviewTickets(ctx, e2eProject(), sm)
 	if err != nil {
 		t.Fatalf("FetchReviewTickets: %v", err)
 	}

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -151,13 +151,14 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 
 			// Build a prompt from the review comments and execute the agent.
 			prompt := buildReworkPrompt(ticket, reviewState, repo)
-			timeout := parseTimeout(o.cfg.ReviewFix.Timeout, 20*time.Minute)
-			o.emit("🤖 %s running: review-fix  (%s, timeout %s)", o.cfg.ReviewFix.Provider, o.cfg.ReviewFix.Model, timeout.Round(time.Minute))
+			rfCfg := o.cfg.EffectiveReviewFix(o.proj)
+			timeout := parseTimeout(rfCfg.Timeout, 20*time.Minute)
+			o.emit("🤖 %s running: review-fix  (%s, timeout %s)", rfCfg.Provider, rfCfg.Model, timeout.Round(time.Minute))
 			agentResult, err := agent.Execute(ctx, agents.ExecuteOptions{
 				Prompt:  prompt,
 				WorkDir: repo.Path,
 				Timeout: timeout,
-				Model:   o.cfg.ReviewFix.Model,
+				Model:   rfCfg.Model,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("jira: feedback: rework agent %s: %w", repo.Name, err)

--- a/internal/jira/mock_server_test.go
+++ b/internal/jira/mock_server_test.go
@@ -143,6 +143,15 @@ func newMockJiraClient(t *testing.T, cfg mockServerConfig) (*Client, *httptest.S
 	return client, srv
 }
 
+// mockProject returns the ProjectConfig matching the default mock server config.
+func mockProject() ProjectConfig {
+	return ProjectConfig{
+		Key:   "VC",
+		Label: "nightshift",
+		Repos: []RepoConfig{{Name: "repo", URL: "git@github.com:org/repo.git", BaseBranch: "main"}},
+	}
+}
+
 // ── Ping ─────────────────────────────────────────────────────────────────────
 
 func TestClientPing_Success(t *testing.T) {
@@ -444,7 +453,7 @@ func TestFetchTodoTickets_Empty(t *testing.T) {
 	client, srv := newMockJiraClient(t, defaultMockConfig())
 	defer srv.Close()
 
-	tickets, err := client.FetchTodoTickets(testCtx(t))
+	tickets, err := client.FetchTodoTickets(testCtx(t), mockProject())
 	if err != nil {
 		t.Fatalf("FetchTodoTickets() error = %v", err)
 	}
@@ -469,7 +478,7 @@ func TestFetchTodoTickets_WithResults(t *testing.T) {
 	client, srv := newMockJiraClient(t, cfg)
 	defer srv.Close()
 
-	tickets, err := client.FetchTodoTickets(testCtx(t))
+	tickets, err := client.FetchTodoTickets(testCtx(t), mockProject())
 	if err != nil {
 		t.Fatalf("FetchTodoTickets() error = %v", err)
 	}
@@ -488,7 +497,7 @@ func TestFetchReviewTickets_NilStatusMap(t *testing.T) {
 	client, srv := newMockJiraClient(t, defaultMockConfig())
 	defer srv.Close()
 
-	tickets, err := client.FetchReviewTickets(testCtx(t), nil)
+	tickets, err := client.FetchReviewTickets(testCtx(t), mockProject(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -509,7 +518,7 @@ func TestFetchReviewTickets_WithStatusMap(t *testing.T) {
 		t.Fatalf("DiscoverStatuses: %v", err)
 	}
 
-	tickets, err := client.FetchReviewTickets(testCtx(t), sm)
+	tickets, err := client.FetchReviewTickets(testCtx(t), mockProject(), sm)
 	if err != nil {
 		t.Fatalf("FetchReviewTickets() error = %v", err)
 	}

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -60,6 +60,7 @@ type Orchestrator struct {
 	cfg             JiraConfig
 	proj            ProjectConfig // the specific project this orchestrator serves
 	validationAgent agents.Agent
+	planAgent       agents.Agent // nil falls back to implAgent at runtime
 	implAgent       agents.Agent
 	reviewFixAgent  agents.Agent
 	skipValidation  bool
@@ -88,8 +89,15 @@ func WithValidationAgent(a agents.Agent) OrchestratorOption {
 }
 
 // WithImplAgent sets the agent used for planning and implementation.
+// When no WithPlanAgent option is provided, this agent is also used for planning.
 func WithImplAgent(a agents.Agent) OrchestratorOption {
 	return func(o *Orchestrator) { o.implAgent = a }
+}
+
+// WithPlanAgent sets the agent used for generating the implementation plan.
+// When not set, the impl agent is used as fallback.
+func WithPlanAgent(a agents.Agent) OrchestratorOption {
+	return func(o *Orchestrator) { o.planAgent = a }
 }
 
 // WithReviewFixAgent sets the agent used for addressing PR review feedback.
@@ -365,7 +373,11 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 		planCfg := o.cfg.EffectivePlan(o.proj)
 		o.emit("🤖 %s running: plan  (%s)", planCfg.Provider, planCfg.Model)
 		planStart := time.Now()
-		planResult, err := o.implAgent.Execute(ctx, agents.ExecuteOptions{
+		planAgent := o.planAgent
+		if planAgent == nil {
+			planAgent = o.implAgent
+		}
+		planResult, err := planAgent.Execute(ctx, agents.ExecuteOptions{
 			Prompt:  o.buildPlanPrompt(ticket),
 			Timeout: parseTimeout(planCfg.Timeout, 5*time.Minute),
 			Model:   planCfg.Model,

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -58,6 +58,7 @@ type jiraClient interface {
 type Orchestrator struct {
 	client          jiraClient
 	cfg             JiraConfig
+	proj            ProjectConfig // the specific project this orchestrator serves
 	validationAgent agents.Agent
 	implAgent       agents.Agent
 	reviewFixAgent  agents.Agent
@@ -113,11 +114,12 @@ func WithProgressPrinter(fn func(format string, args ...any)) OrchestratorOption
 	return func(o *Orchestrator) { o.progressf = fn }
 }
 
-// NewOrchestrator creates an Orchestrator with the given client, config, and options.
-func NewOrchestrator(client *Client, cfg JiraConfig, opts ...OrchestratorOption) *Orchestrator {
+// NewOrchestrator creates an Orchestrator with the given client, config, project, and options.
+func NewOrchestrator(client *Client, cfg JiraConfig, proj ProjectConfig, opts ...OrchestratorOption) *Orchestrator {
 	o := &Orchestrator{
 		client:          client,
 		cfg:             cfg,
+		proj:            proj,
 		log:             logging.Component("jira.orchestrator"),
 		fnHasChanges:    HasChanges,
 		fnCommitAndPush: CommitAndPush,
@@ -350,12 +352,13 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	if !skip(PhasePlan) {
 		result.Phase = PhasePlan
 		o.notifyPhase(ticket.Key, PhasePlan, false)
-		o.emit("🤖 %s running: plan  (%s)", o.cfg.Plan.Provider, o.cfg.Plan.Model)
+		planCfg := o.cfg.EffectivePlan(o.proj)
+		o.emit("🤖 %s running: plan  (%s)", planCfg.Provider, planCfg.Model)
 		planStart := time.Now()
 		planResult, err := o.implAgent.Execute(ctx, agents.ExecuteOptions{
 			Prompt:  o.buildPlanPrompt(ticket),
-			Timeout: parseTimeout(o.cfg.Plan.Timeout, 5*time.Minute),
-			Model:   o.cfg.Plan.Model,
+			Timeout: parseTimeout(planCfg.Timeout, 5*time.Minute),
+			Model:   planCfg.Model,
 		})
 		if err != nil {
 			o.postErrorComment(ctx, ticket.Key, PhasePlan, err)
@@ -377,8 +380,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	if !skip(PhaseImplement) {
 		result.Phase = PhaseImplement
 		o.notifyPhase(ticket.Key, PhaseImplement, false)
-		timeout := parseTimeout(o.cfg.Implement.Timeout, 30*time.Minute)
-		o.emit("🤖 %s running: implement  (%s, timeout %s)", o.cfg.Implement.Provider, o.cfg.Implement.Model, timeout.Round(time.Minute))
+		implCfg := o.cfg.EffectiveImplement(o.proj)
+		timeout := parseTimeout(implCfg.Timeout, 30*time.Minute)
+		o.emit("🤖 %s running: implement  (%s, timeout %s)", implCfg.Provider, implCfg.Model, timeout.Round(time.Minute))
 		implStart := time.Now()
 		workDir := ""
 		if ws != nil && len(ws.Repos) > 0 {
@@ -388,7 +392,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			Prompt:  o.buildImplementPrompt(ticket, result.Plan, ws),
 			WorkDir: workDir,
 			Timeout: timeout,
-			Model:   o.cfg.Implement.Model,
+			Model:   implCfg.Model,
 		})
 		if err != nil {
 			o.postErrorComment(ctx, ticket.Key, PhaseImplement, err)
@@ -702,11 +706,14 @@ func buildPRImplementationComment(ticket Ticket, summary, jiraSite string) strin
 func (o *Orchestrator) providerForCommentType(ct CommentType) (provider, model string) {
 	switch ct {
 	case CommentValidation:
-		return o.cfg.Validation.Provider, o.cfg.Validation.Model
+		cfg := o.cfg.EffectiveValidation(o.proj)
+		return cfg.Provider, cfg.Model
 	case CommentPlan:
-		return o.cfg.Plan.Provider, o.cfg.Plan.Model
+		cfg := o.cfg.EffectivePlan(o.proj)
+		return cfg.Provider, cfg.Model
 	default:
-		return o.cfg.Implement.Provider, o.cfg.Implement.Model
+		cfg := o.cfg.EffectiveImplement(o.proj)
+		return cfg.Provider, cfg.Model
 	}
 }
 

--- a/internal/jira/tickets.go
+++ b/internal/jira/tickets.go
@@ -48,11 +48,11 @@ type IssueLink struct {
 const searchPageSize = 50
 const acKeyword = "acceptance criteria"
 
-// FetchTodoTickets fetches issues in the "To Do" status category filtered by the configured label.
-func (c *Client) FetchTodoTickets(ctx context.Context) ([]Ticket, error) {
+// FetchTodoTickets fetches issues in the "To Do" status category filtered by the project's label.
+func (c *Client) FetchTodoTickets(ctx context.Context, proj ProjectConfig) ([]Ticket, error) {
 	jql := fmt.Sprintf(
 		`project = "%s" AND statusCategory = "To Do" AND labels = "%s" ORDER BY created ASC`,
-		c.cfg.Project, c.cfg.Label,
+		proj.Key, proj.Label,
 	)
 	tickets, err := c.fetchTickets(ctx, jql)
 	if err != nil {
@@ -62,9 +62,9 @@ func (c *Client) FetchTodoTickets(ctx context.Context) ([]Ticket, error) {
 }
 
 // FetchInProgressTickets fetches issues that are in a non-review "indeterminate" status,
-// filtered by the configured label. These are tickets that were started by nightshift but
+// filtered by the project's label. These are tickets that were started by nightshift but
 // failed mid-run (e.g. during plan or implement) and need to be resumed.
-func (c *Client) FetchInProgressTickets(ctx context.Context, statusMap *StatusMap) ([]Ticket, error) {
+func (c *Client) FetchInProgressTickets(ctx context.Context, proj ProjectConfig, statusMap *StatusMap) ([]Ticket, error) {
 	if statusMap == nil || len(statusMap.InProgressStatuses) == 0 {
 		return nil, nil
 	}
@@ -74,7 +74,7 @@ func (c *Client) FetchInProgressTickets(ctx context.Context, statusMap *StatusMa
 	}
 	jql := fmt.Sprintf(
 		`project = "%s" AND status in (%s) AND labels = "%s" ORDER BY created ASC`,
-		c.cfg.Project, strings.Join(names, ", "), c.cfg.Label,
+		proj.Key, strings.Join(names, ", "), proj.Label,
 	)
 	tickets, err := c.fetchTickets(ctx, jql)
 	if err != nil {
@@ -83,8 +83,8 @@ func (c *Client) FetchInProgressTickets(ctx context.Context, statusMap *StatusMa
 	return c.fetchParentDescriptions(ctx, tickets), nil
 }
 
-// FetchReviewTickets fetches issues that are in a review status, filtered by the configured label.
-func (c *Client) FetchReviewTickets(ctx context.Context, statusMap *StatusMap) ([]Ticket, error) {
+// FetchReviewTickets fetches issues that are in a review status, filtered by the project's label.
+func (c *Client) FetchReviewTickets(ctx context.Context, proj ProjectConfig, statusMap *StatusMap) ([]Ticket, error) {
 	if statusMap == nil || len(statusMap.ReviewStatuses) == 0 {
 		return nil, nil
 	}
@@ -94,7 +94,7 @@ func (c *Client) FetchReviewTickets(ctx context.Context, statusMap *StatusMap) (
 	}
 	jql := fmt.Sprintf(
 		`project = "%s" AND status in (%s) AND labels = "%s" ORDER BY created ASC`,
-		c.cfg.Project, strings.Join(names, ", "), c.cfg.Label,
+		proj.Key, strings.Join(names, ", "), proj.Label,
 	)
 	tickets, err := c.fetchTickets(ctx, jql)
 	if err != nil {

--- a/internal/jira/workspace.go
+++ b/internal/jira/workspace.go
@@ -32,13 +32,13 @@ type RepoWorkspace struct {
 }
 
 // SetupWorkspace creates (or reuses) an isolated workspace for ticketKey.
-// Each configured repo is cloned into {WorkspaceRoot}/{ticketKey}/{repo.Name}
+// Each repo configured in proj is cloned into {WorkspaceRoot}/{ticketKey}/{repo.Name}
 // and checked out on feature/{ticketKey}.
-func SetupWorkspace(ctx context.Context, cfg JiraConfig, ticketKey string) (*Workspace, error) {
+func SetupWorkspace(ctx context.Context, cfg JiraConfig, proj ProjectConfig, ticketKey string) (*Workspace, error) {
 	if !validTicketKey.MatchString(ticketKey) {
 		return nil, fmt.Errorf("invalid ticket key %q: must match ^[A-Z][A-Z0-9]+-\\d+$", ticketKey)
 	}
-	for _, r := range cfg.Repos {
+	for _, r := range proj.Repos {
 		if strings.ContainsAny(r.Name, `/\`) || strings.Contains(r.Name, "..") {
 			return nil, fmt.Errorf("repo name %q contains path separators or '..'", r.Name)
 		}
@@ -53,8 +53,8 @@ func SetupWorkspace(ctx context.Context, cfg JiraConfig, ticketKey string) (*Wor
 	}
 
 	branch := BranchName(ticketKey)
-	repos := make([]RepoWorkspace, 0, len(cfg.Repos))
-	for _, r := range cfg.Repos {
+	repos := make([]RepoWorkspace, 0, len(proj.Repos))
+	for _, r := range proj.Repos {
 		repoPath := filepath.Join(wsRoot, r.Name)
 		if _, err := os.Stat(repoPath); err != nil {
 			if !os.IsNotExist(err) {

--- a/internal/jira/workspace_test.go
+++ b/internal/jira/workspace_test.go
@@ -148,11 +148,15 @@ func TestSetupWorkspace_InvalidTicketKey(t *testing.T) {
 	cfg := JiraConfig{
 		WorkspaceRoot:    t.TempDir(),
 		CleanupAfterDays: 30,
-		Repos:            []RepoConfig{{Name: "repo", URL: "git@github.com:org/repo.git", BaseBranch: "main"}},
+	}
+	proj := ProjectConfig{
+		Key:   "PROJ",
+		Label: "nightshift",
+		Repos: []RepoConfig{{Name: "repo", URL: "git@github.com:org/repo.git", BaseBranch: "main"}},
 	}
 	ctx := context.Background()
 	for _, bad := range []string{"../escape", "proj-1", "PROJ", "PROJ-", "PROJ-abc", ""} {
-		_, err := SetupWorkspace(ctx, cfg, bad)
+		_, err := SetupWorkspace(ctx, cfg, proj, bad)
 		if err == nil {
 			t.Errorf("SetupWorkspace with key %q should fail", bad)
 		}
@@ -163,9 +167,13 @@ func TestSetupWorkspace_InvalidRepoName(t *testing.T) {
 	cfg := JiraConfig{
 		WorkspaceRoot:    t.TempDir(),
 		CleanupAfterDays: 30,
-		Repos:            []RepoConfig{{Name: "../evil", URL: "git@github.com:org/repo.git", BaseBranch: "main"}},
 	}
-	_, err := SetupWorkspace(context.Background(), cfg, "PROJ-1")
+	proj := ProjectConfig{
+		Key:   "PROJ",
+		Label: "nightshift",
+		Repos: []RepoConfig{{Name: "../evil", URL: "git@github.com:org/repo.git", BaseBranch: "main"}},
+	}
+	_, err := SetupWorkspace(context.Background(), cfg, proj, "PROJ-1")
 	if err == nil {
 		t.Error("SetupWorkspace with repo name '../evil' should fail")
 	}

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -172,17 +172,17 @@ logging:
 
 ## Jira Autonomous Pipeline
 
-Configure the Jira pipeline to autonomously implement, commit, and PR Jira tickets:
+Configure the Jira pipeline to autonomously implement, commit, and PR Jira tickets.
+
+### Multi-project config (recommended)
 
 ```yaml
 jira:
-  site: "https://yourorg.atlassian.net"
-  token: ""                 # Use NIGHTSHIFT_JIRA_TOKEN env var instead
+  site: "yourorg"              # Atlassian site name (yourorg.atlassian.net)
   email: "you@example.com"
-  project: "PROJ"
-  label: "nightshift"       # Only tickets with this label are processed
+  token_env: NIGHTSHIFT_JIRA_TOKEN   # env var holding the API token
 
-  # AI agent phases
+  # Global AI agent phases — shared by all projects, overridable per-project
   validation:
     provider: copilot
     model: gpt-5.4-mini
@@ -197,29 +197,49 @@ jira:
     timeout: 30m
   review_fix:
     provider: copilot
-    model: gpt-5.4-mini
+    model: claude-sonnet-4.6
     timeout: 20m
 
-  # Git workspace settings
-  workspace_root: "~/.local/share/nightshift/jira-workspaces"
-  cleanup_after_days: 14
+  budget_enabled: true
+  max_tickets: 10
 
-  # Repositories to operate on
+  projects:
+    - key: VC
+      label: nightshift
+      repos:
+        - name: nightshift
+          url: "git@github.com:org/nightshift.git"   # SSH URL required
+          base_branch: main
+
+    - key: INFRA
+      label: nightshift
+      repos:
+        - name: infra
+          url: "git@github.com:org/infra.git"
+          base_branch: trunk
+      # Optional per-project phase override (inherits global if omitted):
+      implement:
+        timeout: 45m
+```
+
+### Backward-compatible single-project config
+
+Old configs with flat `project`, `label`, and `repos` fields continue to work:
+
+```yaml
+jira:
+  site: "yourorg"
+  email: "you@example.com"
+  token_env: NIGHTSHIFT_JIRA_TOKEN
+  project: "PROJ"
+  label: "nightshift"
   repos:
     - name: myrepo
-      url: "git@github.com:org/myrepo.git"   # SSH URL required
+      url: "git@github.com:org/myrepo.git"
       base_branch: main
-      lint_command: "golangci-lint run ./..."
-      test_command: "go test ./..."
-
-  # Jira status names (auto-discovered; set explicitly if discovery fails)
-  statuses:
-    todo: "To Do"
-    in_progress: "In Progress"
-    review: "In Review"
-    done: "Done"
-    needs_info: "Needs Info"
 ```
+
+Nightshift automatically promotes these to a single `Projects[0]` entry on startup.
 
 ### Jira environment variables
 

--- a/website/docs/jira.md
+++ b/website/docs/jira.md
@@ -66,12 +66,11 @@ Find or create a token at: https://id.atlassian.com/manage-profile/security/api-
 
 ```yaml
 jira:
-  site: "https://yourorg.atlassian.net"
+  site: "yourorg"           # Atlassian site name (yourorg.atlassian.net)
   email: "you@example.com"
-  project: "PROJ"
-  label: "nightshift"
+  token_env: NIGHTSHIFT_JIRA_TOKEN
 
-  # Phases — configure provider/model/timeout per phase
+  # Phases — global defaults, overridable per project
   validation:
     provider: copilot
     model: gpt-5.4-mini
@@ -86,19 +85,53 @@ jira:
     timeout: 30m
   review_fix:
     provider: copilot
-    model: gpt-5.4-mini
+    model: claude-sonnet-4.6
     timeout: 20m
 
-  # Workspace (repos cloned here; reused across runs)
-  workspace_root: "~/.local/share/nightshift/jira-workspaces"
-  cleanup_after_days: 14
+  budget_enabled: true
+  max_tickets: 10
 
-  # Repos the agent will operate on (SSH URL required)
-  repos:
-    - name: myrepo
-      url: "git@github.com:org/myrepo.git"
-      base_branch: main
+  projects:
+    - key: PROJ
+      label: nightshift
+      repos:
+        - name: myrepo
+          url: "git@github.com:org/myrepo.git"  # SSH URL required
+          base_branch: main
 ```
+
+#### Multi-project example
+
+```yaml
+jira:
+  site: "yourorg"
+  email: "you@example.com"
+  token_env: NIGHTSHIFT_JIRA_TOKEN
+
+  implement:
+    provider: copilot
+    model: claude-sonnet-4.6
+    timeout: 30m
+
+  projects:
+    - key: WEBAPP
+      label: nightshift
+      repos:
+        - name: webapp
+          url: "git@github.com:org/webapp.git"
+          base_branch: main
+
+    - key: INFRA
+      label: nightshift
+      repos:
+        - name: infra
+          url: "git@github.com:org/infra.git"
+          base_branch: trunk
+      implement:
+        timeout: 45m   # longer timeout for infrastructure changes
+```
+
+`nightshift jira run` iterates all projects, fetching and processing tickets from each independently.
 
 ### 3. Label your tickets
 


### PR DESCRIPTION
## VC-55 — Support multiple Jira projects in nightshift jira config

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-55

### Description

Problem
JiraConfig currently models a single Jira project (project string + a flat repos list). All repos are shared across every ticket regardless of which project they belong to. This makes it impossible to run nightshift across multiple independent Jira projects, each backed by different repositories.
Desired Behaviour
jira.projects becomes a list of project entries. Each project declares its own Jira key, label filter, and repo list:
jira:
  site: mysite
  email: bot@example.com

  projects:
    - key: VC
      label: nightshift
      repos:
        - name: my-api
          url: git@github.com:org/my-api.git
          base_branch: main
        - name: my-frontend
          url: git@github.com:org/my-frontend.git

    - key: INFRA
      label: nightshift
      repos:
        - name: infra-terraform
          url: git@github.com:org/infra.git
          base_branch: trunk

  # shared phase config, overridable per-project
  validation:
    provider: copilot
    model: gpt-5.4-mini
    timeout: 2m
  implement:
    provider: copilot
    model: claude-sonnet-4.6
    timeout: 30m
nightshift jira run and nightshift jira preview iterate over all configured projects, fetch tickets from each, and dispatch them independently.
Scope
internal/jira/config.go
Add ProjectConfig struct: Key, Label, Repos []RepoConfig, optional per-project phase overrides (inheriting from top-level if empty)
Replace JiraConfig.Project string + JiraConfig.Repos []RepoConfig + JiraConfig.Label string with JiraConfig.Projects []ProjectConfig
Keep backward-compat single-project sugar: if jira.project is set (old config), auto-promote it into Projects[0]
Update Validate(): require len(Projects) >= 1; validate each project has key and at least one repo
Update Defaults(): apply repo/phase defaults per project
internal/jira/tickets.go
FetchTodoTickets(ctx, client, cfg) → FetchTodoTickets(ctx, client, project ProjectConfig) (called per-project)
Same for FetchReviewTickets
internal/jira/workspace.go
SetupWorkspace(ctx, cfg JiraConfig, ticketKey) → accept project ProjectConfig to pick the right repos
internal/jira/orchestrator.go
ProcessTicket receives the ProjectConfig for its ticket so it uses the correct repos and label
Orchestrator top-level loop iterates over cfg.Projects
cmd/nightshift/commands/jira_run.go + jira_preview.go
Loop over cfg.Jira.Projects, collect tickets from each, dispatch
Tests
Update all unit tests that construct JiraConfig directly
Add a test for backward-compat single-project promotion
Docs
Update website/docs/configuration.md — new projects block
Update website/docs/jira.md — multi-project config example
Update docs/guides/workspace-management.md — per-project repos

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
