### PR TITLE
[VC-47] CLI Command: `nightshift jira logs`

### DIFF
--- a/cmd/nightshift/commands/jira_logs.go
+++ b/cmd/nightshift/commands/jira_logs.go
@@ -1,0 +1,184 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/marcus/nightshift/internal/db"
+	"github.com/muesli/termenv"
+	"github.com/spf13/cobra"
+)
+
+// validPhases lists all phase values accepted by --phase.
+var validPhases = []string{"validate", "plan", "implement", "commit", "pr", "status", "review_fix"}
+
+var jiraLogsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "View Jira autonomous run logs",
+	Long: `View logs from nightshift jira run invocations.
+
+By default shows the last 50 log entries scoped to the jira component.
+Use --summary to see a table of tickets processed in a run.
+Use --agent-output to see raw agent stdout stored during a run.`,
+	RunE: runJiraLogs,
+}
+
+func init() {
+	jiraCmd.AddCommand(jiraLogsCmd)
+
+	jiraLogsCmd.Flags().IntP("tail", "n", 50, "Number of log entries to show (default 50)")
+	jiraLogsCmd.Flags().BoolP("follow", "f", false, "Follow log output in real-time")
+	jiraLogsCmd.Flags().StringP("ticket", "t", "", "Filter by ticket key (e.g. VC-42)")
+	jiraLogsCmd.Flags().StringP("run", "r", "", "Filter by run ID or \"latest\"")
+	jiraLogsCmd.Flags().String("phase", "", "Filter by phase (validate|plan|implement|commit|pr|status|review_fix)")
+	jiraLogsCmd.Flags().String("status", "", "Filter by outcome (completed|failed|rejected|skipped)")
+	jiraLogsCmd.Flags().String("since", "", "Start time filter (YYYY-MM-DD or RFC3339)")
+	jiraLogsCmd.Flags().String("until", "", "End time filter (YYYY-MM-DD or RFC3339)")
+	jiraLogsCmd.Flags().String("level", "", "Min log level (debug|info|warn|error)")
+	jiraLogsCmd.Flags().Bool("summary", false, "Show run summary only (ticket counts, durations, outcomes)")
+	jiraLogsCmd.Flags().Bool("agent-output", false, "Show full agent stdout from jira_phase_logs")
+	jiraLogsCmd.Flags().Bool("raw", false, "Raw JSON output (for piping)")
+	jiraLogsCmd.Flags().Bool("no-color", false, "Disable ANSI colors")
+	jiraLogsCmd.Flags().StringP("export", "e", "", "Export to file")
+}
+
+func runJiraLogs(cmd *cobra.Command, _ []string) error {
+	tail, _ := cmd.Flags().GetInt("tail")
+	follow, _ := cmd.Flags().GetBool("follow")
+	ticketKey, _ := cmd.Flags().GetString("ticket")
+	runFlag, _ := cmd.Flags().GetString("run")
+	phaseFlag, _ := cmd.Flags().GetString("phase")
+	statusFlag, _ := cmd.Flags().GetString("status")
+	sinceStr, _ := cmd.Flags().GetString("since")
+	untilStr, _ := cmd.Flags().GetString("until")
+	levelFlag, _ := cmd.Flags().GetString("level")
+	summary, _ := cmd.Flags().GetBool("summary")
+	agentOutput, _ := cmd.Flags().GetBool("agent-output")
+	raw, _ := cmd.Flags().GetBool("raw")
+	noColor, _ := cmd.Flags().GetBool("no-color")
+	exportFile, _ := cmd.Flags().GetString("export")
+
+	if noColor {
+		lipgloss.SetColorProfile(termenv.Ascii)
+	}
+
+	// Validate --phase value.
+	if phaseFlag != "" {
+		valid := false
+		for _, p := range validPhases {
+			if p == phaseFlag {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return fmt.Errorf("invalid --phase %q: must be one of %s", phaseFlag, strings.Join(validPhases, "|"))
+		}
+	}
+
+	// Flag compatibility checks.
+	if follow && (summary || agentOutput || raw || exportFile != "" || runFlag != "") {
+		return fmt.Errorf("--follow cannot be combined with --summary, --agent-output, --raw, --export, or --run")
+	}
+
+	// DB-backed modes need the database.
+	needsDB := summary || agentOutput || runFlag != ""
+
+	var database *db.DB
+	if needsDB {
+		var err error
+		database, err = db.Open(db.DefaultPath())
+		if err != nil {
+			return fmt.Errorf("cannot open database (required for --summary/--run/--agent-output): %w", err)
+		}
+		defer func() { _ = database.Close() }()
+	}
+
+	ctx := context.Background()
+
+	// Resolve --run latest.
+	resolvedRunID := runFlag
+	if runFlag == "latest" {
+		if database == nil {
+			return fmt.Errorf("--run latest requires database access")
+		}
+		id, err := database.GetLatestJiraRunID(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve latest run: %w", err)
+		}
+		if id == "" {
+			return fmt.Errorf("no jira runs found in database")
+		}
+		resolvedRunID = id
+	}
+
+	// --summary mode: query DB and render table.
+	if summary {
+		if resolvedRunID == "" {
+			// Find latest run.
+			id, err := database.GetLatestJiraRunID(ctx)
+			if err != nil {
+				return fmt.Errorf("get latest run: %w", err)
+			}
+			if id == "" {
+				return fmt.Errorf("no jira runs found in database")
+			}
+			resolvedRunID = id
+		}
+		return showJiraRunSummary(ctx, database, resolvedRunID, ticketKey, statusFlag, raw)
+	}
+
+	// --agent-output mode: show phase logs from DB.
+	if agentOutput {
+		if resolvedRunID == "" {
+			id, err := database.GetLatestJiraRunID(ctx)
+			if err != nil {
+				return fmt.Errorf("get latest run: %w", err)
+			}
+			if id == "" {
+				return fmt.Errorf("no jira runs found in database")
+			}
+			resolvedRunID = id
+		}
+		return showJiraAgentOutput(ctx, database, resolvedRunID, ticketKey, phaseFlag, raw)
+	}
+
+	// Log-file mode: build filter.
+	logDir := resolveLogDir("")
+	filter := logFilter{
+		level:     strings.ToLower(strings.TrimSpace(levelFlag)),
+		component: "jira",
+		ticketKey: strings.ToUpper(strings.TrimSpace(ticketKey)),
+	}
+	if filter.level != "" && levelRank(filter.level) == 0 {
+		return fmt.Errorf("invalid log level %q (use debug|info|warn|error)", filter.level)
+	}
+	if sinceStr != "" {
+		parsed, err := parseTimeInput(sinceStr, time.Local)
+		if err != nil {
+			return err
+		}
+		filter.since = &parsed
+	}
+	if untilStr != "" {
+		parsed, err := parseTimeInput(untilStr, time.Local)
+		if err != nil {
+			return err
+		}
+		filter.until = &parsed
+	}
+
+	if exportFile != "" {
+		return exportLogs(logDir, exportFile, filter, tail)
+	}
+	if follow {
+		if filter.until != nil {
+			return fmt.Errorf("--until cannot be used with --follow")
+		}
+		return followLogs(logDir, tail, filter, raw)
+	}
+	return showLogs(logDir, tail, filter, false, raw)
+}

--- a/cmd/nightshift/commands/jira_logs.go
+++ b/cmd/nightshift/commands/jira_logs.go
@@ -84,6 +84,14 @@ func runJiraLogs(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("--follow cannot be combined with --summary, --agent-output, --raw, --export, or --run")
 	}
 
+	// --status and --phase only work with DB-backed modes.
+	if statusFlag != "" && !summary && !agentOutput && runFlag == "" {
+		return fmt.Errorf("--status requires --summary, --agent-output, or --run")
+	}
+	if phaseFlag != "" && !summary && !agentOutput && runFlag == "" {
+		return fmt.Errorf("--phase requires --summary, --agent-output, or --run")
+	}
+
 	// DB-backed modes need the database.
 	needsDB := summary || agentOutput || runFlag != ""
 
@@ -95,6 +103,11 @@ func runJiraLogs(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("cannot open database (required for --summary/--run/--agent-output): %w", err)
 		}
 		defer func() { _ = database.Close() }()
+	}
+
+	// --run requires --summary or --agent-output.
+	if runFlag != "" && !summary && !agentOutput {
+		return fmt.Errorf("--run requires --summary or --agent-output")
 	}
 
 	ctx := context.Background()

