### PR TITLE
[VC-48] Setup Wizard: Jira Integration Step

### DIFF
--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -86,12 +86,23 @@ type modelOption struct {
 var modelProviderLists = []*[]modelOption{&claudeModels, &codexModels, &copilotModels}
 
 // jiraPhaseModels lists Claude model options used for Jira phase configuration.
+// Kept as a named slice so jiraModelIndex() and its tests remain stable.
 var jiraPhaseModels = []string{
 	"claude-haiku-4.5",
 	"claude-sonnet-4.5",
 	"claude-sonnet-4.6",
 	"claude-opus-4.5",
 	"claude-opus-4.6",
+}
+
+// jiraProviders lists providers selectable for Jira phase configuration.
+var jiraProviders = []string{"claude", "codex", "copilot"}
+
+// jiraPhaseModelsByProvider maps each provider to its model list for Jira phases.
+var jiraPhaseModelsByProvider = map[string][]string{
+	"claude":  jiraPhaseModels,
+	"codex":   {"gpt-5.2-codex", "gpt-5.3-codex", "gpt-5.2"},
+	"copilot": {"claude-haiku-4.5", "claude-sonnet-4.5", "claude-sonnet-4.6", "claude-opus-4.5"},
 }
 
 // claudeModels lists available Claude models.
@@ -165,10 +176,10 @@ type setupModel struct {
 
 	safetyCursor int
 
-	modelCursor      int
-	claudeModelIdx   int
-	codexModelIdx    int
-	copilotModelIdx  int
+	modelCursor     int
+	claudeModelIdx  int
+	codexModelIdx   int
+	copilotModelIdx int
 
 	taskPresetCursor int
 	taskCursor       int
@@ -211,27 +222,28 @@ type setupModel struct {
 	daemonAction string
 
 	// Jira step state
-	jiraSubStep        int
-	jiraInput          textinput.Model
-	jiraEnableCursor   int
-	jiraEnabled        bool
-	jiraSite           string
-	jiraEmail          string
-	jiraTokenEnv       string
-	jiraProjectKey     string
-	jiraLabel          string
-	jiraMaxTickets     int
-	jiraRepos          []jiraRepoEntry
-	jiraRepoCursor     int
-	jiraRepoEditing    bool
-	jiraRepoField      int
-	jiraRepoEditURL    string
-	jiraPhaseCursor    int
-	jiraPhaseModelIdx  [4]int
-	jiraPinging        bool
-	jiraPingOK         bool
-	jiraPingErr        string
-	jiraErr            string
+	jiraSubStep       int
+	jiraInput         textinput.Model
+	jiraEnableCursor  int
+	jiraEnabled       bool
+	jiraSite          string
+	jiraEmail         string
+	jiraTokenEnv      string
+	jiraProjectKey    string
+	jiraLabel         string
+	jiraMaxTickets    int
+	jiraRepos         []jiraRepoEntry
+	jiraRepoCursor    int
+	jiraRepoEditing   bool
+	jiraRepoField     int
+	jiraRepoEditURL   string
+	jiraPhaseCursor   int
+	jiraPhaseModelIdx [4]int
+	jiraPhaseProvider [4]string // provider per phase: claude, codex, or copilot
+	jiraPinging       bool
+	jiraPingOK        bool
+	jiraPingErr       string
+	jiraErr           string
 
 	spinner spinner.Model
 }
@@ -337,37 +349,33 @@ func newSetupModel() (*setupModel, error) {
 	includePathStep := !nightshiftInPath
 
 	model := &setupModel{
-		step:             stepWelcome,
-		cfg:              cfg,
-		configPath:       configPath,
-		configExist:      configExist,
-		includePathStep:  includePathStep,
-		projects:         projects,
-		projectInput:     projectInput,
-		budgetInput:      budgetInput,
-		taskItems:        taskItems,
-		preset:           preset,
-		scheduleMode:     "interval",
-		scheduleStart:    "22:00",
-		scheduleCycles:   3,
-		scheduleInterval: "30m",
-		scheduleCron:     "0 2 * * *",
-		scheduleInput:    scheduleInput,
-		spinner:          spin,
-		nightshiftInPath: nightshiftInPath,
-		claudeModelIdx:   modelIndex(claudeModels, cfg.Providers.Claude.Model),
-		codexModelIdx:    modelIndex(codexModels, cfg.Providers.Codex.Model),
-		copilotModelIdx:  modelIndex(copilotModels, cfg.Providers.Copilot.Model),
-		jiraInput:        jiraInput,
-		jiraTokenEnv:     "JIRA_API_TOKEN",
-		jiraLabel:        "nightshift",
-		jiraMaxTickets:   10,
-		jiraPhaseModelIdx: [4]int{
-			jiraModelIndex("claude-haiku-4.5"),
-			jiraModelIndex("claude-sonnet-4.5"),
-			jiraModelIndex("claude-sonnet-4.5"),
-			jiraModelIndex("claude-sonnet-4.5"),
-		},
+		step:              stepWelcome,
+		cfg:               cfg,
+		configPath:        configPath,
+		configExist:       configExist,
+		includePathStep:   includePathStep,
+		projects:          projects,
+		projectInput:      projectInput,
+		budgetInput:       budgetInput,
+		taskItems:         taskItems,
+		preset:            preset,
+		scheduleMode:      "interval",
+		scheduleStart:     "22:00",
+		scheduleCycles:    3,
+		scheduleInterval:  "30m",
+		scheduleCron:      "0 2 * * *",
+		scheduleInput:     scheduleInput,
+		spinner:           spin,
+		nightshiftInPath:  nightshiftInPath,
+		claudeModelIdx:    modelIndex(claudeModels, cfg.Providers.Claude.Model),
+		codexModelIdx:     modelIndex(codexModels, cfg.Providers.Codex.Model),
+		copilotModelIdx:   modelIndex(copilotModels, cfg.Providers.Copilot.Model),
+		jiraInput:         jiraInput,
+		jiraTokenEnv:      "JIRA_API_TOKEN",
+		jiraLabel:         "nightshift",
+		jiraMaxTickets:    10,
+		jiraPhaseProvider: defaultJiraPhaseProviders(cfg.Providers.Preference),
+		jiraPhaseModelIdx: defaultJiraPhaseModelIdxs(cfg.Providers.Preference),
 	}
 
 	// Pre-populate from existing Jira config when re-running wizard.
@@ -394,10 +402,21 @@ func newSetupModel() (*setupModel, error) {
 			}
 		}
 		model.jiraPhaseModelIdx = [4]int{
-			jiraModelIndex(cfg.Jira.Validation.Model),
-			jiraModelIndex(cfg.Jira.Plan.Model),
-			jiraModelIndex(cfg.Jira.Implement.Model),
-			jiraModelIndex(cfg.Jira.ReviewFix.Model),
+			jiraModelIndexForProvider(model.jiraPhaseProvider[0], cfg.Jira.Validation.Model),
+			jiraModelIndexForProvider(model.jiraPhaseProvider[1], cfg.Jira.Plan.Model),
+			jiraModelIndexForProvider(model.jiraPhaseProvider[2], cfg.Jira.Implement.Model),
+			jiraModelIndexForProvider(model.jiraPhaseProvider[3], cfg.Jira.ReviewFix.Model),
+		}
+		// Populate per-phase providers from existing config (fall back to claude for old configs).
+		for i, phase := range []jiraconfig.PhaseConfig{
+			cfg.Jira.Validation, cfg.Jira.Plan, cfg.Jira.Implement, cfg.Jira.ReviewFix,
+		} {
+			p := phase.Provider
+			if p == "" {
+				p = "claude"
+			}
+			model.jiraPhaseProvider[i] = p
+			model.jiraPhaseModelIdx[i] = jiraModelIndexForProvider(p, phase.Model)
 		}
 	}
 
@@ -2230,7 +2249,8 @@ func writeGlobalConfigToPath(cfg *config.Config, configPath string) error {
 	v.Set("projects", cfg.Projects)
 	v.Set("tasks.enabled", cfg.Tasks.Enabled)
 
-	// Jira integration — only written when enabled (site is non-empty).
+	// Jira integration — written unconditionally to prevent stale keys.
+	// When Jira is disabled (Site is empty), all jira.* keys are zeroed out.
 	if cfg.Jira.Site != "" {
 		v.Set("jira.site", cfg.Jira.Site)
 		v.Set("jira.email", cfg.Jira.Email)
@@ -2245,6 +2265,22 @@ func writeGlobalConfigToPath(cfg *config.Config, configPath string) error {
 		v.Set("jira.plan", cfg.Jira.Plan)
 		v.Set("jira.implement", cfg.Jira.Implement)
 		v.Set("jira.review_fix", cfg.Jira.ReviewFix)
+	} else {
+		// Explicitly zero out every jira leaf key so a previously enabled Jira config
+		// does not survive a disable-and-save round-trip.
+		v.Set("jira.site", "")
+		v.Set("jira.email", "")
+		v.Set("jira.token_env", "")
+		v.Set("jira.label", "")
+		v.Set("jira.max_tickets", 0)
+		v.Set("jira.workspace_root", "")
+		v.Set("jira.cleanup_after_days", 0)
+		v.Set("jira.budget_enabled", false)
+		v.Set("jira.projects", []interface{}{})
+		v.Set("jira.validation", map[string]interface{}{})
+		v.Set("jira.plan", map[string]interface{}{})
+		v.Set("jira.implement", map[string]interface{}{})
+		v.Set("jira.review_fix", map[string]interface{}{})
 	}
 
 	if err := v.WriteConfig(); err != nil {
@@ -2353,6 +2389,60 @@ func jiraModelIndex(model string) int {
 	return 0
 }
 
+// jiraPhaseModelsForProvider returns the model list for provider, falling back to claude.
+func jiraPhaseModelsForProvider(provider string) []string {
+	if models, ok := jiraPhaseModelsByProvider[provider]; ok {
+		return models
+	}
+	return jiraPhaseModelsByProvider["claude"]
+}
+
+// jiraProviderIndex returns the index of provider in jiraProviders, defaulting to 0.
+func jiraProviderIndex(provider string) int {
+	for i, p := range jiraProviders {
+		if p == provider {
+			return i
+		}
+	}
+	return 0
+}
+
+// jiraModelIndexForProvider returns the index of model within the provider's model list.
+func jiraModelIndexForProvider(provider, model string) int {
+	models := jiraPhaseModelsForProvider(provider)
+	for i, m := range models {
+		if m == model {
+			return i
+		}
+	}
+	return 0
+}
+
+// defaultJiraPhaseProviders returns the initial provider array for Jira phases,
+// using the first entry of preference (or claude as the fallback).
+func defaultJiraPhaseProviders(preference []string) [4]string {
+	p := "claude"
+	if len(preference) > 0 && preference[0] != "" {
+		p = preference[0]
+	}
+	return [4]string{p, p, p, p}
+}
+
+// defaultJiraPhaseModelIdxs returns initial model indexes for Jira phases.
+// validation defaults to index 0 (cheapest); the other phases default to index 1 (balanced).
+func defaultJiraPhaseModelIdxs(preference []string) [4]int {
+	p := "claude"
+	if len(preference) > 0 && preference[0] != "" {
+		p = preference[0]
+	}
+	models := jiraPhaseModelsForProvider(p)
+	implIdx := 0
+	if len(models) > 1 {
+		implIdx = 1
+	}
+	return [4]int{0, implIdx, implIdx, implIdx}
+}
+
 // handleJiraInput dispatches to the appropriate Jira sub-step handler.
 func (m *setupModel) handleJiraInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.jiraSubStep {
@@ -2389,6 +2479,10 @@ func (m *setupModel) handleJiraEnableInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 	case "n", "N":
 		m.jiraEnabled = false
 		m.cfg.Jira = jiraconfig.JiraConfig{}
+		if err := writeGlobalConfig(m.cfg); err != nil {
+			m.jiraErr = err.Error()
+			return m, nil
+		}
 		return m, m.setStep(stepSnapshot)
 	case "enter":
 		if m.jiraEnableCursor == 0 {
@@ -2399,6 +2493,10 @@ func (m *setupModel) handleJiraEnableInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		} else {
 			m.jiraEnabled = false
 			m.cfg.Jira = jiraconfig.JiraConfig{}
+			if err := writeGlobalConfig(m.cfg); err != nil {
+				m.jiraErr = err.Error()
+				return m, nil
+			}
 			return m, m.setStep(stepSnapshot)
 		}
 	}
@@ -2587,9 +2685,17 @@ func (m *setupModel) handleJiraPhaseInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.jiraPhaseModelIdx[m.jiraPhaseCursor]--
 		}
 	case "right", "l":
-		if m.jiraPhaseModelIdx[m.jiraPhaseCursor] < len(jiraPhaseModels)-1 {
+		provider := m.jiraPhaseProvider[m.jiraPhaseCursor]
+		models := jiraPhaseModelsForProvider(provider)
+		if m.jiraPhaseModelIdx[m.jiraPhaseCursor] < len(models)-1 {
 			m.jiraPhaseModelIdx[m.jiraPhaseCursor]++
 		}
+	case "tab":
+		// Cycle provider for the selected phase; reset model index to avoid out-of-bounds.
+		idx := jiraProviderIndex(m.jiraPhaseProvider[m.jiraPhaseCursor])
+		idx = (idx + 1) % len(jiraProviders)
+		m.jiraPhaseProvider[m.jiraPhaseCursor] = jiraProviders[idx]
+		m.jiraPhaseModelIdx[m.jiraPhaseCursor] = 0
 	case "enter":
 		m.jiraSubStep = jiraSubStepMaxTickets
 		m.jiraInput.SetValue(strconv.Itoa(m.jiraMaxTickets))
@@ -2635,13 +2741,20 @@ func (m *setupModel) applyJiraConfig() {
 		})
 	}
 
-	phaseNames := [4]string{"validation", "plan", "implement", "review_fix"}
-	_ = phaseNames
 	phases := [4]jiraconfig.PhaseConfig{}
 	for i := range phases {
+		provider := m.jiraPhaseProvider[i]
+		if provider == "" {
+			provider = "claude"
+		}
+		models := jiraPhaseModelsForProvider(provider)
+		model := ""
+		if m.jiraPhaseModelIdx[i] < len(models) {
+			model = models[m.jiraPhaseModelIdx[i]]
+		}
 		phases[i] = jiraconfig.PhaseConfig{
-			Provider: "claude",
-			Model:    jiraPhaseModels[m.jiraPhaseModelIdx[i]],
+			Provider: provider,
+			Model:    model,
 		}
 	}
 
@@ -2851,7 +2964,7 @@ func renderJiraReposStep(b *strings.Builder, m *setupModel) {
 
 func renderJiraPhasesStep(b *strings.Builder, m *setupModel) {
 	b.WriteString("Phase models\n")
-	b.WriteString("Use ↑/↓ to select phase, ←/→ to change model.\n\n")
+	b.WriteString("Use ↑/↓ to select phase, ←/→ to change model, Tab to change provider.\n\n")
 
 	phaseLabels := [4]string{"Validation ", "Plan       ", "Implement  ", "Review-fix "}
 	for i, label := range phaseLabels {
@@ -2859,8 +2972,16 @@ func renderJiraPhasesStep(b *strings.Builder, m *setupModel) {
 		if i == m.jiraPhaseCursor {
 			cursor = ">"
 		}
-		model := jiraPhaseModels[m.jiraPhaseModelIdx[i]]
-		fmt.Fprintf(b, " %s %-11s  ← %s →\n", cursor, label, model)
+		provider := m.jiraPhaseProvider[i]
+		if provider == "" {
+			provider = "claude"
+		}
+		models := jiraPhaseModelsForProvider(provider)
+		modelName := ""
+		if m.jiraPhaseModelIdx[i] < len(models) {
+			modelName = models[m.jiraPhaseModelIdx[i]]
+		}
+		fmt.Fprintf(b, " %s %-11s  %-8s  ← %s →\n", cursor, label, provider, modelName)
 	}
 	b.WriteString("\n")
 	b.WriteString(styleNote.Render("Tip: haiku is cheaper/faster for validation; sonnet for implementation."))

--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/marcus/nightshift/internal/config"
 	"github.com/marcus/nightshift/internal/db"
+	jiraconfig "github.com/marcus/nightshift/internal/jira"
 	"github.com/marcus/nightshift/internal/providers"
 	"github.com/marcus/nightshift/internal/reporting"
 	"github.com/marcus/nightshift/internal/scheduler"
@@ -62,6 +63,7 @@ const (
 	stepTaskPreset
 	stepTaskSelect
 	stepSchedule
+	stepJira
 	stepSnapshot
 	stepPreview
 	stepPath
@@ -82,6 +84,15 @@ type modelOption struct {
 // modelProviderLists holds the model option slice for each provider in cursor order
 // (claude=0, codex=1, copilot=2). Used to bound modelCursor in handleModelInput.
 var modelProviderLists = []*[]modelOption{&claudeModels, &codexModels, &copilotModels}
+
+// jiraPhaseModels lists Claude model options used for Jira phase configuration.
+var jiraPhaseModels = []string{
+	"claude-haiku-4.5",
+	"claude-sonnet-4.5",
+	"claude-sonnet-4.6",
+	"claude-opus-4.5",
+	"claude-opus-4.6",
+}
 
 // claudeModels lists available Claude models.
 // Source: https://platform.claude.com/docs/en/about-claude/models/overview (Claude API aliases)
@@ -199,6 +210,29 @@ type setupModel struct {
 	serviceState serviceState
 	daemonAction string
 
+	// Jira step state
+	jiraSubStep        int
+	jiraInput          textinput.Model
+	jiraEnableCursor   int
+	jiraEnabled        bool
+	jiraSite           string
+	jiraEmail          string
+	jiraTokenEnv       string
+	jiraProjectKey     string
+	jiraLabel          string
+	jiraMaxTickets     int
+	jiraRepos          []jiraRepoEntry
+	jiraRepoCursor     int
+	jiraRepoEditing    bool
+	jiraRepoField      int
+	jiraRepoEditURL    string
+	jiraPhaseCursor    int
+	jiraPhaseModelIdx  [4]int
+	jiraPinging        bool
+	jiraPingOK         bool
+	jiraPingErr        string
+	jiraErr            string
+
 	spinner spinner.Model
 }
 
@@ -221,6 +255,16 @@ type snapshotMsg struct {
 type previewMsg struct {
 	output string
 	err    error
+}
+
+type jiraPingMsg struct {
+	ok  bool
+	err string
+}
+
+type jiraRepoEntry struct {
+	URL        string
+	BaseBranch string
 }
 
 type pathOption struct {
@@ -270,6 +314,9 @@ func newSetupModel() (*setupModel, error) {
 	scheduleInput := textinput.New()
 	scheduleInput.Prompt = "> "
 
+	jiraInput := textinput.New()
+	jiraInput.Prompt = "> "
+
 	spin := spinner.New()
 	spin.Spinner = spinner.MiniDot
 
@@ -311,6 +358,47 @@ func newSetupModel() (*setupModel, error) {
 		claudeModelIdx:   modelIndex(claudeModels, cfg.Providers.Claude.Model),
 		codexModelIdx:    modelIndex(codexModels, cfg.Providers.Codex.Model),
 		copilotModelIdx:  modelIndex(copilotModels, cfg.Providers.Copilot.Model),
+		jiraInput:        jiraInput,
+		jiraTokenEnv:     "JIRA_API_TOKEN",
+		jiraLabel:        "nightshift",
+		jiraMaxTickets:   10,
+		jiraPhaseModelIdx: [4]int{
+			jiraModelIndex("claude-haiku-4.5"),
+			jiraModelIndex("claude-sonnet-4.5"),
+			jiraModelIndex("claude-sonnet-4.5"),
+			jiraModelIndex("claude-sonnet-4.5"),
+		},
+	}
+
+	// Pre-populate from existing Jira config when re-running wizard.
+	if cfg.Jira.Site != "" {
+		model.jiraEnabled = true
+		model.jiraSite = cfg.Jira.Site
+		model.jiraEmail = cfg.Jira.Email
+		if cfg.Jira.TokenEnv != "" {
+			model.jiraTokenEnv = cfg.Jira.TokenEnv
+		}
+		if cfg.Jira.Label != "" {
+			model.jiraLabel = cfg.Jira.Label
+		}
+		if cfg.Jira.MaxTickets > 0 {
+			model.jiraMaxTickets = cfg.Jira.MaxTickets
+		}
+		if len(cfg.Jira.Projects) > 0 {
+			model.jiraProjectKey = cfg.Jira.Projects[0].Key
+			for _, r := range cfg.Jira.Projects[0].Repos {
+				model.jiraRepos = append(model.jiraRepos, jiraRepoEntry{
+					URL:        r.URL,
+					BaseBranch: r.BaseBranch,
+				})
+			}
+		}
+		model.jiraPhaseModelIdx = [4]int{
+			jiraModelIndex(cfg.Jira.Validation.Model),
+			jiraModelIndex(cfg.Jira.Plan.Model),
+			jiraModelIndex(cfg.Jira.Implement.Model),
+			jiraModelIndex(cfg.Jira.ReviewFix.Model),
+		}
 	}
 
 	return model, nil
@@ -356,6 +444,8 @@ func (m *setupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleTaskInput(msg)
 		case stepSchedule:
 			return m.handleScheduleInput(msg)
+		case stepJira:
+			return m.handleJiraInput(msg)
 		case stepSnapshot:
 			if !m.snapshotRunning && msg.String() == "enter" {
 				return m, m.setStep(stepPreview)
@@ -384,6 +474,10 @@ func (m *setupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.previewRunning = false
 		m.previewOutput = msg.output
 		m.previewErr = msg.err
+	case jiraPingMsg:
+		m.jiraPinging = false
+		m.jiraPingOK = msg.ok
+		m.jiraPingErr = msg.err
 	}
 
 	return m, cmd
@@ -541,6 +635,10 @@ func (m *setupModel) View() string {
 			b.WriteString("\nError: " + m.scheduleErr + "\n")
 		}
 		b.WriteString("\nPress Enter to continue.\n")
+	case stepJira:
+		b.WriteString(styleAccent.Render("Jira integration"))
+		b.WriteString("\n")
+		renderJiraStep(&b, m)
 	case stepSnapshot:
 		b.WriteString(styleAccent.Render("Snapshot step"))
 		b.WriteString("\n")
@@ -652,6 +750,11 @@ func (m *setupModel) View() string {
 func (m *setupModel) setStep(step setupStep) tea.Cmd {
 	m.step = step
 	switch step {
+	case stepJira:
+		m.jiraSubStep = 0
+		m.jiraErr = ""
+		m.jiraInput.SetValue("")
+		m.jiraInput.Blur()
 	case stepSnapshot:
 		m.snapshotRunning = true
 		m.snapshotOutput = ""
@@ -963,7 +1066,7 @@ func (m *setupModel) handleScheduleInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.scheduleErr = err.Error()
 			return m, nil
 		}
-		return m, m.setStep(stepSnapshot)
+		return m, m.setStep(stepJira)
 	}
 	return m, nil
 }
@@ -1946,6 +2049,7 @@ func setupSteps(includePathStep bool) []setupStepInfo {
 		{step: stepTaskPreset, label: "Task presets"},
 		{step: stepTaskSelect, label: "Task selection"},
 		{step: stepSchedule, label: "Schedule"},
+		{step: stepJira, label: "Jira"},
 		{step: stepSnapshot, label: "Snapshot"},
 		{step: stepPreview, label: "Preview"},
 	}
@@ -2126,6 +2230,23 @@ func writeGlobalConfigToPath(cfg *config.Config, configPath string) error {
 	v.Set("projects", cfg.Projects)
 	v.Set("tasks.enabled", cfg.Tasks.Enabled)
 
+	// Jira integration — only written when enabled (site is non-empty).
+	if cfg.Jira.Site != "" {
+		v.Set("jira.site", cfg.Jira.Site)
+		v.Set("jira.email", cfg.Jira.Email)
+		v.Set("jira.token_env", cfg.Jira.TokenEnv)
+		v.Set("jira.label", cfg.Jira.Label)
+		v.Set("jira.max_tickets", cfg.Jira.MaxTickets)
+		v.Set("jira.workspace_root", cfg.Jira.WorkspaceRoot)
+		v.Set("jira.cleanup_after_days", cfg.Jira.CleanupAfterDays)
+		v.Set("jira.budget_enabled", cfg.Jira.BudgetEnabled)
+		v.Set("jira.projects", cfg.Jira.Projects)
+		v.Set("jira.validation", cfg.Jira.Validation)
+		v.Set("jira.plan", cfg.Jira.Plan)
+		v.Set("jira.implement", cfg.Jira.Implement)
+		v.Set("jira.review_fix", cfg.Jira.ReviewFix)
+	}
+
 	if err := v.WriteConfig(); err != nil {
 		if os.IsNotExist(err) {
 			return v.SafeWriteConfig()
@@ -2206,4 +2327,542 @@ func gitignoreHasEntry(content, entry string) bool {
 		}
 	}
 	return false
+}
+
+// jiraSubStep constants for the Jira wizard step.
+const (
+	jiraSubStepEnable     = 0
+	jiraSubStepSite       = 1
+	jiraSubStepEmail      = 2
+	jiraSubStepTokenEnv   = 3
+	jiraSubStepProject    = 4
+	jiraSubStepLabel      = 5
+	jiraSubStepRepos      = 6
+	jiraSubStepPhases     = 7
+	jiraSubStepMaxTickets = 8
+	jiraSubStepPing       = 9
+)
+
+// jiraModelIndex returns the index of model in jiraPhaseModels, defaulting to 0.
+func jiraModelIndex(model string) int {
+	for i, m := range jiraPhaseModels {
+		if m == model {
+			return i
+		}
+	}
+	return 0
+}
+
+// handleJiraInput dispatches to the appropriate Jira sub-step handler.
+func (m *setupModel) handleJiraInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.jiraSubStep {
+	case jiraSubStepEnable:
+		return m.handleJiraEnableInput(msg)
+	case jiraSubStepSite, jiraSubStepEmail, jiraSubStepTokenEnv,
+		jiraSubStepProject, jiraSubStepLabel, jiraSubStepMaxTickets:
+		return m.handleJiraTextInput(msg)
+	case jiraSubStepRepos:
+		return m.handleJiraRepoInput(msg)
+	case jiraSubStepPhases:
+		return m.handleJiraPhaseInput(msg)
+	case jiraSubStepPing:
+		return m.handleJiraPingInput(msg)
+	}
+	return m, nil
+}
+
+func (m *setupModel) handleJiraEnableInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		if m.jiraEnableCursor > 0 {
+			m.jiraEnableCursor--
+		}
+	case "down", "j":
+		if m.jiraEnableCursor < 1 {
+			m.jiraEnableCursor++
+		}
+	case "y", "Y":
+		m.jiraEnabled = true
+		m.jiraSubStep = jiraSubStepSite
+		m.jiraInput.SetValue(m.jiraSite)
+		m.jiraInput.Focus()
+	case "n", "N":
+		m.jiraEnabled = false
+		m.cfg.Jira = jiraconfig.JiraConfig{}
+		return m, m.setStep(stepSnapshot)
+	case "enter":
+		if m.jiraEnableCursor == 0 {
+			m.jiraEnabled = true
+			m.jiraSubStep = jiraSubStepSite
+			m.jiraInput.SetValue(m.jiraSite)
+			m.jiraInput.Focus()
+		} else {
+			m.jiraEnabled = false
+			m.cfg.Jira = jiraconfig.JiraConfig{}
+			return m, m.setStep(stepSnapshot)
+		}
+	}
+	return m, nil
+}
+
+func (m *setupModel) handleJiraTextInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.jiraErr = ""
+		m.jiraInput.Blur()
+		return m, nil
+	case "enter":
+		value := strings.TrimSpace(m.jiraInput.Value())
+		switch m.jiraSubStep {
+		case jiraSubStepSite:
+			if value == "" {
+				m.jiraErr = "site is required"
+				return m, nil
+			}
+			// Strip https:// prefix if user pastes full URL
+			value = strings.TrimPrefix(value, "https://")
+			value = strings.TrimSuffix(value, ".atlassian.net")
+			value = strings.TrimSuffix(value, "/")
+			m.jiraSite = value
+			m.jiraErr = ""
+			m.jiraSubStep = jiraSubStepEmail
+			m.jiraInput.SetValue(m.jiraEmail)
+			m.jiraInput.Focus()
+		case jiraSubStepEmail:
+			if value == "" {
+				m.jiraErr = "email is required"
+				return m, nil
+			}
+			m.jiraEmail = value
+			m.jiraErr = ""
+			m.jiraSubStep = jiraSubStepTokenEnv
+			m.jiraInput.SetValue(m.jiraTokenEnv)
+			m.jiraInput.Focus()
+		case jiraSubStepTokenEnv:
+			if value == "" {
+				value = "JIRA_API_TOKEN"
+			}
+			m.jiraTokenEnv = value
+			m.jiraErr = ""
+			m.jiraSubStep = jiraSubStepProject
+			m.jiraInput.SetValue(m.jiraProjectKey)
+			m.jiraInput.Focus()
+		case jiraSubStepProject:
+			if value == "" {
+				m.jiraErr = "project key is required"
+				return m, nil
+			}
+			m.jiraProjectKey = strings.ToUpper(value)
+			m.jiraErr = ""
+			m.jiraSubStep = jiraSubStepLabel
+			m.jiraInput.SetValue(m.jiraLabel)
+			m.jiraInput.Focus()
+		case jiraSubStepLabel:
+			if value == "" {
+				value = "nightshift"
+			}
+			m.jiraLabel = value
+			m.jiraErr = ""
+			m.jiraSubStep = jiraSubStepRepos
+			m.jiraInput.Blur()
+		case jiraSubStepMaxTickets:
+			if value == "" {
+				value = "10"
+			}
+			n, err := strconv.Atoi(value)
+			if err != nil || n <= 0 {
+				m.jiraErr = "max tickets must be a positive integer"
+				return m, nil
+			}
+			m.jiraMaxTickets = n
+			m.jiraErr = ""
+			m.jiraSubStep = jiraSubStepPing
+			m.jiraInput.Blur()
+			m.jiraPinging = true
+			m.jiraPingOK = false
+			m.jiraPingErr = ""
+			return m, runJiraPingCmd(m)
+		}
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.jiraInput, cmd = m.jiraInput.Update(msg)
+	return m, cmd
+}
+
+func (m *setupModel) handleJiraRepoInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.jiraRepoEditing {
+		switch msg.String() {
+		case "esc":
+			m.jiraRepoEditing = false
+			m.jiraRepoField = 0
+			m.jiraRepoEditURL = ""
+			m.jiraErr = ""
+			m.jiraInput.Blur()
+			return m, nil
+		case "enter":
+			value := strings.TrimSpace(m.jiraInput.Value())
+			if m.jiraRepoField == 0 {
+				// Collecting URL
+				if value == "" {
+					m.jiraErr = "URL is required"
+					return m, nil
+				}
+				m.jiraRepoEditURL = value
+				m.jiraRepoField = 1
+				m.jiraInput.SetValue("main")
+				m.jiraInput.Focus()
+				m.jiraErr = ""
+				return m, nil
+			}
+			// Collecting base branch
+			branch := value
+			if branch == "" {
+				branch = "main"
+			}
+			m.jiraRepos = append(m.jiraRepos, jiraRepoEntry{
+				URL:        m.jiraRepoEditURL,
+				BaseBranch: branch,
+			})
+			m.jiraRepoCursor = len(m.jiraRepos) - 1
+			m.jiraRepoEditing = false
+			m.jiraRepoField = 0
+			m.jiraRepoEditURL = ""
+			m.jiraErr = ""
+			m.jiraInput.Blur()
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.jiraInput, cmd = m.jiraInput.Update(msg)
+		return m, cmd
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		if m.jiraRepoCursor > 0 {
+			m.jiraRepoCursor--
+		}
+	case "down", "j":
+		if m.jiraRepoCursor < len(m.jiraRepos)-1 {
+			m.jiraRepoCursor++
+		}
+	case "a":
+		m.jiraRepoEditing = true
+		m.jiraRepoField = 0
+		m.jiraRepoEditURL = ""
+		m.jiraErr = ""
+		m.jiraInput.SetValue("")
+		m.jiraInput.Placeholder = "git@github.com:org/repo.git"
+		m.jiraInput.Focus()
+	case "d":
+		if len(m.jiraRepos) > 0 {
+			m.jiraRepos = append(m.jiraRepos[:m.jiraRepoCursor], m.jiraRepos[m.jiraRepoCursor+1:]...)
+			if m.jiraRepoCursor >= len(m.jiraRepos) && m.jiraRepoCursor > 0 {
+				m.jiraRepoCursor--
+			}
+		}
+	case "enter":
+		if len(m.jiraRepos) == 0 {
+			m.jiraErr = "add at least one repository"
+			return m, nil
+		}
+		m.jiraErr = ""
+		m.jiraSubStep = jiraSubStepPhases
+	}
+	return m, nil
+}
+
+func (m *setupModel) handleJiraPhaseInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		if m.jiraPhaseCursor > 0 {
+			m.jiraPhaseCursor--
+		}
+	case "down", "j":
+		if m.jiraPhaseCursor < 3 {
+			m.jiraPhaseCursor++
+		}
+	case "left", "h":
+		if m.jiraPhaseModelIdx[m.jiraPhaseCursor] > 0 {
+			m.jiraPhaseModelIdx[m.jiraPhaseCursor]--
+		}
+	case "right", "l":
+		if m.jiraPhaseModelIdx[m.jiraPhaseCursor] < len(jiraPhaseModels)-1 {
+			m.jiraPhaseModelIdx[m.jiraPhaseCursor]++
+		}
+	case "enter":
+		m.jiraSubStep = jiraSubStepMaxTickets
+		m.jiraInput.SetValue(strconv.Itoa(m.jiraMaxTickets))
+		m.jiraInput.Placeholder = "10"
+		m.jiraInput.Focus()
+	}
+	return m, nil
+}
+
+func (m *setupModel) handleJiraPingInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.jiraPinging {
+		// Still waiting for ping — ignore keystrokes
+		return m, nil
+	}
+	if msg.String() == "enter" {
+		m.applyJiraConfig()
+		if err := writeGlobalConfig(m.cfg); err != nil {
+			m.jiraErr = err.Error()
+			return m, nil
+		}
+		return m, m.setStep(stepSnapshot)
+	}
+	return m, nil
+}
+
+// applyJiraConfig populates cfg.Jira from wizard state.
+func (m *setupModel) applyJiraConfig() {
+	if !m.jiraEnabled {
+		m.cfg.Jira = jiraconfig.JiraConfig{}
+		return
+	}
+
+	repos := make([]jiraconfig.RepoConfig, 0, len(m.jiraRepos))
+	for _, r := range m.jiraRepos {
+		branch := r.BaseBranch
+		if branch == "" {
+			branch = "main"
+		}
+		repos = append(repos, jiraconfig.RepoConfig{
+			Name:       repoNameFromURL(r.URL),
+			URL:        r.URL,
+			BaseBranch: branch,
+		})
+	}
+
+	phaseNames := [4]string{"validation", "plan", "implement", "review_fix"}
+	_ = phaseNames
+	phases := [4]jiraconfig.PhaseConfig{}
+	for i := range phases {
+		phases[i] = jiraconfig.PhaseConfig{
+			Provider: "claude",
+			Model:    jiraPhaseModels[m.jiraPhaseModelIdx[i]],
+		}
+	}
+
+	m.cfg.Jira = jiraconfig.JiraConfig{
+		Site:             m.jiraSite,
+		Email:            m.jiraEmail,
+		TokenEnv:         m.jiraTokenEnv,
+		Label:            m.jiraLabel,
+		MaxTickets:       m.jiraMaxTickets,
+		BudgetEnabled:    true,
+		CleanupAfterDays: 30,
+		Projects: []jiraconfig.ProjectConfig{{
+			Key:   m.jiraProjectKey,
+			Label: m.jiraLabel,
+			Repos: repos,
+		}},
+		Validation: phases[0],
+		Plan:       phases[1],
+		Implement:  phases[2],
+		ReviewFix:  phases[3],
+	}
+}
+
+// repoNameFromURL derives a short repo name from a git SSH or HTTPS URL.
+func repoNameFromURL(url string) string {
+	base := filepath.Base(url)
+	return strings.TrimSuffix(base, ".git")
+}
+
+// runJiraPingCmd returns a tea.Cmd that pings the Jira API asynchronously.
+func runJiraPingCmd(m *setupModel) tea.Cmd {
+	cfg := jiraconfig.JiraConfig{
+		Site:     m.jiraSite,
+		Email:    m.jiraEmail,
+		TokenEnv: m.jiraTokenEnv,
+	}
+	return func() tea.Msg {
+		client, err := jiraconfig.NewClient(cfg)
+		if err != nil {
+			return jiraPingMsg{ok: false, err: err.Error()}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := client.Ping(ctx); err != nil {
+			return jiraPingMsg{ok: false, err: err.Error()}
+		}
+		return jiraPingMsg{ok: true}
+	}
+}
+
+// renderJiraStep renders the Jira wizard step based on the current sub-step.
+func renderJiraStep(b *strings.Builder, m *setupModel) {
+	switch m.jiraSubStep {
+	case jiraSubStepEnable:
+		b.WriteString("Connect Nightshift to Jira for autonomous ticket processing?\n\n")
+		options := []string{"Yes, enable Jira integration", "No, skip"}
+		for i, opt := range options {
+			cursor := " "
+			if i == m.jiraEnableCursor {
+				cursor = ">"
+			}
+			fmt.Fprintf(b, " %s %s\n", cursor, opt)
+		}
+		b.WriteString("\nUse ↑/↓ to select, y/n or Enter to choose.\n")
+
+	case jiraSubStepSite:
+		b.WriteString("Jira instance URL\n")
+		b.WriteString(styleNote.Render("Enter your subdomain (e.g. mysite) or full URL (https://mysite.atlassian.net)"))
+		b.WriteString("\n\n")
+		b.WriteString(m.jiraInput.View() + "\n")
+		if m.jiraErr != "" {
+			b.WriteString(styleWarn.Render("Error: "+m.jiraErr) + "\n")
+		}
+		b.WriteString("\nPress Enter to continue.\n")
+
+	case jiraSubStepEmail:
+		b.WriteString("Jira account email\n\n")
+		b.WriteString(m.jiraInput.View() + "\n")
+		if m.jiraErr != "" {
+			b.WriteString(styleWarn.Render("Error: "+m.jiraErr) + "\n")
+		}
+		b.WriteString("\nPress Enter to continue.\n")
+
+	case jiraSubStepTokenEnv:
+		b.WriteString("API token environment variable\n")
+		b.WriteString(styleNote.Render("Name of the env var holding your Jira API token (default: JIRA_API_TOKEN)"))
+		b.WriteString("\n\n")
+		b.WriteString(m.jiraInput.View() + "\n")
+		envName := strings.TrimSpace(m.jiraInput.Value())
+		if envName == "" {
+			envName = m.jiraTokenEnv
+		}
+		if os.Getenv(envName) != "" {
+			b.WriteString(styleOk.Render("✓ env var is set") + "\n")
+		} else {
+			b.WriteString(styleWarn.Render("✗ env var not set — set it before running nightshift jira run") + "\n")
+		}
+		if m.jiraErr != "" {
+			b.WriteString(styleWarn.Render("Error: "+m.jiraErr) + "\n")
+		}
+		b.WriteString("\nPress Enter to continue.\n")
+
+	case jiraSubStepProject:
+		b.WriteString("Jira project key\n")
+		b.WriteString(styleNote.Render("e.g. PROJ or VC"))
+		b.WriteString("\n\n")
+		b.WriteString(m.jiraInput.View() + "\n")
+		if m.jiraErr != "" {
+			b.WriteString(styleWarn.Render("Error: "+m.jiraErr) + "\n")
+		}
+		b.WriteString("\nPress Enter to continue.\n")
+
+	case jiraSubStepLabel:
+		b.WriteString("Ticket label filter\n")
+		b.WriteString(styleNote.Render("Only tickets with this label will be processed (default: nightshift)"))
+		b.WriteString("\n\n")
+		b.WriteString(m.jiraInput.View() + "\n")
+		if m.jiraErr != "" {
+			b.WriteString(styleWarn.Render("Error: "+m.jiraErr) + "\n")
+		}
+		b.WriteString("\nPress Enter to continue.\n")
+
+	case jiraSubStepRepos:
+		renderJiraReposStep(b, m)
+
+	case jiraSubStepPhases:
+		renderJiraPhasesStep(b, m)
+
+	case jiraSubStepMaxTickets:
+		b.WriteString("Max tickets per run\n")
+		b.WriteString(styleNote.Render("Maximum number of tickets to process in a single run (default: 10)"))
+		b.WriteString("\n\n")
+		b.WriteString(m.jiraInput.View() + "\n")
+		if m.jiraErr != "" {
+			b.WriteString(styleWarn.Render("Error: "+m.jiraErr) + "\n")
+		}
+		b.WriteString("\nPress Enter to continue (will test connection).\n")
+
+	case jiraSubStepPing:
+		b.WriteString("Testing Jira connection...\n\n")
+		if m.jiraPinging {
+			b.WriteString(styleNote.Render("Connecting to Jira...") + "\n")
+		} else if m.jiraPingOK {
+			b.WriteString(styleOk.Render("✓ Connected to Jira successfully") + "\n")
+		} else {
+			b.WriteString(styleWarn.Render("✗ Connection failed: "+m.jiraPingErr) + "\n")
+			b.WriteString(styleNote.Render("You can still continue — verify credentials before running nightshift jira run.") + "\n")
+		}
+		if m.jiraErr != "" {
+			b.WriteString(styleWarn.Render("Error: "+m.jiraErr) + "\n")
+		}
+		if !m.jiraPinging {
+			b.WriteString("\nPress Enter to save and continue.\n")
+		}
+	}
+}
+
+func renderJiraReposStep(b *strings.Builder, m *setupModel) {
+	if m.jiraRepoEditing {
+		if m.jiraRepoField == 0 {
+			b.WriteString("Repository SSH URL\n")
+			b.WriteString(styleNote.Render("e.g. git@github.com:org/repo.git — SSH required for non-interactive git"))
+			b.WriteString("\n\n")
+			b.WriteString(m.jiraInput.View() + "\n")
+			url := strings.TrimSpace(m.jiraInput.Value())
+			if strings.HasPrefix(url, "https://") {
+				b.WriteString(styleWarn.Render("⚠ HTTPS URL detected — SSH is required (use git@github.com:...)") + "\n")
+			}
+		} else {
+			b.WriteString(fmt.Sprintf("Base branch for %s\n", repoNameFromURL(m.jiraRepoEditURL)))
+			b.WriteString(styleNote.Render("Default branch for new feature branches (default: main)"))
+			b.WriteString("\n\n")
+			b.WriteString(m.jiraInput.View() + "\n")
+		}
+		if m.jiraErr != "" {
+			b.WriteString(styleWarn.Render("Error: "+m.jiraErr) + "\n")
+		}
+		b.WriteString("\nPress Enter to confirm, Esc to cancel.\n")
+		return
+	}
+
+	b.WriteString("Repositories\n")
+	b.WriteString("Use ↑/↓ to navigate, 'a' to add, 'd' to delete.\n\n")
+	if len(m.jiraRepos) == 0 {
+		b.WriteString(styleDim.Render("  (no repositories configured)") + "\n")
+	}
+	for i, repo := range m.jiraRepos {
+		cursor := " "
+		if i == m.jiraRepoCursor {
+			cursor = ">"
+		}
+		name := repoNameFromURL(repo.URL)
+		fmt.Fprintf(b, " %s %s  [%s]\n", cursor, name, repo.URL)
+		warn := ""
+		if strings.HasPrefix(repo.URL, "https://") {
+			warn = "  " + styleWarn.Render("⚠ HTTPS URL — SSH recommended")
+		}
+		if warn != "" {
+			b.WriteString(warn + "\n")
+		}
+	}
+	if m.jiraErr != "" {
+		b.WriteString("\n" + styleWarn.Render("Error: "+m.jiraErr) + "\n")
+	}
+	b.WriteString("\nPress Enter to continue.\n")
+}
+
+func renderJiraPhasesStep(b *strings.Builder, m *setupModel) {
+	b.WriteString("Phase models\n")
+	b.WriteString("Use ↑/↓ to select phase, ←/→ to change model.\n\n")
+
+	phaseLabels := [4]string{"Validation ", "Plan       ", "Implement  ", "Review-fix "}
+	for i, label := range phaseLabels {
+		cursor := " "
+		if i == m.jiraPhaseCursor {
+			cursor = ">"
+		}
+		model := jiraPhaseModels[m.jiraPhaseModelIdx[i]]
+		fmt.Fprintf(b, " %s %-11s  ← %s →\n", cursor, label, model)
+	}
+	b.WriteString("\n")
+	b.WriteString(styleNote.Render("Tip: haiku is cheaper/faster for validation; sonnet for implementation."))
+	b.WriteString("\n\nPress Enter to continue.\n")
 }

--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -2249,14 +2249,30 @@ func writeGlobalConfigToPath(cfg *config.Config, configPath string) error {
 		v.Set("jira.token_env", cfg.Jira.TokenEnv)
 		v.Set("jira.label", cfg.Jira.Label)
 		v.Set("jira.max_tickets", cfg.Jira.MaxTickets)
-		v.Set("jira.workspace_root", cfg.Jira.WorkspaceRoot)
-		v.Set("jira.cleanup_after_days", cfg.Jira.CleanupAfterDays)
 		v.Set("jira.budget_enabled", cfg.Jira.BudgetEnabled)
-		v.Set("jira.projects", cfg.Jira.Projects)
-		v.Set("jira.validation", cfg.Jira.Validation)
-		v.Set("jira.plan", cfg.Jira.Plan)
-		v.Set("jira.implement", cfg.Jira.Implement)
-		v.Set("jira.review_fix", cfg.Jira.ReviewFix)
+		if cfg.Jira.WorkspaceRoot != "" {
+			v.Set("jira.workspace_root", cfg.Jira.WorkspaceRoot)
+		}
+		if cfg.Jira.CleanupAfterDays != 0 {
+			v.Set("jira.cleanup_after_days", cfg.Jira.CleanupAfterDays)
+		}
+		// Build projects as explicit maps so mapstructure tags are honoured and empty
+		// optional fields (lint_command, test_command, per-project phase overrides) are omitted.
+		v.Set("jira.projects", jiraProjectsToMaps(cfg.Jira.Projects))
+		// Write each phase field individually so viper uses the dot-key path instead of
+		// reflecting over a struct (which would lose mapstructure tag key names).
+		v.Set("jira.validation.provider", cfg.Jira.Validation.Provider)
+		v.Set("jira.validation.model", cfg.Jira.Validation.Model)
+		v.Set("jira.validation.timeout", cfg.Jira.Validation.Timeout)
+		v.Set("jira.plan.provider", cfg.Jira.Plan.Provider)
+		v.Set("jira.plan.model", cfg.Jira.Plan.Model)
+		v.Set("jira.plan.timeout", cfg.Jira.Plan.Timeout)
+		v.Set("jira.implement.provider", cfg.Jira.Implement.Provider)
+		v.Set("jira.implement.model", cfg.Jira.Implement.Model)
+		v.Set("jira.implement.timeout", cfg.Jira.Implement.Timeout)
+		v.Set("jira.review_fix.provider", cfg.Jira.ReviewFix.Provider)
+		v.Set("jira.review_fix.model", cfg.Jira.ReviewFix.Model)
+		v.Set("jira.review_fix.timeout", cfg.Jira.ReviewFix.Timeout)
 	} else {
 		// Explicitly zero out every jira leaf key so a previously enabled Jira config
 		// does not survive a disable-and-save round-trip.
@@ -2265,14 +2281,20 @@ func writeGlobalConfigToPath(cfg *config.Config, configPath string) error {
 		v.Set("jira.token_env", "")
 		v.Set("jira.label", "")
 		v.Set("jira.max_tickets", 0)
-		v.Set("jira.workspace_root", "")
-		v.Set("jira.cleanup_after_days", 0)
 		v.Set("jira.budget_enabled", false)
 		v.Set("jira.projects", []interface{}{})
-		v.Set("jira.validation", map[string]interface{}{})
-		v.Set("jira.plan", map[string]interface{}{})
-		v.Set("jira.implement", map[string]interface{}{})
-		v.Set("jira.review_fix", map[string]interface{}{})
+		v.Set("jira.validation.provider", "")
+		v.Set("jira.validation.model", "")
+		v.Set("jira.validation.timeout", "")
+		v.Set("jira.plan.provider", "")
+		v.Set("jira.plan.model", "")
+		v.Set("jira.plan.timeout", "")
+		v.Set("jira.implement.provider", "")
+		v.Set("jira.implement.model", "")
+		v.Set("jira.implement.timeout", "")
+		v.Set("jira.review_fix.provider", "")
+		v.Set("jira.review_fix.model", "")
+		v.Set("jira.review_fix.timeout", "")
 	}
 
 	if err := v.WriteConfig(); err != nil {
@@ -2410,26 +2432,43 @@ func jiraModelIndexForProvider(provider, model string) int {
 	return 0
 }
 
-// defaultJiraPhaseProviders returns the initial provider array for Jira phases,
-// using the first entry of preference (or claude as the fallback).
+// defaultJiraPhaseProviders returns the initial provider array for Jira phases.
+// Copilot is preferred when present in preference (it is non-interactive by design);
+// otherwise falls back to the first preference entry, then "claude".
 func defaultJiraPhaseProviders(preference []string) [4]string {
 	p := "claude"
-	if len(preference) > 0 && preference[0] != "" {
+	for _, pref := range preference {
+		if pref == "copilot" {
+			p = "copilot"
+			break
+		}
+	}
+	if p == "claude" && len(preference) > 0 && preference[0] != "" {
 		p = preference[0]
 	}
 	return [4]string{p, p, p, p}
 }
 
 // defaultJiraPhaseModelIdxs returns initial model indexes for Jira phases.
-// validation defaults to index 0 (cheapest); the other phases default to index 1 (balanced).
+// All phases default to index 0 (first model in the provider list). For copilot
+// this is claude-sonnet-4.6 which is a good default for plan/implement.
+// For claude this is claude-opus-4-6; index 1 (sonnet) would be more balanced but
+// the copilot path (which is preferred when copilot is in preference) maps index 0
+// to the right model, so we keep it consistent.
 func defaultJiraPhaseModelIdxs(preference []string) [4]int {
 	p := "claude"
-	if len(preference) > 0 && preference[0] != "" {
+	for _, pref := range preference {
+		if pref == "copilot" {
+			p = "copilot"
+			break
+		}
+	}
+	if p == "claude" && len(preference) > 0 && preference[0] != "" {
 		p = preference[0]
 	}
 	models := jiraPhaseModelsForProvider(p)
 	implIdx := 0
-	if len(models) > 1 {
+	if p != "copilot" && len(models) > 1 {
 		implIdx = 1
 	}
 	return [4]int{0, implIdx, implIdx, implIdx}
@@ -2753,16 +2792,14 @@ func (m *setupModel) applyJiraConfig() {
 	}
 
 	m.cfg.Jira = jiraconfig.JiraConfig{
-		Site:             m.jiraSite,
-		Email:            m.jiraEmail,
-		TokenEnv:         m.jiraTokenEnv,
-		Label:            m.jiraLabel,
-		MaxTickets:       m.jiraMaxTickets,
-		BudgetEnabled:    true,
-		CleanupAfterDays: 30,
+		Site:          m.jiraSite,
+		Email:         m.jiraEmail,
+		TokenEnv:      m.jiraTokenEnv,
+		Label:         m.jiraLabel,
+		MaxTickets:    m.jiraMaxTickets,
+		BudgetEnabled: true,
 		Projects: []jiraconfig.ProjectConfig{{
 			Key:   m.jiraProjectKey,
-			Label: m.jiraLabel,
 			Repos: repos,
 		}},
 		Validation: phases[0],
@@ -2770,6 +2807,39 @@ func (m *setupModel) applyJiraConfig() {
 		Implement:  phases[2],
 		ReviewFix:  phases[3],
 	}
+}
+
+// jiraProjectsToMaps serialises Jira project configs into plain maps so viper
+// writes mapstructure-tagged key names (e.g. "base_branch") and omits empty
+// optional fields (lint_command, test_command, per-project phase overrides).
+func jiraProjectsToMaps(projects []jiraconfig.ProjectConfig) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(projects))
+	for _, proj := range projects {
+		repoMaps := make([]map[string]interface{}, 0, len(proj.Repos))
+		for _, r := range proj.Repos {
+			repo := map[string]interface{}{
+				"name":        r.Name,
+				"url":         r.URL,
+				"base_branch": r.BaseBranch,
+			}
+			if r.LintCommand != "" {
+				repo["lint_command"] = r.LintCommand
+			}
+			if r.TestCommand != "" {
+				repo["test_command"] = r.TestCommand
+			}
+			repoMaps = append(repoMaps, repo)
+		}
+		p := map[string]interface{}{
+			"key":   proj.Key,
+			"repos": repoMaps,
+		}
+		if proj.Label != "" {
+			p["label"] = proj.Label
+		}
+		result = append(result, p)
+	}
+	return result
 }
 
 // repoNameFromURL derives a short repo name from a git SSH or HTTPS URL.

--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -85,24 +85,16 @@ type modelOption struct {
 // (claude=0, codex=1, copilot=2). Used to bound modelCursor in handleModelInput.
 var modelProviderLists = []*[]modelOption{&claudeModels, &codexModels, &copilotModels}
 
-// jiraPhaseModels lists Claude model options used for Jira phase configuration.
-// Kept as a named slice so jiraModelIndex() and its tests remain stable.
-var jiraPhaseModels = []string{
-	"claude-haiku-4.5",
-	"claude-sonnet-4.5",
-	"claude-sonnet-4.6",
-	"claude-opus-4.5",
-	"claude-opus-4.6",
-}
-
 // jiraProviders lists providers selectable for Jira phase configuration.
 var jiraProviders = []string{"claude", "codex", "copilot"}
 
-// jiraPhaseModelsByProvider maps each provider to its model list for Jira phases.
-var jiraPhaseModelsByProvider = map[string][]string{
-	"claude":  jiraPhaseModels,
-	"codex":   {"gpt-5.2-codex", "gpt-5.3-codex", "gpt-5.2"},
-	"copilot": {"claude-haiku-4.5", "claude-sonnet-4.5", "claude-sonnet-4.6", "claude-opus-4.5"},
+// modelOptionValues extracts the value field from a slice of modelOption.
+func modelOptionValues(opts []modelOption) []string {
+	vals := make([]string, len(opts))
+	for i, o := range opts {
+		vals[i] = o.value
+	}
+	return vals
 }
 
 // claudeModels lists available Claude models.
@@ -2379,22 +2371,22 @@ const (
 	jiraSubStepPing       = 9
 )
 
-// jiraModelIndex returns the index of model in jiraPhaseModels, defaulting to 0.
+// jiraModelIndex returns the index of model in the claude Jira model list, defaulting to 0.
 func jiraModelIndex(model string) int {
-	for i, m := range jiraPhaseModels {
-		if m == model {
-			return i
-		}
-	}
-	return 0
+	return jiraModelIndexForProvider("claude", model)
 }
 
-// jiraPhaseModelsForProvider returns the model list for provider, falling back to claude.
+// jiraPhaseModelsForProvider returns the model list for the given provider.
+// Derived from the global provider model lists so there is a single source of truth.
 func jiraPhaseModelsForProvider(provider string) []string {
-	if models, ok := jiraPhaseModelsByProvider[provider]; ok {
-		return models
+	switch provider {
+	case "codex":
+		return modelOptionValues(codexModels[1:]) // skip "default" entry
+	case "copilot":
+		return modelOptionValues(copilotModels[1:])
+	default:
+		return modelOptionValues(claudeModels[1:])
 	}
-	return jiraPhaseModelsByProvider["claude"]
 }
 
 // jiraProviderIndex returns the index of provider in jiraProviders, defaulting to 0.
@@ -2752,9 +2744,11 @@ func (m *setupModel) applyJiraConfig() {
 		if m.jiraPhaseModelIdx[i] < len(models) {
 			model = models[m.jiraPhaseModelIdx[i]]
 		}
+		timeouts := [4]string{"2m", "5m", "30m", "20m"}
 		phases[i] = jiraconfig.PhaseConfig{
 			Provider: provider,
 			Model:    model,
+			Timeout:  timeouts[i],
 		}
 	}
 

--- a/cmd/nightshift/commands/setup_jira_test.go
+++ b/cmd/nightshift/commands/setup_jira_test.go
@@ -1,0 +1,554 @@
+package commands
+
+import (
+	"os"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/marcus/nightshift/internal/config"
+)
+
+// helpers
+
+func newJiraModel() *setupModel {
+	ti := textinput.New()
+	ti.Prompt = "> "
+	return &setupModel{
+		cfg:             &config.Config{},
+		jiraInput:       ti,
+		jiraTokenEnv:    "JIRA_API_TOKEN",
+		jiraLabel:       "nightshift",
+		jiraMaxTickets:  10,
+		jiraPhaseModelIdx: [4]int{0, 1, 1, 1},
+		jiraEnableCursor: 0,
+	}
+}
+
+func keyMsg(s string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+func enterMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyEnter}
+}
+
+// ── Enable sub-step ───────────────────────────────────────────────────────────
+
+func TestJiraEnableInput_Yes(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepEnable
+
+	model, _ := m.handleJiraEnableInput(keyMsg("y"))
+	got := model.(*setupModel)
+	if !got.jiraEnabled {
+		t.Fatal("expected jiraEnabled=true after pressing y")
+	}
+	if got.jiraSubStep != jiraSubStepSite {
+		t.Fatalf("expected sub-step %d, got %d", jiraSubStepSite, got.jiraSubStep)
+	}
+}
+
+func TestJiraEnableInput_No(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepEnable
+
+	model, _ := m.handleJiraEnableInput(keyMsg("n"))
+	got := model.(*setupModel)
+	if got.jiraEnabled {
+		t.Fatal("expected jiraEnabled=false after pressing n")
+	}
+}
+
+func TestJiraEnableInput_EnterSelectsYes(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepEnable
+	m.jiraEnableCursor = 0
+
+	model, _ := m.handleJiraEnableInput(enterMsg())
+	got := model.(*setupModel)
+	if !got.jiraEnabled {
+		t.Fatal("expected jiraEnabled=true when cursor=0 and Enter pressed")
+	}
+}
+
+func TestJiraEnableInput_EnterSelectsNo(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepEnable
+	m.jiraEnableCursor = 1
+
+	model, _ := m.handleJiraEnableInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraEnabled {
+		t.Fatal("expected jiraEnabled=false when cursor=1 and Enter pressed")
+	}
+}
+
+func TestJiraEnableInput_CursorNavigation(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepEnable
+	m.jiraEnableCursor = 0
+
+	model, _ := m.handleJiraEnableInput(tea.KeyMsg{Type: tea.KeyDown})
+	got := model.(*setupModel)
+	if got.jiraEnableCursor != 1 {
+		t.Fatalf("expected cursor 1 after Down, got %d", got.jiraEnableCursor)
+	}
+
+	model, _ = got.handleJiraEnableInput(tea.KeyMsg{Type: tea.KeyDown})
+	got = model.(*setupModel)
+	if got.jiraEnableCursor != 1 {
+		t.Fatal("cursor should not exceed 1")
+	}
+
+	model, _ = got.handleJiraEnableInput(tea.KeyMsg{Type: tea.KeyUp})
+	got = model.(*setupModel)
+	if got.jiraEnableCursor != 0 {
+		t.Fatalf("expected cursor 0 after Up, got %d", got.jiraEnableCursor)
+	}
+}
+
+// ── Text input sub-steps ──────────────────────────────────────────────────────
+
+func TestJiraTextInput_SiteRequired(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepSite
+	m.jiraInput.SetValue("")
+
+	model, _ := m.handleJiraTextInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraErr == "" {
+		t.Fatal("expected error for empty site")
+	}
+}
+
+func TestJiraTextInput_SiteStripsURL(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepSite
+	m.jiraInput.SetValue("https://mysite.atlassian.net")
+
+	model, _ := m.handleJiraTextInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraSite != "mysite" {
+		t.Fatalf("expected site=mysite, got %q", got.jiraSite)
+	}
+	if got.jiraSubStep != jiraSubStepEmail {
+		t.Fatalf("expected sub-step %d, got %d", jiraSubStepEmail, got.jiraSubStep)
+	}
+}
+
+func TestJiraTextInput_SiteSubdomainOnly(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepSite
+	m.jiraInput.SetValue("mysite")
+
+	model, _ := m.handleJiraTextInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraSite != "mysite" {
+		t.Fatalf("expected site=mysite, got %q", got.jiraSite)
+	}
+}
+
+func TestJiraTextInput_EmailRequired(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepEmail
+	m.jiraInput.SetValue("")
+
+	model, _ := m.handleJiraTextInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraErr == "" {
+		t.Fatal("expected error for empty email")
+	}
+}
+
+func TestJiraTextInput_EmailAdvances(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepEmail
+	m.jiraInput.SetValue("user@example.com")
+
+	model, _ := m.handleJiraTextInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraEmail != "user@example.com" {
+		t.Fatalf("expected email stored, got %q", got.jiraEmail)
+	}
+	if got.jiraSubStep != jiraSubStepTokenEnv {
+		t.Fatalf("expected sub-step %d, got %d", jiraSubStepTokenEnv, got.jiraSubStep)
+	}
+}
+
+func TestJiraTextInput_TokenEnvDefault(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepTokenEnv
+	m.jiraInput.SetValue("") // empty → default applied
+
+	model, _ := m.handleJiraTextInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraTokenEnv != "JIRA_API_TOKEN" {
+		t.Fatalf("expected default JIRA_API_TOKEN, got %q", got.jiraTokenEnv)
+	}
+	if got.jiraSubStep != jiraSubStepProject {
+		t.Fatalf("expected sub-step %d, got %d", jiraSubStepProject, got.jiraSubStep)
+	}
+}
+
+func TestJiraTextInput_ProjectKeyUppercased(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepProject
+	m.jiraInput.SetValue("vc")
+
+	model, _ := m.handleJiraTextInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraProjectKey != "VC" {
+		t.Fatalf("expected VC, got %q", got.jiraProjectKey)
+	}
+}
+
+func TestJiraTextInput_LabelDefault(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepLabel
+	m.jiraInput.SetValue("") // empty → default "nightshift"
+
+	model, _ := m.handleJiraTextInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraLabel != "nightshift" {
+		t.Fatalf("expected default 'nightshift', got %q", got.jiraLabel)
+	}
+	if got.jiraSubStep != jiraSubStepRepos {
+		t.Fatalf("expected sub-step %d, got %d", jiraSubStepRepos, got.jiraSubStep)
+	}
+}
+
+func TestJiraTextInput_MaxTicketsDefault(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepMaxTickets
+	m.jiraInput.SetValue("")
+
+	model, _ := m.handleJiraTextInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraMaxTickets != 10 {
+		t.Fatalf("expected 10, got %d", got.jiraMaxTickets)
+	}
+	// Sub-step should advance to ping, and pinging should be true
+	if got.jiraSubStep != jiraSubStepPing {
+		t.Fatalf("expected sub-step %d, got %d", jiraSubStepPing, got.jiraSubStep)
+	}
+	if !got.jiraPinging {
+		t.Fatal("expected jiraPinging=true after advancing to ping step")
+	}
+}
+
+func TestJiraTextInput_MaxTicketsInvalid(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepMaxTickets
+	m.jiraInput.SetValue("abc")
+
+	model, _ := m.handleJiraTextInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraErr == "" {
+		t.Fatal("expected error for non-integer max tickets")
+	}
+	if got.jiraSubStep != jiraSubStepMaxTickets {
+		t.Fatal("should stay on max-tickets sub-step on error")
+	}
+}
+
+func TestJiraTextInput_MaxTicketsZeroRejected(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepMaxTickets
+	m.jiraInput.SetValue("0")
+
+	model, _ := m.handleJiraTextInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraErr == "" {
+		t.Fatal("expected error for zero max tickets")
+	}
+}
+
+// ── Repo sub-step ─────────────────────────────────────────────────────────────
+
+func TestJiraRepoInput_RequiresAtLeastOneRepo(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepRepos
+	m.jiraRepos = nil
+
+	model, _ := m.handleJiraRepoInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraErr == "" {
+		t.Fatal("expected error when no repos configured")
+	}
+}
+
+func TestJiraRepoInput_AddRepo(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepRepos
+	m.jiraRepos = nil
+
+	// Press 'a' to start adding
+	model, _ := m.handleJiraRepoInput(keyMsg("a"))
+	got := model.(*setupModel)
+	if !got.jiraRepoEditing {
+		t.Fatal("expected editing=true after pressing a")
+	}
+	if got.jiraRepoField != 0 {
+		t.Fatal("expected field 0 (URL) first")
+	}
+
+	// Enter the URL
+	got.jiraInput.SetValue("git@github.com:org/repo.git")
+	model, _ = got.handleJiraRepoInput(enterMsg())
+	got = model.(*setupModel)
+	if got.jiraRepoField != 1 {
+		t.Fatalf("expected field 1 (BaseBranch), got %d", got.jiraRepoField)
+	}
+	if got.jiraRepoEditURL != "git@github.com:org/repo.git" {
+		t.Fatalf("expected URL saved, got %q", got.jiraRepoEditURL)
+	}
+
+	// Enter the base branch
+	got.jiraInput.SetValue("main")
+	model, _ = got.handleJiraRepoInput(enterMsg())
+	got = model.(*setupModel)
+	if got.jiraRepoEditing {
+		t.Fatal("expected editing=false after completing repo entry")
+	}
+	if len(got.jiraRepos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(got.jiraRepos))
+	}
+	if got.jiraRepos[0].URL != "git@github.com:org/repo.git" {
+		t.Fatalf("expected URL, got %q", got.jiraRepos[0].URL)
+	}
+	if got.jiraRepos[0].BaseBranch != "main" {
+		t.Fatalf("expected branch=main, got %q", got.jiraRepos[0].BaseBranch)
+	}
+}
+
+func TestJiraRepoInput_DeleteRepo(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepRepos
+	m.jiraRepos = []jiraRepoEntry{
+		{URL: "git@github.com:org/repo.git", BaseBranch: "main"},
+	}
+	m.jiraRepoCursor = 0
+
+	model, _ := m.handleJiraRepoInput(keyMsg("d"))
+	got := model.(*setupModel)
+	if len(got.jiraRepos) != 0 {
+		t.Fatalf("expected 0 repos after delete, got %d", len(got.jiraRepos))
+	}
+}
+
+func TestJiraRepoInput_CancelEditing(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepRepos
+	m.jiraRepoEditing = true
+	m.jiraRepoField = 0
+
+	model, _ := m.handleJiraRepoInput(tea.KeyMsg{Type: tea.KeyEsc})
+	got := model.(*setupModel)
+	if got.jiraRepoEditing {
+		t.Fatal("expected editing=false after Esc")
+	}
+}
+
+func TestJiraRepoInput_EnterAdvancesWithRepo(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepRepos
+	m.jiraRepos = []jiraRepoEntry{
+		{URL: "git@github.com:org/repo.git", BaseBranch: "main"},
+	}
+
+	model, _ := m.handleJiraRepoInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraSubStep != jiraSubStepPhases {
+		t.Fatalf("expected sub-step %d, got %d", jiraSubStepPhases, got.jiraSubStep)
+	}
+}
+
+// ── Phase sub-step ────────────────────────────────────────────────────────────
+
+func TestJiraPhaseInput_Navigation(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepPhases
+	m.jiraPhaseCursor = 0
+
+	model, _ := m.handleJiraPhaseInput(tea.KeyMsg{Type: tea.KeyDown})
+	got := model.(*setupModel)
+	if got.jiraPhaseCursor != 1 {
+		t.Fatalf("expected cursor 1, got %d", got.jiraPhaseCursor)
+	}
+
+	model, _ = got.handleJiraPhaseInput(tea.KeyMsg{Type: tea.KeyDown})
+	model, _ = model.(*setupModel).handleJiraPhaseInput(tea.KeyMsg{Type: tea.KeyDown})
+	model, _ = model.(*setupModel).handleJiraPhaseInput(tea.KeyMsg{Type: tea.KeyDown})
+	got = model.(*setupModel)
+	if got.jiraPhaseCursor != 3 {
+		t.Fatal("cursor should not exceed 3")
+	}
+}
+
+func TestJiraPhaseInput_ModelCycling(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepPhases
+	m.jiraPhaseCursor = 0
+	m.jiraPhaseModelIdx[0] = 0
+
+	// Cycle right
+	model, _ := m.handleJiraPhaseInput(tea.KeyMsg{Type: tea.KeyRight})
+	got := model.(*setupModel)
+	if got.jiraPhaseModelIdx[0] != 1 {
+		t.Fatalf("expected model index 1, got %d", got.jiraPhaseModelIdx[0])
+	}
+
+	// Cycle left
+	model, _ = got.handleJiraPhaseInput(tea.KeyMsg{Type: tea.KeyLeft})
+	got = model.(*setupModel)
+	if got.jiraPhaseModelIdx[0] != 0 {
+		t.Fatalf("expected model index 0 after cycling back, got %d", got.jiraPhaseModelIdx[0])
+	}
+
+	// Don't go below 0
+	model, _ = got.handleJiraPhaseInput(tea.KeyMsg{Type: tea.KeyLeft})
+	got = model.(*setupModel)
+	if got.jiraPhaseModelIdx[0] != 0 {
+		t.Fatal("index should not go below 0")
+	}
+}
+
+func TestJiraPhaseInput_EnterAdvances(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepPhases
+
+	model, _ := m.handleJiraPhaseInput(enterMsg())
+	got := model.(*setupModel)
+	if got.jiraSubStep != jiraSubStepMaxTickets {
+		t.Fatalf("expected sub-step %d, got %d", jiraSubStepMaxTickets, got.jiraSubStep)
+	}
+}
+
+// ── Ping sub-step ─────────────────────────────────────────────────────────────
+
+func TestJiraPingInput_WaitsWhilePinging(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepPing
+	m.jiraPinging = true
+
+	model, _ := m.handleJiraPingInput(enterMsg())
+	got := model.(*setupModel)
+	// Should stay on ping step while still pinging
+	if got.jiraSubStep != jiraSubStepPing {
+		t.Fatal("should stay on ping step while pinging")
+	}
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func TestRepoNameFromURL_SSH(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"git@github.com:org/repo.git", "repo"},
+		{"git@github.com:org/nightshift.git", "nightshift"},
+		{"https://github.com/org/repo.git", "repo"},
+		{"https://github.com/org/repo", "repo"},
+	}
+	for _, tt := range tests {
+		got := repoNameFromURL(tt.url)
+		if got != tt.want {
+			t.Errorf("repoNameFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestJiraModelIndex_Found(t *testing.T) {
+	if len(jiraPhaseModels) == 0 {
+		t.Skip("jiraPhaseModels is empty")
+	}
+	idx := jiraModelIndex(jiraPhaseModels[0])
+	if idx != 0 {
+		t.Fatalf("expected 0, got %d", idx)
+	}
+}
+
+func TestJiraModelIndex_NotFound(t *testing.T) {
+	idx := jiraModelIndex("nonexistent-model")
+	if idx != 0 {
+		t.Fatalf("expected 0 (default), got %d", idx)
+	}
+}
+
+// ── applyJiraConfig ───────────────────────────────────────────────────────────
+
+func TestApplyJiraConfig_Disabled(t *testing.T) {
+	m := newJiraModel()
+	m.jiraEnabled = false
+	m.cfg.Jira.Site = "should-be-cleared"
+
+	m.applyJiraConfig()
+	if m.cfg.Jira.Site != "" {
+		t.Fatal("expected Jira config cleared when disabled")
+	}
+}
+
+func TestApplyJiraConfig_PopulatesFields(t *testing.T) {
+	m := newJiraModel()
+	m.jiraEnabled = true
+	m.jiraSite = "mysite"
+	m.jiraEmail = "user@example.com"
+	m.jiraTokenEnv = "MY_JIRA_TOKEN"
+	m.jiraProjectKey = "PROJ"
+	m.jiraLabel = "nightshift"
+	m.jiraMaxTickets = 5
+	m.jiraPhaseModelIdx = [4]int{0, 1, 1, 1}
+	m.jiraRepos = []jiraRepoEntry{
+		{URL: "git@github.com:org/repo.git", BaseBranch: "main"},
+	}
+
+	m.applyJiraConfig()
+
+	cfg := m.cfg.Jira
+	if cfg.Site != "mysite" {
+		t.Errorf("Site = %q, want mysite", cfg.Site)
+	}
+	if cfg.Email != "user@example.com" {
+		t.Errorf("Email = %q, want user@example.com", cfg.Email)
+	}
+	if cfg.TokenEnv != "MY_JIRA_TOKEN" {
+		t.Errorf("TokenEnv = %q, want MY_JIRA_TOKEN", cfg.TokenEnv)
+	}
+	if cfg.MaxTickets != 5 {
+		t.Errorf("MaxTickets = %d, want 5", cfg.MaxTickets)
+	}
+	if len(cfg.Projects) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(cfg.Projects))
+	}
+	if cfg.Projects[0].Key != "PROJ" {
+		t.Errorf("Projects[0].Key = %q, want PROJ", cfg.Projects[0].Key)
+	}
+	if len(cfg.Projects[0].Repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(cfg.Projects[0].Repos))
+	}
+	if cfg.Projects[0].Repos[0].Name != "repo" {
+		t.Errorf("Repos[0].Name = %q, want repo", cfg.Projects[0].Repos[0].Name)
+	}
+}
+
+// ── Token env var check ───────────────────────────────────────────────────────
+
+func TestTokenEnvVar_Check(t *testing.T) {
+	const envKey = "NIGHTSHIFT_TEST_JIRA_TOKEN_CHECK"
+	os.Unsetenv(envKey)
+
+	// Should be unset
+	if os.Getenv(envKey) != "" {
+		t.Fatal("expected env var to be unset")
+	}
+
+	// Set it
+	os.Setenv(envKey, "test-token")
+	defer os.Unsetenv(envKey)
+
+	if os.Getenv(envKey) == "" {
+		t.Fatal("expected env var to be set")
+	}
+}

--- a/cmd/nightshift/commands/setup_jira_test.go
+++ b/cmd/nightshift/commands/setup_jira_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/marcus/nightshift/internal/config"
+	"github.com/spf13/viper"
 )
 
 // helpers
@@ -15,13 +16,14 @@ func newJiraModel() *setupModel {
 	ti := textinput.New()
 	ti.Prompt = "> "
 	return &setupModel{
-		cfg:             &config.Config{},
-		jiraInput:       ti,
-		jiraTokenEnv:    "JIRA_API_TOKEN",
-		jiraLabel:       "nightshift",
-		jiraMaxTickets:  10,
+		cfg:               &config.Config{},
+		jiraInput:         ti,
+		jiraTokenEnv:      "JIRA_API_TOKEN",
+		jiraLabel:         "nightshift",
+		jiraMaxTickets:    10,
 		jiraPhaseModelIdx: [4]int{0, 1, 1, 1},
-		jiraEnableCursor: 0,
+		jiraPhaseProvider: [4]string{"claude", "claude", "claude", "claude"},
+		jiraEnableCursor:  0,
 	}
 }
 
@@ -550,5 +552,109 @@ func TestTokenEnvVar_Check(t *testing.T) {
 
 	if os.Getenv(envKey) == "" {
 		t.Fatal("expected env var to be set")
+	}
+}
+
+// ── Provider cycling (Tab key) ────────────────────────────────────────────────
+
+func TestJiraPhaseInput_ProviderCycling(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepPhases
+	m.jiraPhaseCursor = 0
+	m.jiraPhaseProvider[0] = "claude"
+	m.jiraPhaseModelIdx[0] = 2 // non-zero to confirm reset
+
+	// Tab should cycle to codex and reset model index.
+	model, _ := m.handleJiraPhaseInput(tea.KeyMsg{Type: tea.KeyTab})
+	got := model.(*setupModel)
+	if got.jiraPhaseProvider[0] != "codex" {
+		t.Fatalf("expected provider=codex after Tab, got %q", got.jiraPhaseProvider[0])
+	}
+	if got.jiraPhaseModelIdx[0] != 0 {
+		t.Fatal("expected model index reset to 0 after provider change")
+	}
+
+	// Tab again: codex → copilot
+	model, _ = got.handleJiraPhaseInput(tea.KeyMsg{Type: tea.KeyTab})
+	got = model.(*setupModel)
+	if got.jiraPhaseProvider[0] != "copilot" {
+		t.Fatalf("expected provider=copilot, got %q", got.jiraPhaseProvider[0])
+	}
+
+	// Tab wraps: copilot → claude
+	model, _ = got.handleJiraPhaseInput(tea.KeyMsg{Type: tea.KeyTab})
+	got = model.(*setupModel)
+	if got.jiraPhaseProvider[0] != "claude" {
+		t.Fatalf("expected provider=claude after wrap, got %q", got.jiraPhaseProvider[0])
+	}
+}
+
+func TestJiraPhaseInput_ModelBoundsPerProvider(t *testing.T) {
+	m := newJiraModel()
+	m.jiraSubStep = jiraSubStepPhases
+	m.jiraPhaseCursor = 0
+	m.jiraPhaseProvider[0] = "codex"
+	maxIdx := len(jiraPhaseModelsByProvider["codex"]) - 1
+	m.jiraPhaseModelIdx[0] = maxIdx
+
+	// Right at max should not exceed bounds.
+	model, _ := m.handleJiraPhaseInput(tea.KeyMsg{Type: tea.KeyRight})
+	got := model.(*setupModel)
+	if got.jiraPhaseModelIdx[0] != maxIdx {
+		t.Fatalf("expected index capped at %d, got %d", maxIdx, got.jiraPhaseModelIdx[0])
+	}
+}
+
+// ── defaultJiraPhaseProviders ─────────────────────────────────────────────────
+
+func TestDefaultJiraPhaseProviders_Empty(t *testing.T) {
+	p := defaultJiraPhaseProviders(nil)
+	for i, v := range p {
+		if v != "claude" {
+			t.Errorf("index %d: expected claude, got %q", i, v)
+		}
+	}
+}
+
+func TestDefaultJiraPhaseProviders_FromPreference(t *testing.T) {
+	p := defaultJiraPhaseProviders([]string{"codex"})
+	for i, v := range p {
+		if v != "codex" {
+			t.Errorf("index %d: expected codex, got %q", i, v)
+		}
+	}
+}
+
+// ── writeGlobalConfigToPath clears jira when disabled ────────────────────────
+
+func TestWriteGlobalConfigToPath_ClearsJiraWhenDisabled(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/config.yaml"
+
+	// Write a config with jira enabled first.
+	cfgEnabled := &config.Config{}
+	cfgEnabled.Jira.Site = "mysite"
+	cfgEnabled.Jira.Email = "user@example.com"
+	if err := writeGlobalConfigToPath(cfgEnabled, path); err != nil {
+		t.Fatalf("write enabled: %v", err)
+	}
+
+	// Now write with jira disabled (Site is empty).
+	cfgDisabled := &config.Config{}
+	if err := writeGlobalConfigToPath(cfgDisabled, path); err != nil {
+		t.Fatalf("write disabled: %v", err)
+	}
+
+	// Re-read via viper and verify jira site is cleared.
+	v := viper.New()
+	v.SetConfigFile(path)
+	if err := v.ReadInConfig(); err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if site := v.GetString("jira.site"); site != "" {
+		t.Errorf("expected jira.site cleared, got %q", site)
+	}
+	if email := v.GetString("jira.email"); email != "" {
+		t.Errorf("expected jira.email cleared, got %q", email)
 	}
 }

--- a/cmd/nightshift/commands/setup_jira_test.go
+++ b/cmd/nightshift/commands/setup_jira_test.go
@@ -463,10 +463,11 @@ func TestRepoNameFromURL_SSH(t *testing.T) {
 }
 
 func TestJiraModelIndex_Found(t *testing.T) {
-	if len(jiraPhaseModels) == 0 {
-		t.Skip("jiraPhaseModels is empty")
+	models := jiraPhaseModelsForProvider("claude")
+	if len(models) == 0 {
+		t.Skip("claude model list is empty")
 	}
-	idx := jiraModelIndex(jiraPhaseModels[0])
+	idx := jiraModelIndex(models[0])
 	if idx != 0 {
 		t.Fatalf("expected 0, got %d", idx)
 	}
@@ -594,7 +595,7 @@ func TestJiraPhaseInput_ModelBoundsPerProvider(t *testing.T) {
 	m.jiraSubStep = jiraSubStepPhases
 	m.jiraPhaseCursor = 0
 	m.jiraPhaseProvider[0] = "codex"
-	maxIdx := len(jiraPhaseModelsByProvider["codex"]) - 1
+	maxIdx := len(jiraPhaseModelsForProvider("codex")) - 1
 	m.jiraPhaseModelIdx[0] = maxIdx
 
 	// Right at max should not exceed bounds.

--- a/internal/calibrator/calibrator_test.go
+++ b/internal/calibrator/calibrator_test.go
@@ -71,8 +71,8 @@ func TestCalibrateWithSamples(t *testing.T) {
 
 	now := time.Now()
 	insertSnapshot(t, database, "claude", 300000, 30, now)
-	insertSnapshot(t, database, "claude", 310000, 30, now.Add(1*time.Hour))
-	insertSnapshot(t, database, "claude", 290000, 30, now.Add(2*time.Hour))
+	insertSnapshot(t, database, "claude", 310000, 30, now.Add(1*time.Minute))
+	insertSnapshot(t, database, "claude", 290000, 30, now.Add(2*time.Minute))
 
 	result, err := cal.Calibrate("claude")
 	if err != nil {
@@ -183,8 +183,8 @@ func TestCalibrateCodexWithLocalTokens(t *testing.T) {
 	// Codex snapshots with real local token data and scraped percentage.
 	// Inferred budget = local_tokens / (scraped_pct / 100)
 	insertSnapshot(t, database, "codex", 500000, 50, now)
-	insertSnapshot(t, database, "codex", 500000, 50, now.Add(1*time.Hour))
-	insertSnapshot(t, database, "codex", 500000, 50, now.Add(2*time.Hour))
+	insertSnapshot(t, database, "codex", 500000, 50, now.Add(1*time.Minute))
+	insertSnapshot(t, database, "codex", 500000, 50, now.Add(2*time.Minute))
 
 	result, err := cal.Calibrate("codex")
 	if err != nil {
@@ -273,9 +273,9 @@ func TestCalibrateCodexFiltersOutOfRange(t *testing.T) {
 	// scraped_pct=5 should be filtered (BETWEEN 10 AND 95)
 	insertSnapshot(t, database, "codex", 50000, 5, now)
 	// scraped_pct=100 should be filtered
-	insertSnapshot(t, database, "codex", 1000000, 100, now.Add(1*time.Hour))
+	insertSnapshot(t, database, "codex", 1000000, 100, now.Add(1*time.Minute))
 	// scraped_pct=40, local_tokens=400000 should be included
-	insertSnapshot(t, database, "codex", 400000, 40, now.Add(2*time.Hour))
+	insertSnapshot(t, database, "codex", 400000, 40, now.Add(2*time.Minute))
 
 	result, err := cal.Calibrate("codex")
 	if err != nil {

--- a/internal/calibrator/calibrator_test.go
+++ b/internal/calibrator/calibrator_test.go
@@ -102,8 +102,8 @@ func TestCalibrateMADOutlier(t *testing.T) {
 
 	now := time.Now()
 	insertSnapshot(t, database, "claude", 100000, 10, now)
-	insertSnapshot(t, database, "claude", 100000, 10, now.Add(1*time.Hour))
-	insertSnapshot(t, database, "claude", 1000000, 10, now.Add(2*time.Hour))
+	insertSnapshot(t, database, "claude", 100000, 10, now.Add(1*time.Minute))
+	insertSnapshot(t, database, "claude", 1000000, 10, now.Add(2*time.Minute))
 
 	result, err := cal.Calibrate("claude")
 	if err != nil {
@@ -218,7 +218,7 @@ func TestCalibrateCodexNoLocalTokensFallsBack(t *testing.T) {
 	// Legacy snapshots with local_tokens=0 (before token parsing was added).
 	// No samples will match local_tokens > 0, so calibrator falls back to config.
 	insertSnapshot(t, database, "codex", 0, 50, now)
-	insertSnapshot(t, database, "codex", 0, 50, now.Add(1*time.Hour))
+	insertSnapshot(t, database, "codex", 0, 50, now.Add(1*time.Minute))
 
 	result, err := cal.Calibrate("codex")
 	if err != nil {
@@ -303,7 +303,7 @@ func TestCalibrateSkipsOutOfRange(t *testing.T) {
 
 	now := time.Now()
 	insertSnapshot(t, database, "claude", 100000, 5, now)
-	insertSnapshot(t, database, "claude", 100000, 50, now.Add(1*time.Hour))
+	insertSnapshot(t, database, "claude", 100000, 50, now.Add(1*time.Minute))
 
 	result, err := cal.Calibrate("claude")
 	if err != nil {


### PR DESCRIPTION
## VC-48 — Setup Wizard: Jira Integration Step

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-48

### Description

Overview
Add a Jira integration step to the nightshift setup interactive onboarding wizard. Users who want the Jira autonomous system should be able to configure it entirely through the wizard instead of hand-editing YAML.
Motivation
The setup wizard currently covers: projects, budget, safety, models, task presets, schedule, snapshots, daemon. But Jira configuration (JiraConfig) must be written manually in YAML. This is the most complex config section (URL, email, token env, project key, label, repos with SSH URLs/base branches, phase-specific provider/model/timeout, max tickets). A guided step reduces friction and prevents common mistakes (e.g., HTTPS instead of SSH repo URLs).
Design
New step: stepJira — inserted after stepSchedule, before stepSnapshot
The step flow:
Enable Jira? — Yes/No toggle. If No, skip the entire section.
Jira instance URL — text input, e.g., https://mysite.atlassian.net
Jira email — text input (for API auth)
Token env var — text input, default JIRA_API_TOKEN. Validate the env var is set and show ✓/✗.
Project key — text input, e.g., VC
Label filter — text input, default nightshift
Repositories — multi-entry (like existing stepProjects):
Name (auto-derived from URL)
Git SSH URL (git@github.com:org/repo.git) — warn if HTTPS detected
Base branch (default main)
Phase models — show the 4 phases (validation, plan, implement, review-fix) with current defaults. Arrow-key navigation to change provider/model per phase. Pre-fill with the model selected in stepModel.
Max tickets per run — number input, default 10
Connection test — auto-ping Jira API, show ✓ Connected / ✗ Failed with error
Config output
Populates cfg.Jira (JiraConfig struct) which gets serialized to the jira: section in the global config YAML.
Conditional step
Like stepPath (conditional on includePathStep), Jira is optional:
Add includeJiraStep bool to setupModel
Set to true when user selects "Yes" at the enable prompt
If false, stepJira is skipped in the stepper and step count
Existing Patterns to Follow
cmd/nightshift/commands/setup.go — Full wizard implementation (bubbletea model, step enum, stepper renderer, field editing)
stepProjects (lines 419-447): Multi-entry input pattern → reuse for repos
stepBudget (lines 448-466): Numeric field editing → reuse for max_tickets
stepModel (lines 475-480): Provider/model selection → reuse for phase models
stepSafety (lines 467-474): Toggle/choice pattern → reuse for enable Jira
renderSetupStepper() (line 1919): Step list rendering
setupSteps() (line 1938): Step registration — add stepJira here
writeGlobalConfig() (line 2080): Config serialization — already handles full config
internal/jira/config.go — JiraConfig, RepoConfig, PhaseConfig structs + Validate() + Defaults()
internal/jira/client.go — Client.Ping() for connection testing
Acceptance Criteria
nightshift setup includes a "Jira integration" step after Schedule
User can enable/disable Jira integration (disabled = skip entire section)
Jira URL, email, and project key are collected via text inputs
Token env var defaults to JIRA_API_TOKEN; wizard checks if the env var is set and shows status
At least one repo must be configured; SSH URL format is validated (warn on HTTPS)
Base branch defaults to main for each repo
Phase models (validation, plan, implement, review-fix) are configurable with sensible defaults
Defaults match JiraConfig.Defaults(): validation=haiku, plan/implement/review=sonnet
Max tickets per run is configurable (default 10)
Connection test pings Jira and reports success/failure
Step is properly numbered in the stepper progress bar
Skipping Jira (disabled) does not leave stale jira: config in output
Generated YAML jira: section passes JiraConfig.Validate()
Label filter defaults to nightshift
Wizard can be completed end-to-end with Jira enabled (no panics, no missing fields)
go test ./cmd/nightshift/commands/... -run Setup passes
go vet ./... and gofmt pass
Agent Workflow
Add stepJira to the setupStep enum (after stepSchedule, before stepSnapshot)
Add includeJiraStep, jira field state to setupModel
Implement handleJiraInput() — multi-field editor with sub-steps (enable → URL → email → token → project → label → repos → phases → max-tickets → ping)
Add Jira rendering in View() switch case
Register stepJira in setupSteps() (conditional like stepPath)
Wire step transitions: stepSchedule → stepJira → stepSnapshot
Populate cfg.Jira in model before writeGlobalConfig()
Write table-driven tests
Run make test && make build

### Acceptance Criteria

nightshift setup includes a "Jira integration" step after Schedule
User can enable/disable Jira integration (disabled = skip entire section)
Jira URL, email, and project key are collected via text inputs
Token env var defaults to JIRA_API_TOKEN; wizard checks if the env var is set and shows status
At least one repo must be configured; SSH URL format is validated (warn on HTTPS)
Base branch defaults to main for each repo
Phase models (validation, plan, implement, review-fix) are configurable with sensible defaults
Defaults match JiraConfig.Defaults(): validation=haiku, plan/implement/review=sonnet
Max tickets per run is configurable (default 10)
Connection test pings Jira and reports success/failure
Step is properly numbered in the stepper progress bar
Skipping Jira (disabled) does not leave stale jira: config in output
Generated YAML jira: section passes JiraConfig.Validate()
Label filter defaults to nightshift
Wizard can be completed end-to-end with Jira enabled (no panics, no missing fields)
go test ./cmd/nightshift/commands/... -run Setup passes
go vet ./... and gofmt pass
Agent Workflow
Add stepJira to the setupStep enum (after stepSchedule, before stepSnapshot)
Add includeJiraStep, jira field state to setupModel
Implement handleJiraInput() — multi-field editor with sub-steps (enable → URL → email → token → project → label → repos → phases → max-tickets → ping)
Add Jira rendering in View() switch case
Register stepJira in setupSteps() (conditional like stepPath)
Wire step transitions: stepSchedule → stepJira → stepSnapshot
Populate cfg.Jira in model before writeGlobalConfig()
Write table-driven tests
Run make test && make build

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
