### PR TITLE
[VC-56] review_fix agent has no ticket context (description, AC, comments missing from rework prompt)

### DIFF
--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -238,8 +238,20 @@ func hasActionableComments(rs *PRReviewState) bool {
 }
 
 // buildReworkPrompt constructs the agent prompt from PR review comments.
+// Ticket context (title, description, AC, comments) is prepended so the agent
+// can cross-reference the original intent while addressing feedback.
 func buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace) string {
 	var b strings.Builder
+
+	// Ticket context — mirrors buildPlanPrompt / buildImplementPrompt pattern.
+	fmt.Fprintf(&b, "## Ticket\nKey: %s\nTitle: %s\n", ticket.Key, ticket.Summary)
+	fmt.Fprintf(&b, "Description:\n%s\n", ticket.Description)
+	if ticket.AcceptanceCriteria != "" {
+		fmt.Fprintf(&b, "\nAcceptance Criteria:\n%s\n", ticket.AcceptanceCriteria)
+	}
+	buildCommentsSection(&b, ticket)
+	b.WriteString("\n---\n\n")
+
 	fmt.Fprintf(&b, "## Review Feedback for %s\n\n", ticket.Key)
 	fmt.Fprintf(&b, "PR: %s\nRepo: %s (branch: %s)\n\n", review.URL, repo.Name, repo.Branch)
 	b.WriteString("### Reviewer Comments\n\n")

--- a/internal/jira/feedback_test.go
+++ b/internal/jira/feedback_test.go
@@ -41,7 +41,15 @@ func TestFilterNewComments(t *testing.T) {
 // ── buildReworkPrompt ─────────────────────────────────────────────────────────
 
 func TestBuildReworkPrompt(t *testing.T) {
-	ticket := Ticket{Key: "VC-10", Summary: "feedback loop"}
+	ticket := Ticket{
+		Key:                "VC-10",
+		Summary:            "feedback loop",
+		Description:        "Implement the PR feedback loop for review-fix.",
+		AcceptanceCriteria: "Agent addresses all reviewer comments.",
+		Comments: []Comment{
+			{Author: "alice", Body: "please also check edge cases"},
+		},
+	}
 	review := &PRReviewState{
 		URL:            "https://github.com/org/repo/pull/42",
 		ReviewDecision: "CHANGES_REQUESTED",
@@ -60,7 +68,14 @@ func TestBuildReworkPrompt(t *testing.T) {
 	prompt := buildReworkPrompt(ticket, review, repo)
 
 	mustContain := []string{
+		// Ticket context
 		"VC-10",
+		"feedback loop",                           // Summary
+		"Implement the PR feedback loop",          // Description
+		"Agent addresses all reviewer comments",   // AcceptanceCriteria
+		"please also check edge cases",            // Comment body
+		"alice",                                   // Comment author
+		// PR review context
 		"https://github.com/org/repo/pull/42",
 		"nightshift",
 		"feature/VC-10",
@@ -83,6 +98,31 @@ func TestBuildReworkPrompt(t *testing.T) {
 	// General comment without path must NOT appear as inline.
 	if strings.Contains(prompt, "general comment no path") {
 		t.Error("prompt should not include general comments in inline section")
+	}
+}
+
+func TestBuildReworkPrompt_NoAcceptanceCriteria(t *testing.T) {
+	ticket := Ticket{
+		Key:         "VC-10",
+		Summary:     "feedback loop",
+		Description: "Some description.",
+		// AcceptanceCriteria intentionally empty
+	}
+	review := &PRReviewState{
+		URL: "https://github.com/org/repo/pull/1",
+		Reviews: []Review{
+			{Author: "alice", State: "CHANGES_REQUESTED", Body: "fix it"},
+		},
+	}
+	repo := RepoWorkspace{Name: "nightshift", Branch: "feature/VC-10"}
+
+	prompt := buildReworkPrompt(ticket, review, repo)
+
+	if strings.Contains(prompt, "Acceptance Criteria") {
+		t.Error("prompt should not include Acceptance Criteria section when empty")
+	}
+	if !strings.Contains(prompt, "Some description.") {
+		t.Error("prompt missing Description")
 	}
 }
 


### PR DESCRIPTION
## VC-56 — review_fix agent has no ticket context (description, AC, comments missing from rework prompt)

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-56

### Description

Bug
buildReworkPrompt (in internal/jira/feedback.go:240) only provides GitHub PR review state (reviewer body + inline comments) to the review-fix agent. The Jira ticket's title, description, acceptance criteria, and comments are entirely absent.
Every other phase (validate, plan, implement) includes full ticket context via buildCommentsSection and the ticket struct fields. The review_fix phase is the only one that does not.
Impact
If a reviewer says "this doesn't match the acceptance criteria", the agent has no idea what those criteria were
The agent cannot cross-reference the original intent of the ticket while addressing feedback
Rework quality is lower than it should be; the agent may address the literal review comment but miss the broader acceptance criteria
Root Cause
buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace) receives the ticket argument but only uses ticket.Key for the header line:
fmt.Fprintf(&b, "## Review Feedback for %s\n\n", ticket.Key)
The ticket's Summary, Description, AcceptanceCriteria, and Comments are never written to the prompt.
Fix
Prepend ticket context to the rework prompt, before the reviewer feedback section, reusing the existing buildCommentsSection helper:
// Ticket context
fmt.Fprintf(&b, "## Ticket\nKey: %s\nTitle: %s\n", ticket.Key, ticket.Summary)
fmt.Fprintf(&b, "Description:\n%s\n", ticket.Description)
if ticket.AcceptanceCriteria != "" {
    fmt.Fprintf(&b, "\nAcceptance Criteria:\n%s\n", ticket.AcceptanceCriteria)
}
buildCommentsSection(&b, ticket)
b.WriteString("\n---\n\n")
// then the existing reviewer comments / inline comments sections
Affected files
internal/jira/feedback.go — buildReworkPrompt function
internal/jira/feedback_test.go — add assertion that ticket fields appear in the prompt
Acceptance Criteria
buildReworkPrompt output includes ticket key, summary, description, acceptance criteria, and Jira comments
Existing TestBuildReworkPrompt (or equivalent) is extended to assert ticket context is present
go test ./internal/jira/... passes

### Acceptance Criteria

buildReworkPrompt output includes ticket key, summary, description, acceptance criteria, and Jira comments
Existing TestBuildReworkPrompt (or equivalent) is extended to assert ticket context is present
go test ./internal/jira/... passes

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