--- a/cmd/nightshift/commands/jira_logs_output.go
+++ b/cmd/nightshift/commands/jira_logs_output.go
@@ -1,0 +1,250 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/marcus/nightshift/internal/db"
+)
+
+const maxOutputRunes = 10_000
+
+func showJiraRunSummary(ctx context.Context, database *db.DB, runID, ticketFilter, statusFilter string, raw bool) error {
+	run, err := database.GetJiraRun(ctx, runID)
+	if err != nil {
+		return fmt.Errorf("get run %s: %w", runID, err)
+	}
+	if run == nil {
+		return fmt.Errorf("run %s not found", runID)
+	}
+
+	results, err := database.GetJiraTicketResults(ctx, runID)
+	if err != nil {
+		return fmt.Errorf("get ticket results: %w", err)
+	}
+
+	// Apply filters.
+	var filtered []db.JiraTicketResult
+	for _, r := range results {
+		if ticketFilter != "" && !strings.EqualFold(r.TicketKey, ticketFilter) {
+			continue
+		}
+		if statusFilter != "" && !strings.EqualFold(r.Status, statusFilter) {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+
+	if raw {
+		return renderJiraRunSummaryJSON(run, filtered)
+	}
+
+	return renderJiraRunSummaryTable(run, filtered)
+}
+
+func renderJiraRunSummaryJSON(run *db.JiraRun, results []db.JiraTicketResult) error {
+	enc := json.NewEncoder(newWriter())
+	_ = enc.Encode(map[string]any{
+		"run":     run,
+		"tickets": results,
+	})
+	return nil
+}
+
+type stdoutWriter struct{}
+
+func newWriter() *stdoutWriter { return &stdoutWriter{} }
+func (w *stdoutWriter) Write(p []byte) (int, error) {
+	fmt.Print(string(p))
+	return len(p), nil
+}
+
+func renderJiraRunSummaryTable(run *db.JiraRun, results []db.JiraTicketResult) error {
+	styles := newLogStyles()
+
+	// Header.
+	endStr := "in progress"
+	if run.EndedAt != nil {
+		endStr = run.EndedAt.Format("2006-01-02T15:04:05Z")
+	}
+	header := fmt.Sprintf("Jira Run  %s  → %s  (%d processed, %d completed, %d failed)",
+		run.StartedAt.Format("2006-01-02T15:04:05Z"),
+		endStr,
+		run.TicketsProcessed, run.TicketsCompleted, run.TicketsFailed,
+	)
+	fmt.Println(styles.Title.Render(header))
+	fmt.Println()
+
+	if len(results) == 0 {
+		fmt.Println(styles.Muted.Render("  No ticket results."))
+		return nil
+	}
+
+	// Column widths.
+	const (
+		wTicket = 10
+		wStatus = 12
+		wDur    = 10
+		wPhase  = 12
+		wPR     = 40
+	)
+
+	headerLine := fmt.Sprintf("  %-*s  %-*s  %-*s  %-*s  %s",
+		wTicket, "TICKET",
+		wStatus, "STATUS",
+		wDur, "DURATION",
+		wPhase, "PHASE",
+		"PR",
+	)
+	fmt.Println(styles.Label.Render(headerLine))
+	fmt.Println(styles.Muted.Render("  " + strings.Repeat("─", 70)))
+
+	for _, r := range results {
+		dur := formatDurationMs(r.DurationMs)
+		prCell := "—"
+		if r.PRURL != "" {
+			prCell = r.PRURL
+			if len(prCell) > wPR {
+				prCell = "…" + prCell[len(prCell)-wPR+1:]
+			}
+		}
+		statusStyle := statusStyle(styles, r.Status)
+		line := fmt.Sprintf("  %-*s  %-*s  %-*s  %-*s  %s",
+			wTicket, r.TicketKey,
+			wStatus, r.Status,
+			wDur, dur,
+			wPhase, r.PhaseReached,
+			prCell,
+		)
+		_ = statusStyle
+		fmt.Println(line)
+	}
+
+	return nil
+}
+
+func showJiraAgentOutput(ctx context.Context, database *db.DB, runID, ticketKey, phaseFilter string, raw bool) error {
+	logs, err := database.GetJiraPhaseLogs(ctx, runID, ticketKey, phaseFilter)
+	if err != nil {
+		return fmt.Errorf("get phase logs: %w", err)
+	}
+
+	if len(logs) == 0 {
+		fmt.Println("No phase logs found.")
+		return nil
+	}
+
+	if raw {
+		enc := json.NewEncoder(newWriter())
+		_ = enc.Encode(logs)
+		return nil
+	}
+
+	styles := newLogStyles()
+
+	// Group by ticket key.
+	type group struct {
+		key  string
+		logs []db.JiraPhaseLog
+	}
+	var groups []group
+	seen := make(map[string]int)
+	for _, l := range logs {
+		if idx, ok := seen[l.TicketKey]; ok {
+			groups[idx].logs = append(groups[idx].logs, l)
+		} else {
+			seen[l.TicketKey] = len(groups)
+			groups = append(groups, group{key: l.TicketKey, logs: []db.JiraPhaseLog{l}})
+		}
+	}
+
+	for gi, g := range groups {
+		if gi > 0 {
+			fmt.Println()
+		}
+		fmt.Println(styles.Title.Render(fmt.Sprintf("%s — phase logs", g.key)))
+		for _, l := range g.logs {
+			renderPhaseEntry(l, styles)
+		}
+	}
+
+	return nil
+}
+
+func renderPhaseEntry(l db.JiraPhaseLog, styles logStyles) {
+	status := "✓"
+	if !l.ExitOk {
+		status = "✗"
+	}
+	providerModel := "—"
+	if l.Provider != "" || l.Model != "" {
+		providerModel = fmt.Sprintf("%s/%s", l.Provider, l.Model)
+	}
+	dur := formatDurationMs(l.DurationMs)
+
+	headerLine := fmt.Sprintf("  %-12s  %-30s  %-8s  %s",
+		l.Phase, providerModel, dur, status)
+
+	var lineStyle lipgloss.Style
+	if l.ExitOk {
+		lineStyle = styles.LevelInfo
+	} else {
+		lineStyle = styles.LevelError
+	}
+	fmt.Println(lineStyle.Render(headerLine))
+	fmt.Println(styles.Muted.Render("  " + strings.Repeat("─", 60)))
+
+	if l.Phase == "commit" || l.Phase == "pr" || l.Phase == "status" {
+		fmt.Println(styles.Muted.Render("  (no agent output)"))
+	} else if l.Output == "" && l.Error == "" {
+		fmt.Println(styles.Muted.Render("  (no output recorded)"))
+	} else {
+		if l.Output != "" {
+			output := truncateOutput(l.Output)
+			for _, line := range strings.Split(output, "\n") {
+				fmt.Printf("  %s\n", line)
+			}
+		}
+		if l.Error != "" {
+			fmt.Println(styles.LevelError.Render("  Error: " + l.Error))
+		}
+	}
+	fmt.Println()
+}
+
+func truncateOutput(s string) string {
+	if utf8.RuneCountInString(s) <= maxOutputRunes {
+		return s
+	}
+	runes := []rune(s)
+	truncated := runes[len(runes)-maxOutputRunes:]
+	return "[... truncated ...]\n" + string(truncated)
+}
+
+func formatDurationMs(ms int64) string {
+	d := time.Duration(ms) * time.Millisecond
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	m := int(d.Minutes())
+	s := int(d.Seconds()) % 60
+	return fmt.Sprintf("%dm%02ds", m, s)
+}
+
+func statusStyle(styles logStyles, status string) lipgloss.Style {
+	switch strings.ToLower(status) {
+	case "completed":
+		return styles.LevelInfo
+	case "failed":
+		return styles.LevelError
+	case "rejected":
+		return styles.LevelWarn
+	default:
+		return styles.Muted
+	}
+}

--- a/cmd/nightshift/commands/jira_logs_output.go
+++ b/cmd/nightshift/commands/jira_logs_output.go
@@ -114,14 +114,15 @@ func renderJiraRunSummaryTable(run *db.JiraRun, results []db.JiraTicketResult) e
 			}
 		}
 		statusStyle := statusStyle(styles, r.Status)
+		// Apply status style to the status field
+		styledStatus := statusStyle.Render(r.Status)
 		line := fmt.Sprintf("  %-*s  %-*s  %-*s  %-*s  %s",
 			wTicket, r.TicketKey,
-			wStatus, r.Status,
+			wStatus, styledStatus,
 			wDur, dur,
 			wPhase, r.PhaseReached,
 			prCell,
 		)
-		_ = statusStyle
 		fmt.Println(line)
 	}
 
@@ -221,9 +222,25 @@ func truncateOutput(s string) string {
 	if utf8.RuneCountInString(s) <= maxOutputRunes {
 		return s
 	}
-	runes := []rune(s)
-	truncated := runes[len(runes)-maxOutputRunes:]
-	return "[... truncated ...]\n" + string(truncated)
+	// Efficiently truncate by byte boundary to avoid converting entire string to []rune
+	// This is O(n) in worst case but typically O(maxOutputRunes) in practice
+	startIdx := len(s) - maxOutputRunes*4 // estimate bytes needed (4 bytes per rune max in UTF-8)
+	if startIdx < 0 {
+		startIdx = 0
+	}
+	// Walk backwards from estimated position to find safe UTF-8 boundary
+	for startIdx < len(s) {
+		r, size := utf8.DecodeRuneInString(s[startIdx:])
+		if r == utf8.RuneError {
+			startIdx++ // skip invalid byte
+			continue
+		}
+		if utf8.RuneCountInString(s[startIdx:]) <= maxOutputRunes {
+			break
+		}
+		startIdx += size
+	}
+	return "[... truncated ...]\n" + s[startIdx:]
 }
 
 func formatDurationMs(ms int64) string {

--- a/cmd/nightshift/commands/jira_preview_test.go
+++ b/cmd/nightshift/commands/jira_preview_test.go
@@ -77,9 +77,9 @@ func TestRenderJiraPreviewText_TodoTickets(t *testing.T) {
 
 func TestRenderJiraPreviewText_BlockedTickets(t *testing.T) {
 	result := &jiraPreviewResult{
-		GeneratedAt:  time.Now(),
-		JiraProject:  "PROJ",
-		ConnectionOK: true,
+		GeneratedAt:    time.Now(),
+		JiraProject:    "PROJ",
+		ConnectionOK:   true,
 		ExecutionOrder: []string{"PROJ-1"},
 		FullOrder: []jiraPreviewOrderEntry{
 			{Key: "PROJ-1", Ready: true},
@@ -201,7 +201,7 @@ func TestRenderJiraPreviewText_NoTodoTickets(t *testing.T) {
 		GeneratedAt:  time.Now(),
 		JiraProject:  "PROJ",
 		ConnectionOK: true,
-		Phases: []jiraPreviewPhase{},
+		Phases:       []jiraPreviewPhase{},
 	}
 	out := renderJiraPreviewText(result, jiraPreviewTextOptions{})
 	if !strings.Contains(out, "none") {

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -8,8 +8,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/marcus/nightshift/internal/agents"
 	"github.com/marcus/nightshift/internal/config"
+	"github.com/marcus/nightshift/internal/db"
 	"github.com/marcus/nightshift/internal/jira"
 	"github.com/marcus/nightshift/internal/logging"
 	"github.com/spf13/cobra"
@@ -70,6 +72,18 @@ func runJira(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
+	runID := uuid.New().String()
+	runDB, dbErr := openDB()
+	if dbErr != nil {
+		log.Errorf("open db (run history disabled): %v", dbErr)
+		runDB = nil
+	}
+	if runDB != nil {
+		if err := runDB.SaveJiraRun(ctx, runID, firstProjectKey(cfg.Jira), time.Now()); err != nil {
+			log.Errorf("save jira run: %v", err)
+		}
+	}
+
 	client, err := jira.NewClient(cfg.Jira)
 	if err != nil {
 		return fmt.Errorf("jira client: %w", err)
@@ -90,7 +104,7 @@ func runJira(cmd *cobra.Command, _ []string) error {
 	start := time.Now()
 
 	if singleTicket != "" {
-		found, err := runSingleTicket(ctx, log, client, cfg, statusMap, singleTicket, skipValidation, &results, &feedbackResults)
+		found, err := runSingleTicket(ctx, log, client, cfg, statusMap, singleTicket, skipValidation, runDB, runID, &results, &feedbackResults)
 		if err != nil {
 			return err
 		}
@@ -99,7 +113,7 @@ func runJira(cmd *cobra.Command, _ []string) error {
 		}
 	} else {
 		for _, proj := range cfg.Jira.Projects {
-			orch, err := buildOrchestrator(client, cfg, proj, skipValidation)
+			orch, err := buildOrchestrator(client, cfg, proj, skipValidation, runDB, runID)
 			if err != nil {
 				return err
 			}
@@ -116,6 +130,13 @@ func runJira(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	if runDB != nil {
+		completed, failed := countResults(results)
+		if err := runDB.UpdateJiraRun(ctx, runID, time.Now(), len(results), completed, failed); err != nil {
+			log.Errorf("update jira run: %v", err)
+		}
+	}
+
 	if n, err := jira.CleanupStaleWorkspaces(cfg.Jira); err != nil {
 		log.Errorf("workspace cleanup: %v", err)
 	} else if n > 0 {
@@ -128,7 +149,7 @@ func runJira(cmd *cobra.Command, _ []string) error {
 
 // buildOrchestrator creates an Orchestrator for the given project,
 // constructing agents from the project's effective phase configs.
-func buildOrchestrator(client *jira.Client, cfg *config.Config, proj jira.ProjectConfig, skipValidation bool) (*jira.Orchestrator, error) {
+func buildOrchestrator(client *jira.Client, cfg *config.Config, proj jira.ProjectConfig, skipValidation bool, runDB *db.DB, runID string) (*jira.Orchestrator, error) {
 	jiracfg := cfg.Jira
 
 	var validationAgent agents.Agent
@@ -189,6 +210,9 @@ func buildOrchestrator(client *jira.Client, cfg *config.Config, proj jira.Projec
 	} else {
 		orchOpts = append(orchOpts, jira.WithValidationAgent(validationAgent))
 	}
+	if runDB != nil && runID != "" {
+		orchOpts = append(orchOpts, jira.WithDB(runDB, runID))
+	}
 	return jira.NewOrchestrator(client, jiracfg, proj, orchOpts...), nil
 }
 
@@ -200,6 +224,8 @@ func runSingleTicket(
 	statusMap *jira.StatusMap,
 	key string,
 	skipValidation bool,
+	runDB *db.DB,
+	runID string,
 	results *[]jira.TicketResult,
 	feedbackResults *[]jira.FeedbackResult,
 ) (found bool, err error) {
@@ -217,7 +243,7 @@ func runSingleTicket(
 		if !strings.EqualFold(proj.Key, keyPrefix) {
 			continue
 		}
-		orch, err := buildOrchestrator(client, cfg, proj, skipValidation)
+		orch, err := buildOrchestrator(client, cfg, proj, skipValidation, runDB, runID)
 		if err != nil {
 			return false, err
 		}
@@ -496,17 +522,14 @@ func printFeedbackResult(r *jira.FeedbackResult) {
 }
 
 func printJiraRunSummary(results []jira.TicketResult, feedback []jira.FeedbackResult, d time.Duration) {
-	completed, rejected, skipped, failed := 0, 0, 0, 0
+	completed, failed := countResults(results)
+	rejected, skipped := 0, 0
 	for _, r := range results {
 		switch r.Status {
-		case jira.TicketCompleted:
-			completed++
 		case jira.TicketRejected:
 			rejected++
 		case jira.TicketSkipped:
 			skipped++
-		default:
-			failed++
 		}
 	}
 
@@ -531,4 +554,30 @@ func printJiraRunSummary(results []jira.TicketResult, feedback []jira.FeedbackRe
 		}
 		fmt.Printf("  🔄 Reworked: %d\n", reworked)
 	}
+}
+
+func countResults(results []jira.TicketResult) (completed, failed int) {
+	for _, r := range results {
+		switch r.Status {
+		case jira.TicketCompleted:
+			completed++
+		default:
+			if r.Status != jira.TicketSkipped && r.Status != jira.TicketRejected {
+				failed++
+			}
+		}
+	}
+	return
+}
+
+func firstProjectKey(cfg jira.JiraConfig) string {
+	if len(cfg.Projects) > 0 {
+		return cfg.Projects[0].Key
+	}
+	return ""
+}
+
+// openDB opens the nightshift database; returns nil,err if it cannot be opened.
+func openDB() (*db.DB, error) {
+	return db.Open(db.DefaultPath())
 }

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -79,7 +79,13 @@ func runJira(cmd *cobra.Command, _ []string) error {
 		runDB = nil
 	}
 	if runDB != nil {
-		if err := runDB.SaveJiraRun(ctx, runID, firstProjectKey(cfg.Jira), time.Now()); err != nil {
+		defer func() { _ = runDB.Close() }()
+		projectKey := firstProjectKey(cfg.Jira)
+		// When multiple projects run, use "multi" to avoid misleading metadata.
+		if len(cfg.Jira.Projects) > 1 {
+			projectKey = "multi"
+		}
+		if err := runDB.SaveJiraRun(ctx, runID, projectKey, time.Now()); err != nil {
 			log.Errorf("save jira run: %v", err)
 		}
 	}

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -46,6 +46,9 @@ func runJira(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+	if err := initLogging(cfg); err != nil {
+		return fmt.Errorf("init logging: %w", err)
+	}
 	cfg.Jira.Defaults()
 	if err := cfg.Jira.Validate(); err != nil {
 		return fmt.Errorf("jira config: %w", err)

--- a/cmd/nightshift/commands/logs.go
+++ b/cmd/nightshift/commands/logs.go
@@ -125,6 +125,7 @@ type logEntry struct {
 	Message   string    `json:"message"`
 	Component string    `json:"component,omitempty"`
 	Error     string    `json:"error,omitempty"`
+	TicketKey string    `json:"ticket_key,omitempty"`
 }
 
 type logFilter struct {
@@ -133,6 +134,7 @@ type logFilter struct {
 	level     string
 	component string
 	match     string
+	ticketKey string
 }
 
 type logRecord struct {
@@ -442,6 +444,18 @@ func matchesFilter(record logRecord, filter logFilter) bool {
 			return false
 		}
 		if !strings.Contains(strings.ToLower(record.entry.Component), filter.component) {
+			return false
+		}
+	}
+	if filter.ticketKey != "" {
+		if record.parsed {
+			key := strings.ToUpper(filter.ticketKey)
+			if !strings.Contains(strings.ToUpper(record.entry.TicketKey), key) &&
+				!strings.Contains(strings.ToUpper(record.entry.Message), key) &&
+				!strings.Contains(strings.ToUpper(record.entry.Error), key) {
+				return false
+			}
+		} else if !strings.Contains(strings.ToUpper(record.raw), strings.ToUpper(filter.ticketKey)) {
 			return false
 		}
 	}

--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -154,10 +154,10 @@ type setupModel struct {
 
 	safetyCursor int
 
-	modelCursor      int
-	claudeModelIdx   int
-	codexModelIdx    int
-	copilotModelIdx  int
+	modelCursor     int
+	claudeModelIdx  int
+	codexModelIdx   int
+	copilotModelIdx int
 
 	taskPresetCursor int
 	taskCursor       int

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/ctreminiom/go-atlassian/v2 v2.11.0
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/google/uuid v1.6.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/muesli/termenv v0.16.0
 	github.com/robfig/cron/v3 v3.0.1
@@ -29,7 +30,6 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2,11 +2,13 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -112,4 +114,224 @@ func expandPath(path string) string {
 	}
 
 	return path
+}
+
+// --- Jira run history ---
+
+// JiraRun holds a summary row for a single nightshift jira run CLI invocation.
+type JiraRun struct {
+	RunID            string
+	StartedAt        time.Time
+	EndedAt          *time.Time
+	ProjectKey       string
+	TicketsProcessed int
+	TicketsCompleted int
+	TicketsFailed    int
+}
+
+// JiraTicketResult holds the final outcome of a single ticket within a run.
+type JiraTicketResult struct {
+	ID           int64
+	RunID        string
+	TicketKey    string
+	Status       string
+	DurationMs   int64
+	PhaseReached string
+	PRURL        string
+	ErrorMsg     string
+}
+
+// JiraPhaseLog holds data for a single phase execution within a ticket run.
+type JiraPhaseLog struct {
+	ID         int64
+	RunID      string
+	TicketKey  string
+	Phase      string
+	Provider   string
+	Model      string
+	StartedAt  time.Time
+	DurationMs int64
+	ExitOk     bool
+	Output     string
+	Error      string
+}
+
+// SaveJiraRun inserts a new jira_runs row. Call before the ticket processing loop.
+func (d *DB) SaveJiraRun(ctx context.Context, runID, projectKey string, startedAt time.Time) error {
+	if d == nil || d.sql == nil {
+		return fmt.Errorf("db not open")
+	}
+	_, err := d.sql.ExecContext(ctx,
+		`INSERT INTO jira_runs (run_id, started_at, project_key) VALUES (?, ?, ?)`,
+		runID, startedAt.UTC().Format(time.RFC3339), projectKey,
+	)
+	return err
+}
+
+// UpdateJiraRun updates the ended_at and ticket counters of a jira_runs row.
+func (d *DB) UpdateJiraRun(ctx context.Context, runID string, endedAt time.Time, processed, completed, failed int) error {
+	if d == nil || d.sql == nil {
+		return fmt.Errorf("db not open")
+	}
+	_, err := d.sql.ExecContext(ctx,
+		`UPDATE jira_runs SET ended_at=?, tickets_processed=?, tickets_completed=?, tickets_failed=? WHERE run_id=?`,
+		endedAt.UTC().Format(time.RFC3339), processed, completed, failed, runID,
+	)
+	return err
+}
+
+// SaveJiraTicketResult inserts a jira_ticket_results row.
+func (d *DB) SaveJiraTicketResult(ctx context.Context, r JiraTicketResult) error {
+	if d == nil || d.sql == nil {
+		return fmt.Errorf("db not open")
+	}
+	_, err := d.sql.ExecContext(ctx,
+		`INSERT INTO jira_ticket_results (run_id, ticket_key, status, duration_ms, phase_reached, pr_url, error_msg)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		r.RunID, r.TicketKey, r.Status, r.DurationMs, r.PhaseReached, nullableString(r.PRURL), nullableString(r.ErrorMsg),
+	)
+	return err
+}
+
+// SaveJiraPhaseLog inserts a jira_phase_logs row.
+func (d *DB) SaveJiraPhaseLog(ctx context.Context, l JiraPhaseLog) error {
+	if d == nil || d.sql == nil {
+		return fmt.Errorf("db not open")
+	}
+	exitOk := 0
+	if l.ExitOk {
+		exitOk = 1
+	}
+	_, err := d.sql.ExecContext(ctx,
+		`INSERT INTO jira_phase_logs (run_id, ticket_key, phase, provider, model, started_at, duration_ms, exit_ok, output, error)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		l.RunID, l.TicketKey, l.Phase, nullableString(l.Provider), nullableString(l.Model),
+		l.StartedAt.UTC().Format(time.RFC3339), l.DurationMs, exitOk,
+		nullableString(l.Output), nullableString(l.Error),
+	)
+	return err
+}
+
+// GetLatestJiraRunID returns the run_id of the most recently started jira run.
+// Returns ("", nil) when no runs exist.
+func (d *DB) GetLatestJiraRunID(ctx context.Context) (string, error) {
+	if d == nil || d.sql == nil {
+		return "", fmt.Errorf("db not open")
+	}
+	row := d.sql.QueryRowContext(ctx, `SELECT run_id FROM jira_runs ORDER BY started_at DESC LIMIT 1`)
+	var runID string
+	if err := row.Scan(&runID); err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		return "", err
+	}
+	return runID, nil
+}
+
+// GetJiraTicketResults returns all jira_ticket_results rows for the given run.
+func (d *DB) GetJiraTicketResults(ctx context.Context, runID string) ([]JiraTicketResult, error) {
+	if d == nil || d.sql == nil {
+		return nil, fmt.Errorf("db not open")
+	}
+	rows, err := d.sql.QueryContext(ctx,
+		`SELECT id, run_id, ticket_key, status, duration_ms, phase_reached, COALESCE(pr_url,''), COALESCE(error_msg,'')
+		 FROM jira_ticket_results WHERE run_id=? ORDER BY id`,
+		runID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []JiraTicketResult
+	for rows.Next() {
+		var r JiraTicketResult
+		if err := rows.Scan(&r.ID, &r.RunID, &r.TicketKey, &r.Status, &r.DurationMs, &r.PhaseReached, &r.PRURL, &r.ErrorMsg); err != nil {
+			return nil, err
+		}
+		results = append(results, r)
+	}
+	return results, rows.Err()
+}
+
+// GetJiraPhaseLogs returns jira_phase_logs rows filtered by runID, and optionally by ticketKey and phase.
+// Empty ticketKey or phase means "no filter on that field".
+func (d *DB) GetJiraPhaseLogs(ctx context.Context, runID, ticketKey, phase string) ([]JiraPhaseLog, error) {
+	if d == nil || d.sql == nil {
+		return nil, fmt.Errorf("db not open")
+	}
+	query := `SELECT id, run_id, ticket_key, phase, COALESCE(provider,''), COALESCE(model,''),
+	           started_at, duration_ms, exit_ok, COALESCE(output,''), COALESCE(error,'')
+	           FROM jira_phase_logs WHERE run_id=?`
+	args := []any{runID}
+	if ticketKey != "" {
+		query += " AND ticket_key=?"
+		args = append(args, ticketKey)
+	}
+	if phase != "" {
+		query += " AND phase=?"
+		args = append(args, phase)
+	}
+	query += " ORDER BY id"
+
+	rows, err := d.sql.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var logs []JiraPhaseLog
+	for rows.Next() {
+		var l JiraPhaseLog
+		var startedAtStr string
+		var exitOk int
+		if err := rows.Scan(&l.ID, &l.RunID, &l.TicketKey, &l.Phase, &l.Provider, &l.Model,
+			&startedAtStr, &l.DurationMs, &exitOk, &l.Output, &l.Error); err != nil {
+			return nil, err
+		}
+		l.ExitOk = exitOk != 0
+		if t, err := time.Parse(time.RFC3339, startedAtStr); err == nil {
+			l.StartedAt = t
+		}
+		logs = append(logs, l)
+	}
+	return logs, rows.Err()
+}
+
+// GetJiraRun returns the jira_runs row for the given run_id.
+func (d *DB) GetJiraRun(ctx context.Context, runID string) (*JiraRun, error) {
+	if d == nil || d.sql == nil {
+		return nil, fmt.Errorf("db not open")
+	}
+	row := d.sql.QueryRowContext(ctx,
+		`SELECT run_id, started_at, ended_at, project_key, tickets_processed, tickets_completed, tickets_failed
+		 FROM jira_runs WHERE run_id=?`, runID)
+	var r JiraRun
+	var startedStr string
+	var endedStr sql.NullString
+	if err := row.Scan(&r.RunID, &startedStr, &endedStr, &r.ProjectKey,
+		&r.TicketsProcessed, &r.TicketsCompleted, &r.TicketsFailed); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if t, err := time.Parse(time.RFC3339, startedStr); err == nil {
+		r.StartedAt = t
+	}
+	if endedStr.Valid && endedStr.String != "" {
+		if t, err := time.Parse(time.RFC3339, endedStr.String); err == nil {
+			r.EndedAt = &t
+		}
+	}
+	return &r, nil
+}
+
+// nullableString returns nil for empty strings so they become SQL NULL.
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -40,6 +40,11 @@ var migrations = []Migration{
 		Description: "add branch column to run_history",
 		SQL:         migration005SQL,
 	},
+	{
+		Version:     6,
+		Description: "add jira run history tables: jira_runs, jira_ticket_results, jira_phase_logs",
+		SQL:         migration006SQL,
+	},
 }
 
 const migration002SQL = `
@@ -119,6 +124,46 @@ CREATE INDEX idx_run_history_time ON run_history(start_time DESC);
 
 const migration005SQL = `
 ALTER TABLE run_history ADD COLUMN branch TEXT NOT NULL DEFAULT '';
+`
+
+const migration006SQL = `
+CREATE TABLE IF NOT EXISTS jira_runs (
+    run_id            TEXT     PRIMARY KEY,
+    started_at        DATETIME NOT NULL,
+    ended_at          DATETIME,
+    project_key       TEXT     NOT NULL,
+    tickets_processed INTEGER  NOT NULL DEFAULT 0,
+    tickets_completed INTEGER  NOT NULL DEFAULT 0,
+    tickets_failed    INTEGER  NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS jira_ticket_results (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id        TEXT    NOT NULL REFERENCES jira_runs(run_id),
+    ticket_key    TEXT    NOT NULL,
+    status        TEXT    NOT NULL,
+    duration_ms   INTEGER NOT NULL,
+    phase_reached TEXT    NOT NULL,
+    pr_url        TEXT,
+    error_msg     TEXT
+);
+
+CREATE TABLE IF NOT EXISTS jira_phase_logs (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id      TEXT    NOT NULL REFERENCES jira_runs(run_id),
+    ticket_key  TEXT    NOT NULL,
+    phase       TEXT    NOT NULL,
+    provider    TEXT,
+    model       TEXT,
+    started_at  DATETIME NOT NULL,
+    duration_ms INTEGER  NOT NULL,
+    exit_ok     INTEGER  NOT NULL,
+    output      TEXT,
+    error       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_jira_phase_logs_run_ticket ON jira_phase_logs(run_id, ticket_key);
+CREATE INDEX IF NOT EXISTS idx_jira_ticket_results_run ON jira_ticket_results(run_id);
 `
 
 // Migrate runs all pending migrations inside transactions.

--- a/internal/jira/config.go
+++ b/internal/jira/config.go
@@ -50,7 +50,7 @@ type JiraConfig struct {
 	CleanupAfterDays int    `mapstructure:"cleanup_after_days"` // default: 30
 
 	// Budget
-	BudgetEnabled bool    `mapstructure:"budget_enabled"`  // default: true
+	BudgetEnabled bool    `mapstructure:"budget_enabled"`   // default: true
 	MaxCostPerRun float64 `mapstructure:"max_cost_per_run"` // optional cap per run (USD)
 
 	// Behavior

--- a/internal/jira/dependencies_test.go
+++ b/internal/jira/dependencies_test.go
@@ -139,10 +139,10 @@ func TestBuildDependencyGraph_DoneBlockerIgnored(t *testing.T) {
 	// A-1 is blocked by DONE-99 which has statusCategory="done" — should be treated as resolved.
 	tickets := []Ticket{
 		makeTicket("A-1", []IssueLink{{
-			Type:                 "Blocks",
-			InwardKey:            "DONE-99",
-			OutwardKey:           "A-1",
-			Direction:            "inward",
+			Type:                  "Blocks",
+			InwardKey:             "DONE-99",
+			OutwardKey:            "A-1",
+			Direction:             "inward",
 			BlockerStatusCategory: "done",
 		}}),
 		makeTicket("A-2", nil),

--- a/internal/jira/e2e_test.go
+++ b/internal/jira/e2e_test.go
@@ -573,7 +573,7 @@ func (n *noMutationJiraClient) HandleInvalidTicket(_ context.Context, _ string, 
 	return nil
 }
 func (n *noMutationJiraClient) TransitionToInProgress(_ context.Context, _ string) error { return nil }
-func (n *noMutationJiraClient) TransitionToReview(_ context.Context, _ string) error    { return nil }
+func (n *noMutationJiraClient) TransitionToReview(_ context.Context, _ string) error     { return nil }
 
 func TestE2E_VC8_ProcessTicket_WithStubAgents(t *testing.T) {
 	client := e2eClient(t)

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -154,6 +154,7 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			rfCfg := o.cfg.EffectiveReviewFix(o.proj)
 			timeout := parseTimeout(rfCfg.Timeout, 20*time.Minute)
 			o.emit("🤖 %s running: review-fix  (%s, timeout %s)", rfCfg.Provider, rfCfg.Model, timeout.Round(time.Minute))
+			rfStart := time.Now()
 			agentResult, err := agent.Execute(ctx, agents.ExecuteOptions{
 				Prompt:  prompt,
 				WorkDir: repo.Path,
@@ -161,8 +162,10 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 				Model:   rfCfg.Model,
 			})
 			if err != nil {
+				o.savePhaseLog(ctx, ticket.Key, PhaseReviewFix, rfCfg.Provider, rfCfg.Model, rfStart, false, "", err.Error())
 				return nil, fmt.Errorf("jira: feedback: rework agent %s: %w", repo.Name, err)
 			}
+			o.savePhaseLog(ctx, ticket.Key, PhaseReviewFix, rfCfg.Provider, rfCfg.Model, rfStart, true, agentResult.Output, "")
 
 			// Only commit and report when the agent produced file changes.
 			changed, err := o.fnHasChanges(ctx, repo.Path)

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -55,6 +55,22 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 	result := &FeedbackResult{TicketKey: ticket.Key}
 	start := time.Now()
 
+	// Persist ticket result when ProcessFeedback returns; non-fatal.
+	defer func() {
+		if result != nil {
+			prURL := ""
+			if len(result.PRURLs) > 0 {
+				prURL = result.PRURLs[0]
+			}
+			// For feedback runs, the phase is review_fix and phase_reached is also review_fix.
+			status := "completed"
+			if result.Error != "" {
+				status = "failed"
+			}
+			o.saveTicketResult(ctx, ticket.Key, status, string(PhaseReviewFix), prURL, result.Error, result.Duration.Milliseconds())
+		}
+	}()
+
 	agent := o.reviewFixAgent
 	if agent == nil {
 		agent = o.implAgent

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -14,9 +14,9 @@ import (
 type FeedbackResult struct {
 	TicketKey        string
 	PRURLs           []string
-	ReviewsFound     int // total review comments found
-	FixesMade        int // number of repos where review feedback was addressed
-	PushedCommits    int // number of commits pushed
+	ReviewsFound     int  // total review comments found
+	FixesMade        int  // number of repos where review feedback was addressed
+	PushedCommits    int  // number of commits pushed
 	AcknowledgedOnly bool // true when the agent ran but made no changes (review already handled)
 	Summary          string
 	Error            string

--- a/internal/jira/feedback_test.go
+++ b/internal/jira/feedback_test.go
@@ -70,19 +70,19 @@ func TestBuildReworkPrompt(t *testing.T) {
 	mustContain := []string{
 		// Ticket context
 		"VC-10",
-		"feedback loop",                           // Summary
-		"Implement the PR feedback loop",          // Description
-		"Agent addresses all reviewer comments",   // AcceptanceCriteria
-		"please also check edge cases",            // Comment body
-		"alice",                                   // Comment author
+		"feedback loop",                         // Summary
+		"Implement the PR feedback loop",        // Description
+		"Agent addresses all reviewer comments", // AcceptanceCriteria
+		"please also check edge cases",          // Comment body
+		"alice",                                 // Comment author
 		// PR review context
 		"https://github.com/org/repo/pull/42",
 		"nightshift",
 		"feature/VC-10",
-		"fix the nil check",          // CHANGES_REQUESTED review included
-		"consider renaming",          // COMMENTED review included
-		"main.go:42",                 // inline comment path:line
-		"add error handling here",    // inline comment body
+		"fix the nil check",       // CHANGES_REQUESTED review included
+		"consider renaming",       // COMMENTED review included
+		"main.go:42",              // inline comment path:line
+		"add error handling here", // inline comment body
 		"Address ALL reviewer feedback",
 	}
 	for _, want := range mustContain {

--- a/internal/jira/mock_server_test.go
+++ b/internal/jira/mock_server_test.go
@@ -17,13 +17,13 @@ import (
 
 // mockServerConfig controls which endpoints succeed and which fail.
 type mockServerConfig struct {
-	myselfStatus      int
-	statusesPayload   string // JSON for project statuses
-	commentStatus     int
-	transitionsGet    string // JSON for GET transitions
-	transitionsPost   int    // HTTP status for POST transitions (move)
-	searchPayload     string // JSON for POST /rest/api/3/search
-	failTransitions   bool   // force GET transitions to return error
+	myselfStatus    int
+	statusesPayload string // JSON for project statuses
+	commentStatus   int
+	transitionsGet  string // JSON for GET transitions
+	transitionsPost int    // HTTP status for POST transitions (move)
+	searchPayload   string // JSON for POST /rest/api/3/search
+	failTransitions bool   // force GET transitions to return error
 }
 
 func defaultMockConfig() mockServerConfig {
@@ -45,7 +45,7 @@ func defaultMockConfig() mockServerConfig {
 			{"id":"11","name":"Todo","to":{"id":"10001","statusCategory":{"key":"new"}}}
 		]}`,
 		transitionsPost: http.StatusNoContent,
-		searchPayload: `{"total":0,"issues":[]}`,
+		searchPayload:   `{"total":0,"issues":[]}`,
 	}
 }
 

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -310,6 +310,13 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 		o.fnPushBranch = PushBranch
 	}
 
+	if o.implAgent == nil {
+		return nil, fmt.Errorf("jira: orchestrator: impl agent is required")
+	}
+	if !o.skipValidation && o.validationAgent == nil {
+		return nil, fmt.Errorf("jira: orchestrator: validation agent is required when not skipping validation")
+	}
+
 	start := time.Now()
 	result := &TicketResult{TicketKey: ticket.Key}
 
@@ -323,13 +330,6 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			o.saveTicketResult(ctx, ticket.Key, string(result.Status), string(result.Phase), prURL, result.Error, result.Duration.Milliseconds())
 		}
 	}()
-
-	if o.implAgent == nil {
-		return nil, fmt.Errorf("jira: orchestrator: impl agent is required")
-	}
-	if !o.skipValidation && o.validationAgent == nil {
-		return nil, fmt.Errorf("jira: orchestrator: validation agent is required when not skipping validation")
-	}
 
 	rs := detectResumeState(ticket)
 	if rs.alreadyDone {
@@ -489,6 +489,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	if !skip(PhaseCommit) {
 		result.Phase = PhaseCommit
 		o.notifyPhase(ticket.Key, PhaseCommit, false)
+		commitStart := time.Now()
 		var changedRepos []RepoWorkspace
 		var skippedRepos []RepoWorkspace // repos with no uncommitted changes
 		if ws != nil {
@@ -500,6 +501,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 					result.Error = err.Error()
 					result.Duration = time.Since(start)
 					o.notifyPhase(ticket.Key, PhaseCommit, true)
+					o.savePhaseLog(ctx, ticket.Key, PhaseCommit, "", "", commitStart, false, "", err.Error())
 					return result, nil
 				}
 				if !changed {
@@ -511,6 +513,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 						result.Error = err.Error()
 						result.Duration = time.Since(start)
 						o.notifyPhase(ticket.Key, PhaseCommit, true)
+						o.savePhaseLog(ctx, ticket.Key, PhaseCommit, "", "", commitStart, false, "", err.Error())
 						return result, nil
 					}
 					if localAhead {
@@ -521,6 +524,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 							result.Error = err.Error()
 							result.Duration = time.Since(start)
 							o.notifyPhase(ticket.Key, PhaseCommit, true)
+							o.savePhaseLog(ctx, ticket.Key, PhaseCommit, "", "", commitStart, false, "", err.Error())
 							return result, nil
 						}
 						changedRepos = append(changedRepos, repo)
@@ -542,12 +546,15 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 					result.Error = err.Error()
 					result.Duration = time.Since(start)
 					o.notifyPhase(ticket.Key, PhaseCommit, true)
+					o.savePhaseLog(ctx, ticket.Key, PhaseCommit, "", "", commitStart, false, "", err.Error())
 					return result, nil
 				}
 				changedRepos = append(changedRepos, repo)
 			}
 		}
 		o.notifyPhase(ticket.Key, PhaseCommit, true)
+		// Persist commit phase log (non-agent phase: no provider/model/output).
+		o.savePhaseLog(ctx, ticket.Key, PhaseCommit, "", "", commitStart, true, "", "")
 
 		// Recovery pass: a repo with no uncommitted changes may have been committed and pushed
 		// in a prior run that crashed before the CommentPR was posted. If the branch is ahead
@@ -660,6 +667,8 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			}
 		}
 		o.notifyPhase(ticket.Key, PhasePR, true)
+		// Persist PR phase log (non-agent phase: no provider/model/output).
+		o.savePhaseLog(ctx, ticket.Key, PhasePR, "", "", prStart, true, "", "")
 	} else if skip(PhaseCommit) && !skip(PhaseStatus) {
 		// Resuming at PhaseStatus: scan workspace repos for open PRs and merge with
 		// any URLs recovered from comments, deduplicating to avoid duplicates when
@@ -686,6 +695,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	if !skip(PhaseStatus) {
 		result.Phase = PhaseStatus
 		o.notifyPhase(ticket.Key, PhaseStatus, false)
+		statusStart := time.Now()
 		o.emit("🔄 transitioning %s → review (Jira)", ticket.Key)
 		if err := o.client.TransitionToReview(ctx, ticket.Key); err != nil {
 			o.postErrorComment(ctx, ticket.Key, PhaseStatus, err)
@@ -693,9 +703,12 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			result.Error = err.Error()
 			result.Duration = time.Since(start)
 			o.notifyPhase(ticket.Key, PhaseStatus, true)
+			o.savePhaseLog(ctx, ticket.Key, PhaseStatus, "", "", statusStart, false, "", err.Error())
 			return result, nil
 		}
 		o.notifyPhase(ticket.Key, PhaseStatus, true)
+		// Persist status phase log (non-agent phase: no provider/model/output).
+		o.savePhaseLog(ctx, ticket.Key, PhaseStatus, "", "", statusStart, true, "", "")
 	}
 
 	result.Status = TicketCompleted
@@ -928,7 +941,7 @@ func (o *Orchestrator) savePhaseLog(ctx context.Context, ticketKey string, phase
 	}
 }
 
-// saveTicketResult persists the final ticket outcome to the DB. Non-fatal: logs WARN on error.
+// saveTicketResult persists the final ticket outcome to the DB. Non-fatal: logs error on failure.
 func (o *Orchestrator) saveTicketResult(ctx context.Context, ticketKey, status, phaseReached, prURL, errMsg string, durationMs int64) {
 	if o.db == nil || o.runID == "" {
 		return

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -7,8 +7,15 @@ import (
 	"time"
 
 	"github.com/marcus/nightshift/internal/agents"
+	"github.com/marcus/nightshift/internal/db"
 	"github.com/marcus/nightshift/internal/logging"
 )
+
+// jiraDB is a local interface satisfied by *db.DB.
+type jiraDB interface {
+	SaveJiraPhaseLog(ctx context.Context, l db.JiraPhaseLog) error
+	SaveJiraTicketResult(ctx context.Context, r db.JiraTicketResult) error
+}
 
 // Phase represents a stage in the Jira ticket processing lifecycle.
 type Phase string
@@ -20,7 +27,19 @@ const (
 	PhaseCommit    Phase = "commit"
 	PhasePR        Phase = "pr"
 	PhaseStatus    Phase = "status"
+	PhaseReviewFix Phase = "review_fix"
 )
+
+// AllPhases lists every valid phase value accepted by --phase filters.
+var AllPhases = []Phase{
+	PhaseValidate,
+	PhasePlan,
+	PhaseImplement,
+	PhaseCommit,
+	PhasePR,
+	PhaseStatus,
+	PhaseReviewFix,
+}
 
 // TicketStatus represents the outcome of processing a ticket.
 type TicketStatus string
@@ -67,6 +86,10 @@ type Orchestrator struct {
 	onPhase         func(ticketKey string, phase Phase, done bool) // optional progress callback
 	progressf       func(format string, args ...any)               // optional human-readable progress printer
 	log             *logging.Logger
+
+	// db and runID are optional; when set, phase logs and ticket results are persisted.
+	db    jiraDB
+	runID string
 
 	// ops are injectable for testing; set to real functions by NewOrchestrator.
 	fnHasChanges        func(ctx context.Context, repoPath string) (bool, error)
@@ -122,6 +145,15 @@ func WithPhaseCallback(fn func(ticketKey string, phase Phase, done bool)) Orches
 // progress events (agent start, PR creation, Jira transitions, etc.).
 func WithProgressPrinter(fn func(format string, args ...any)) OrchestratorOption {
 	return func(o *Orchestrator) { o.progressf = fn }
+}
+
+// WithDB attaches a database and run ID for persisting phase logs and ticket results.
+// When not set, persistence is skipped and the orchestrator operates as before.
+func WithDB(d jiraDB, runID string) OrchestratorOption {
+	return func(o *Orchestrator) {
+		o.db = d
+		o.runID = runID
+	}
 }
 
 // NewOrchestrator creates an Orchestrator with the given client, config, project, and options.
@@ -281,6 +313,17 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	start := time.Now()
 	result := &TicketResult{TicketKey: ticket.Key}
 
+	// Persist ticket result when ProcessTicket returns; non-fatal.
+	defer func() {
+		if result != nil {
+			prURL := ""
+			if len(result.PRURLs) > 0 {
+				prURL = result.PRURLs[0]
+			}
+			o.saveTicketResult(ctx, ticket.Key, string(result.Status), string(result.Phase), prURL, result.Error, result.Duration.Milliseconds())
+		}
+	}()
+
 	if o.implAgent == nil {
 		return nil, fmt.Errorf("jira: orchestrator: impl agent is required")
 	}
@@ -326,8 +369,11 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 		result.Phase = PhaseValidate
 		o.notifyPhase(ticket.Key, PhaseValidate, false)
 		if !o.skipValidation {
+			validateStart := time.Now()
+			valCfg := o.cfg.EffectiveValidation(o.proj)
 			vr, err := ValidateTicket(ctx, o.validationAgent, ticket)
 			if err != nil {
+				o.savePhaseLog(ctx, ticket.Key, PhaseValidate, valCfg.Provider, valCfg.Model, validateStart, false, "", err.Error())
 				o.postErrorComment(ctx, ticket.Key, PhaseValidate, err)
 				result.Status = TicketFailed
 				result.Error = err.Error()
@@ -337,6 +383,8 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				return result, nil
 			}
 			if !vr.Valid {
+				issues := strings.Join(vr.Issues, "; ")
+				o.savePhaseLog(ctx, ticket.Key, PhaseValidate, valCfg.Provider, valCfg.Model, validateStart, false, issues, fmt.Sprintf("score %d/10: %s", vr.Score, issues))
 				if hErr := o.client.HandleInvalidTicket(ctx, ticket.Key, vr); hErr != nil {
 					o.log.Errorf("ticket %s: handle invalid: %v", ticket.Key, hErr)
 				}
@@ -347,6 +395,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				o.notifyPhase(ticket.Key, PhaseValidate, true)
 				return result, nil
 			}
+			o.savePhaseLog(ctx, ticket.Key, PhaseValidate, valCfg.Provider, valCfg.Model, validateStart, true, strings.Join(vr.Suggestions, "; "), "")
 			o.postPhaseComment(ctx, ticket.Key, CommentValidation,
 				fmt.Sprintf("Ticket validated (score %d/10).", vr.Score), time.Since(start))
 			o.log.Infof("ticket %s validated (score %d/10)", ticket.Key, vr.Score)
@@ -383,6 +432,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			Model:   planCfg.Model,
 		})
 		if err != nil {
+			o.savePhaseLog(ctx, ticket.Key, PhasePlan, planCfg.Provider, planCfg.Model, planStart, false, "", err.Error())
 			o.postErrorComment(ctx, ticket.Key, PhasePlan, err)
 			result.Status = TicketFailed
 			result.Error = err.Error()
@@ -391,6 +441,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			o.notifyPhase(ticket.Key, PhasePlan, true)
 			return result, nil
 		}
+		o.savePhaseLog(ctx, ticket.Key, PhasePlan, planCfg.Provider, planCfg.Model, planStart, true, planResult.Output, "")
 		result.Plan = planResult.Output
 		o.emit("📝 posting plan to Jira %s", ticket.Key)
 		o.postPhaseComment(ctx, ticket.Key, CommentPlan, planResult.Output, time.Since(planStart))
@@ -417,6 +468,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			Model:   implCfg.Model,
 		})
 		if err != nil {
+			o.savePhaseLog(ctx, ticket.Key, PhaseImplement, implCfg.Provider, implCfg.Model, implStart, false, "", err.Error())
 			o.postErrorComment(ctx, ticket.Key, PhaseImplement, err)
 			result.Status = TicketFailed
 			result.Error = err.Error()
@@ -425,6 +477,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			o.notifyPhase(ticket.Key, PhaseImplement, true)
 			return result, nil
 		}
+		o.savePhaseLog(ctx, ticket.Key, PhaseImplement, implCfg.Provider, implCfg.Model, implStart, true, implResult.Output, "")
 		result.ImplementationSummary = implResult.Output
 		o.emit("📝 posting implementation summary to Jira %s", ticket.Key)
 		o.postPhaseComment(ctx, ticket.Key, CommentImplement, implResult.Output, time.Since(implStart))
@@ -850,5 +903,46 @@ func (o *Orchestrator) notifyPhase(ticketKey string, phase Phase, done bool) {
 func (o *Orchestrator) emit(format string, args ...any) {
 	if o.progressf != nil {
 		o.progressf(format, args...)
+	}
+}
+
+// savePhaseLog persists a phase execution record to the DB. Non-fatal: logs WARN on error.
+func (o *Orchestrator) savePhaseLog(ctx context.Context, ticketKey string, phase Phase, provider, model string, startedAt time.Time, exitOk bool, output, errMsg string) {
+	if o.db == nil || o.runID == "" {
+		return
+	}
+	l := db.JiraPhaseLog{
+		RunID:      o.runID,
+		TicketKey:  ticketKey,
+		Phase:      string(phase),
+		Provider:   provider,
+		Model:      model,
+		StartedAt:  startedAt,
+		DurationMs: time.Since(startedAt).Milliseconds(),
+		ExitOk:     exitOk,
+		Output:     output,
+		Error:      errMsg,
+	}
+	if err := o.db.SaveJiraPhaseLog(ctx, l); err != nil {
+		o.log.Errorf("save phase log %s/%s: %v", ticketKey, phase, err)
+	}
+}
+
+// saveTicketResult persists the final ticket outcome to the DB. Non-fatal: logs WARN on error.
+func (o *Orchestrator) saveTicketResult(ctx context.Context, ticketKey, status, phaseReached, prURL, errMsg string, durationMs int64) {
+	if o.db == nil || o.runID == "" {
+		return
+	}
+	r := db.JiraTicketResult{
+		RunID:        o.runID,
+		TicketKey:    ticketKey,
+		Status:       status,
+		DurationMs:   durationMs,
+		PhaseReached: phaseReached,
+		PRURL:        prURL,
+		ErrorMsg:     errMsg,
+	}
+	if err := o.db.SaveJiraTicketResult(ctx, r); err != nil {
+		o.log.Errorf("save ticket result %s: %v", ticketKey, err)
 	}
 }

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -92,12 +92,12 @@ type Orchestrator struct {
 	runID string
 
 	// ops are injectable for testing; set to real functions by NewOrchestrator.
-	fnHasChanges        func(ctx context.Context, repoPath string) (bool, error)
-	fnCommitAndPush     func(ctx context.Context, repoPath, message string) error
-	fnCreatePR          func(ctx context.Context, repo RepoWorkspace, ticket Ticket, jiraSite string) (*PRInfo, error)
-	fnFindPR            func(ctx context.Context, repoPath, branch string) (*PRInfo, error)
-	fnFetchReviews      func(ctx context.Context, repoPath, prURL string) (*PRReviewState, error)
-	fnPostPRComment     func(ctx context.Context, repoPath, prURL, body string) error
+	fnHasChanges             func(ctx context.Context, repoPath string) (bool, error)
+	fnCommitAndPush          func(ctx context.Context, repoPath, message string) error
+	fnCreatePR               func(ctx context.Context, repo RepoWorkspace, ticket Ticket, jiraSite string) (*PRInfo, error)
+	fnFindPR                 func(ctx context.Context, repoPath, branch string) (*PRInfo, error)
+	fnFetchReviews           func(ctx context.Context, repoPath, prURL string) (*PRReviewState, error)
+	fnPostPRComment          func(ctx context.Context, repoPath, prURL, body string) error
 	fnBranchAheadOfBase      func(ctx context.Context, repoPath, branch, base string) (bool, error)
 	fnLocalBranchAheadOfBase func(ctx context.Context, repoPath, base string) (bool, error)
 	fnPushBranch             func(ctx context.Context, repoPath string) error
@@ -816,6 +816,7 @@ func (o *Orchestrator) buildImplementPrompt(ticket Ticket, plan string, ws *Work
 	}
 	return b.String()
 }
+
 // implementation summary so reviewers have full context inline.
 func buildPRImplementationComment(ticket Ticket, summary, jiraSite string) string {
 	var b strings.Builder

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -919,7 +919,7 @@ func (o *Orchestrator) emit(format string, args ...any) {
 	}
 }
 
-// savePhaseLog persists a phase execution record to the DB. Non-fatal: logs WARN on error.
+// savePhaseLog persists a phase execution record to the DB. Non-fatal: logs error on failure.
 func (o *Orchestrator) savePhaseLog(ctx context.Context, ticketKey string, phase Phase, provider, model string, startedAt time.Time, exitOk bool, output, errMsg string) {
 	if o.db == nil || o.runID == "" {
 		return

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/marcus/nightshift/internal/agents"
+	"github.com/marcus/nightshift/internal/db"
 )
 
 // stubJiraClient implements the jiraClient interface for testing.
@@ -1776,4 +1777,129 @@ func (s *stubJiraClientSelectiveErr) TransitionToInProgress(_ context.Context, i
 func (s *stubJiraClientSelectiveErr) TransitionToReview(_ context.Context, issueKey string) error {
 	s.transitionCalls = append(s.transitionCalls, "review:"+issueKey)
 	return s.reviewErr
+}
+
+// stubDB implements the jiraDB interface for testing.
+type stubDB struct {
+phaseLogs     []db.JiraPhaseLog
+ticketResults []db.JiraTicketResult
+err           error
+}
+
+func (s *stubDB) SaveJiraPhaseLog(_ context.Context, l db.JiraPhaseLog) error {
+if s.err != nil {
+return s.err
+}
+s.phaseLogs = append(s.phaseLogs, l)
+return nil
+}
+
+func (s *stubDB) SaveJiraTicketResult(_ context.Context, r db.JiraTicketResult) error {
+if s.err != nil {
+return s.err
+}
+s.ticketResults = append(s.ticketResults, r)
+return nil
+}
+
+func TestWithDB_OptionsSet(t *testing.T) {
+db := &stubDB{}
+runID := "test-run-123"
+
+o := &Orchestrator{}
+WithDB(db, runID)(o)
+
+if o.db != db {
+t.Error("WithDB did not set db")
+}
+if o.runID != runID {
+t.Error("WithDB did not set runID")
+}
+}
+
+func TestProcessTicket_DBPersistence_PhaseLogsRecorded(t *testing.T) {
+sc := &stubJiraClient{}
+ia := &stubAgent{name: "impl", output: "implementation done"}
+db := &stubDB{}
+runID := "run-phase-test"
+
+o := &Orchestrator{
+client:          sc,
+cfg:             JiraConfig{},
+skipValidation:  true,
+implAgent:       ia,
+db:              db,
+runID:           runID,
+}
+
+ticket := Ticket{Key: "DB-1", Summary: "DB test", Description: "Do the thing."}
+ws := &Workspace{TicketKey: "DB-1"}
+
+_, err := o.ProcessTicket(context.Background(), ticket, ws)
+if err != nil {
+t.Fatalf("ProcessTicket failed: %v", err)
+}
+
+// Verify phase logs were recorded (at least for implement phase).
+if len(db.phaseLogs) == 0 {
+t.Error("no phase logs recorded")
+}
+
+// Verify ticket result was recorded.
+if len(db.ticketResults) == 0 {
+t.Error("no ticket results recorded")
+}
+}
+
+func TestProcessTicket_DBPersistence_NonFatalOnError(t *testing.T) {
+sc := &stubJiraClient{}
+ia := &stubAgent{name: "impl", output: "implementation done"}
+db := &stubDB{err: errors.New("db write failed")}
+runID := "run-nonfatal-test"
+
+o := &Orchestrator{
+client:          sc,
+cfg:             JiraConfig{},
+skipValidation:  true,
+implAgent:       ia,
+db:              db,
+runID:           runID,
+}
+
+ticket := Ticket{Key: "NF-1", Summary: "Non-fatal test", Description: "Do the thing."}
+ws := &Workspace{TicketKey: "NF-1"}
+
+result, err := o.ProcessTicket(context.Background(), ticket, ws)
+// ProcessTicket should NOT error; DB errors are non-fatal
+if err != nil {
+t.Fatalf("ProcessTicket failed with DB error (should be non-fatal): %v", err)
+}
+if result == nil || result.Status != TicketCompleted {
+t.Error("ProcessTicket should have completed despite DB error")
+}
+}
+
+func TestProcessTicket_DBPersistence_NoDBIsNoop(t *testing.T) {
+sc := &stubJiraClient{}
+ia := &stubAgent{name: "impl", output: "implementation done"}
+
+o := &Orchestrator{
+client:          sc,
+cfg:             JiraConfig{},
+skipValidation:  true,
+implAgent:       ia,
+db:              nil, // no DB
+runID:           "",
+}
+
+ticket := Ticket{Key: "NODB-1", Summary: "No DB test", Description: "Do the thing."}
+ws := &Workspace{TicketKey: "NODB-1"}
+
+result, err := o.ProcessTicket(context.Background(), ticket, ws)
+if err != nil {
+t.Fatalf("ProcessTicket failed: %v", err)
+}
+if result == nil || result.Status != TicketCompleted {
+t.Error("ProcessTicket should complete when DB is nil")
+}
 }

--- a/internal/jira/orchestrator_test.go
+++ b/internal/jira/orchestrator_test.go
@@ -1781,125 +1781,125 @@ func (s *stubJiraClientSelectiveErr) TransitionToReview(_ context.Context, issue
 
 // stubDB implements the jiraDB interface for testing.
 type stubDB struct {
-phaseLogs     []db.JiraPhaseLog
-ticketResults []db.JiraTicketResult
-err           error
+	phaseLogs     []db.JiraPhaseLog
+	ticketResults []db.JiraTicketResult
+	err           error
 }
 
 func (s *stubDB) SaveJiraPhaseLog(_ context.Context, l db.JiraPhaseLog) error {
-if s.err != nil {
-return s.err
-}
-s.phaseLogs = append(s.phaseLogs, l)
-return nil
+	if s.err != nil {
+		return s.err
+	}
+	s.phaseLogs = append(s.phaseLogs, l)
+	return nil
 }
 
 func (s *stubDB) SaveJiraTicketResult(_ context.Context, r db.JiraTicketResult) error {
-if s.err != nil {
-return s.err
-}
-s.ticketResults = append(s.ticketResults, r)
-return nil
+	if s.err != nil {
+		return s.err
+	}
+	s.ticketResults = append(s.ticketResults, r)
+	return nil
 }
 
 func TestWithDB_OptionsSet(t *testing.T) {
-db := &stubDB{}
-runID := "test-run-123"
+	db := &stubDB{}
+	runID := "test-run-123"
 
-o := &Orchestrator{}
-WithDB(db, runID)(o)
+	o := &Orchestrator{}
+	WithDB(db, runID)(o)
 
-if o.db != db {
-t.Error("WithDB did not set db")
-}
-if o.runID != runID {
-t.Error("WithDB did not set runID")
-}
+	if o.db != db {
+		t.Error("WithDB did not set db")
+	}
+	if o.runID != runID {
+		t.Error("WithDB did not set runID")
+	}
 }
 
 func TestProcessTicket_DBPersistence_PhaseLogsRecorded(t *testing.T) {
-sc := &stubJiraClient{}
-ia := &stubAgent{name: "impl", output: "implementation done"}
-db := &stubDB{}
-runID := "run-phase-test"
+	sc := &stubJiraClient{}
+	ia := &stubAgent{name: "impl", output: "implementation done"}
+	db := &stubDB{}
+	runID := "run-phase-test"
 
-o := &Orchestrator{
-client:          sc,
-cfg:             JiraConfig{},
-skipValidation:  true,
-implAgent:       ia,
-db:              db,
-runID:           runID,
-}
+	o := &Orchestrator{
+		client:         sc,
+		cfg:            JiraConfig{},
+		skipValidation: true,
+		implAgent:      ia,
+		db:             db,
+		runID:          runID,
+	}
 
-ticket := Ticket{Key: "DB-1", Summary: "DB test", Description: "Do the thing."}
-ws := &Workspace{TicketKey: "DB-1"}
+	ticket := Ticket{Key: "DB-1", Summary: "DB test", Description: "Do the thing."}
+	ws := &Workspace{TicketKey: "DB-1"}
 
-_, err := o.ProcessTicket(context.Background(), ticket, ws)
-if err != nil {
-t.Fatalf("ProcessTicket failed: %v", err)
-}
+	_, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("ProcessTicket failed: %v", err)
+	}
 
-// Verify phase logs were recorded (at least for implement phase).
-if len(db.phaseLogs) == 0 {
-t.Error("no phase logs recorded")
-}
+	// Verify phase logs were recorded (at least for implement phase).
+	if len(db.phaseLogs) == 0 {
+		t.Error("no phase logs recorded")
+	}
 
-// Verify ticket result was recorded.
-if len(db.ticketResults) == 0 {
-t.Error("no ticket results recorded")
-}
+	// Verify ticket result was recorded.
+	if len(db.ticketResults) == 0 {
+		t.Error("no ticket results recorded")
+	}
 }
 
 func TestProcessTicket_DBPersistence_NonFatalOnError(t *testing.T) {
-sc := &stubJiraClient{}
-ia := &stubAgent{name: "impl", output: "implementation done"}
-db := &stubDB{err: errors.New("db write failed")}
-runID := "run-nonfatal-test"
+	sc := &stubJiraClient{}
+	ia := &stubAgent{name: "impl", output: "implementation done"}
+	db := &stubDB{err: errors.New("db write failed")}
+	runID := "run-nonfatal-test"
 
-o := &Orchestrator{
-client:          sc,
-cfg:             JiraConfig{},
-skipValidation:  true,
-implAgent:       ia,
-db:              db,
-runID:           runID,
-}
+	o := &Orchestrator{
+		client:         sc,
+		cfg:            JiraConfig{},
+		skipValidation: true,
+		implAgent:      ia,
+		db:             db,
+		runID:          runID,
+	}
 
-ticket := Ticket{Key: "NF-1", Summary: "Non-fatal test", Description: "Do the thing."}
-ws := &Workspace{TicketKey: "NF-1"}
+	ticket := Ticket{Key: "NF-1", Summary: "Non-fatal test", Description: "Do the thing."}
+	ws := &Workspace{TicketKey: "NF-1"}
 
-result, err := o.ProcessTicket(context.Background(), ticket, ws)
-// ProcessTicket should NOT error; DB errors are non-fatal
-if err != nil {
-t.Fatalf("ProcessTicket failed with DB error (should be non-fatal): %v", err)
-}
-if result == nil || result.Status != TicketCompleted {
-t.Error("ProcessTicket should have completed despite DB error")
-}
+	result, err := o.ProcessTicket(context.Background(), ticket, ws)
+	// ProcessTicket should NOT error; DB errors are non-fatal
+	if err != nil {
+		t.Fatalf("ProcessTicket failed with DB error (should be non-fatal): %v", err)
+	}
+	if result == nil || result.Status != TicketCompleted {
+		t.Error("ProcessTicket should have completed despite DB error")
+	}
 }
 
 func TestProcessTicket_DBPersistence_NoDBIsNoop(t *testing.T) {
-sc := &stubJiraClient{}
-ia := &stubAgent{name: "impl", output: "implementation done"}
+	sc := &stubJiraClient{}
+	ia := &stubAgent{name: "impl", output: "implementation done"}
 
-o := &Orchestrator{
-client:          sc,
-cfg:             JiraConfig{},
-skipValidation:  true,
-implAgent:       ia,
-db:              nil, // no DB
-runID:           "",
-}
+	o := &Orchestrator{
+		client:         sc,
+		cfg:            JiraConfig{},
+		skipValidation: true,
+		implAgent:      ia,
+		db:             nil, // no DB
+		runID:          "",
+	}
 
-ticket := Ticket{Key: "NODB-1", Summary: "No DB test", Description: "Do the thing."}
-ws := &Workspace{TicketKey: "NODB-1"}
+	ticket := Ticket{Key: "NODB-1", Summary: "No DB test", Description: "Do the thing."}
+	ws := &Workspace{TicketKey: "NODB-1"}
 
-result, err := o.ProcessTicket(context.Background(), ticket, ws)
-if err != nil {
-t.Fatalf("ProcessTicket failed: %v", err)
-}
-if result == nil || result.Status != TicketCompleted {
-t.Error("ProcessTicket should complete when DB is nil")
-}
+	result, err := o.ProcessTicket(context.Background(), ticket, ws)
+	if err != nil {
+		t.Fatalf("ProcessTicket failed: %v", err)
+	}
+	if result == nil || result.Status != TicketCompleted {
+		t.Error("ProcessTicket should complete when DB is nil")
+	}
 }

--- a/internal/jira/tickets.go
+++ b/internal/jira/tickets.go
@@ -38,10 +38,10 @@ type Comment struct {
 
 // IssueLink represents a link between two Jira issues.
 type IssueLink struct {
-	Type                 string // e.g. "Blocks"
-	InwardKey            string // the issue that blocks (inward side)
-	OutwardKey           string // the issue that is being blocked (outward side)
-	Direction            string // "inward" or "outward" relative to this ticket
+	Type                  string // e.g. "Blocks"
+	InwardKey             string // the issue that blocks (inward side)
+	OutwardKey            string // the issue that is being blocked (outward side)
+	Direction             string // "inward" or "outward" relative to this ticket
 	BlockerStatusCategory string // status category key of the blocking issue (e.g. "done")
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -39,13 +39,13 @@ type Scheduler struct {
 	location *time.Location
 
 	// Runtime state
-	cron        *cron.Cron
-	jobs        []Job
-	running     bool
-	stopCh      chan struct{}
-	doneCh      chan struct{}
-	nextRun     time.Time
-	entryID     cron.EntryID
+	cron         *cron.Cron
+	jobs         []Job
+	running      bool
+	stopCh       chan struct{}
+	doneCh       chan struct{}
+	nextRun      time.Time
+	entryID      cron.EntryID
 	stopTimeoutD time.Duration // overridable in tests; 0 means use default (30s)
 }
 


### PR DESCRIPTION
## VC-47 — CLI Command: `nightshift jira logs`

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-47

### Description

Overview
Add a nightshift jira logs subcommand that displays Jira-specific run history and per-ticket processing logs. Mirrors the existing nightshift logs UX (tail, follow, filters, export) but scoped to the Jira autonomous system — filtering by ticket key, run cycle, phase, and outcome.
Motivation
The existing nightshift logs command shows all nightshift logs (general scheduler, budget, etc). When debugging or reviewing Jira autonomous runs, users need a focused view:
"What happened with VC-42 last night?"
"Show me all failed tickets from the last run"
"Follow the current jira run in real-time"
Currently users have to manually grep general logs with --component jira or --match <ticket-key>. A dedicated command provides a better UX with ticket-aware formatting and structured output.
Phase Taxonomy
The command covers both ProcessTicket (ticket → implementation) and ProcessFeedback (review rework) lifecycles. The allowed phase values are:
PhaseLifecycleAgent?validateProcessTicketyesplanProcessTicketyesimplementProcessTicketyescommitProcessTicketnoprProcessTicketnostatusProcessTicketnoreview_fixProcessFeedbackyesNon-agent phases (commit, pr, status) do not have agent stdout. The --agent-output flag is only meaningful for agent phases; for non-agent phases it shows an empty section. The --phase flag accepts any value from the table above.
DB Schema
New tables added in internal/db/migrations.go:
CREATE TABLE jira_runs (
    run_id       TEXT     PRIMARY KEY,  -- UUID, generated once per CLI invocation
    started_at   DATETIME NOT NULL,
    ended_at     DATETIME,
    project_key  TEXT     NOT NULL,
    tickets_processed INTEGER NOT NULL DEFAULT 0,
    tickets_completed INTEGER NOT NULL DEFAULT 0,
    tickets_failed    INTEGER NOT NULL DEFAULT 0
);

CREATE TABLE jira_ticket_results (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    run_id       TEXT    NOT NULL REFERENCES jira_runs(run_id),
    ticket_key   TEXT    NOT NULL,
    status       TEXT    NOT NULL,  -- completed|failed|rejected|skipped
    duration_ms  INTEGER NOT NULL,
    phase_reached TEXT   NOT NULL,  -- last phase attempted
    pr_url       TEXT,
    error_msg    TEXT
);

CREATE TABLE jira_phase_logs (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    run_id       TEXT    NOT NULL REFERENCES jira_runs(run_id),
    ticket_key   TEXT    NOT NULL,
    phase        TEXT    NOT NULL,  -- validate|plan|implement|commit|pr|status|review_fix
    provider     TEXT,              -- empty for non-agent phases
    model        TEXT,              -- empty for non-agent phases
    started_at   DATETIME NOT NULL,
    duration_ms  INTEGER NOT NULL,
    exit_ok      INTEGER NOT NULL,  -- 0/1
    output       TEXT,              -- agent stdout; NULL for non-agent phases
    error        TEXT               -- error message on failure
);
DB Access / run_id Data Flow
jira_run.go generates a run_id (UUID) once per nightshift jira run invocation.
The DB handle (*db.DB) is opened in jira_run.go (same as other commands) and passed into the orchestrator via a new WithDB(db, runID) option.
Orchestrator.ProcessTicket and Orchestrator.ProcessFeedback insert rows into jira_phase_logs after each phase, and into jira_ticket_results after the ticket completes.
After the full run loop ends, jira_run.go upserts the jira_runs summary row.
DB is optional: when WithDB is not set (e.g., in tests), the orchestrator skips persistence — no behavior change.
CLI Interface
nightshift jira logs [flags]

Flags:
  -n, --tail int          Number of log entries to show (default 50)
  -f, --follow            Follow log output in real-time
  -t, --ticket string     Filter by ticket key (e.g. VC-42)
  -r, --run string        Filter by run ID or "latest" (queries DB for most recent run_id)
      --phase string      Filter by phase (validate|plan|implement|commit|pr|status|review_fix)
      --status string     Filter by outcome (completed|failed|rejected|skipped)
      --since string      Start time filter
      --until string      End time filter
      --level string      Min log level (debug|info|warn|error)
      --summary           Show run summary only (ticket counts, durations, outcomes)
      --agent-output      Show full agent stdout (from jira_phase_logs.output); agent phases only
      --raw               Raw JSON output (for piping)
      --no-color          Disable ANSI colors
  -e, --export string     Export to file
Filter semantics: All filters are strict AND. --run latest queries jira_runs for the row with the most recent started_at and substitutes its run_id. When multiple projects ran in the same invocation, --run latest returns results across all projects from that invocation.
Output Modes
Default (log lines): Same lipgloss-styled output as nightshift logs but only jira-component entries, with ticket keys highlighted. Ticket key extraction uses structured field ticket_key if present; falls back to regex [A-Z]+-[0-9]+ on the message.
Summary mode (--summary): Queries jira_ticket_results + jira_runs. Table of tickets processed with status, duration, phase reached, and PR link.
Jira Run 2026-04-07T22:00:00Z (3 tickets, 2 completed, 1 failed)

  TICKET   STATUS      DURATION  PHASE       PR
  VC-42    completed   4m12s     pr          #52
  VC-43    completed   2m34s     pr          #53
  VC-44    failed      1m07s     implement   —
Per-ticket mode (--ticket VC-42): Full chronological log for that ticket across all phases. With --agent-output also shows the raw agent stdout from jira_phase_logs.
Non-agent phases (commit, pr, status): provider/model columns show —. --agent-output shows (no agent output) for these phases.
Implementation
New file: cmd/nightshift/commands/jira_logs.go
Register as jiraCmd.AddCommand(jiraLogsCmd) (under nightshift jira)
Reuse logFilter, logRecord, loadLogEntries from logs.go — add component: "jira" to the filter automatically
Add ticket-key extraction from structured log fields or message parsing (regex [A-Z]+-[0-9]+)
For --summary, --run, and --agent-output: query DB for jira_runs, jira_ticket_results, jira_phase_logs
New file: cmd/nightshift/commands/jira_logs_output.go
Rendering helpers: renderJiraLogHeader, renderJiraRunSummary, renderTicketTimeline
Lipgloss styles matching existing log viewer
Orchestrator change (internal/jira/orchestrator.go):
Add db *db.DB and runID string fields, set via WithDB(db, runID) option
After each phase: insert row into jira_phase_logs (skip when db == nil)
After ProcessTicket/ProcessFeedback: insert row into jira_ticket_results (skip when db == nil)
Existing Patterns to Follow
cmd/nightshift/commands/logs.go — Full log viewer with tail/follow/filter/export/summary. Reuse logFilter, loadLogEntries, rendering helpers.
cmd/nightshift/commands/jira.go — Parent command; register with jiraCmd.AddCommand()
cmd/nightshift/commands/jira_run.go — Jira run command pattern (flag parsing, config loading)
cmd/nightshift/commands/jira_preview_output.go — Jira-specific lipgloss rendering
internal/db/migrations.go — Versioned schema migrations pattern
internal/jira/orchestrator.go — TicketResult struct (ticket_key, status, duration, error)
Acceptance Criteria
nightshift jira logs shows jira-component log entries (default last 50)
nightshift jira logs -f follows jira logs in real-time
nightshift jira logs --ticket VC-42 filters to a single ticket's logs
nightshift jira logs --status failed filters to failed ticket entries
nightshift jira logs --summary shows a table from DB records
nightshift jira logs --run latest resolves the most recent run_id and filters to it
nightshift jira logs --agent-output includes full agent stdout for agent phases
When DB is unavailable, --summary / --run / --agent-output show a clear error; log-file mode still works
nightshift jira logs --phase review_fix works for both ProcessTicket and ProcessFeedback lifecycles

### Acceptance Criteria

nightshift jira logs shows jira-component log entries (default last 50)
nightshift jira logs -f follows jira logs in real-time
nightshift jira logs --ticket VC-42 filters to a single ticket's logs
nightshift jira logs --status failed filters to failed ticket entries
nightshift jira logs --summary shows a table from DB records
nightshift jira logs --run latest resolves the most recent run_id and filters to it
nightshift jira logs --agent-output includes full agent stdout for agent phases
When DB is unavailable, --summary / --run / --agent-output show a clear error; log-file mode still works
nightshift jira logs --phase review_fix works for both ProcessTicket and ProcessFeedback lifecycles

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
