### PR TITLE
[VC-61] jira run missing --type flag present in jira preview

### DIFF
--- a/cmd/nightshift/commands/jira_preview.go
+++ b/cmd/nightshift/commands/jira_preview.go
@@ -200,7 +200,7 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 					}
 				}
 
-				todoTickets, err := client.FetchTodoTickets(ctx, proj)
+				todoTickets, err := client.FetchTodoTickets(ctx, proj, "")
 				if err != nil {
 					result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
 						Key:    proj.Key + ":*",
@@ -208,7 +208,7 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 					})
 					continue
 				}
-				inProgressTickets, ipErr := client.FetchInProgressTickets(ctx, proj, statusMap)
+				inProgressTickets, ipErr := client.FetchInProgressTickets(ctx, proj, statusMap, "")
 				if ipErr != nil {
 					result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
 						Key:    proj.Key + ":*",
@@ -265,7 +265,7 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 					})
 				}
 
-				reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap)
+				reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap, "")
 				if err != nil {
 					result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
 						Key:    proj.Key + ":*review*",

--- a/cmd/nightshift/commands/jira_preview.go
+++ b/cmd/nightshift/commands/jira_preview.go
@@ -200,7 +200,7 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 					}
 				}
 
-				todoTickets, err := client.FetchTodoTickets(ctx, proj, "")
+				todoTickets, err := client.FetchTodoTickets(ctx, proj, typeFilter)
 				if err != nil {
 					result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
 						Key:    proj.Key + ":*",
@@ -208,7 +208,7 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 					})
 					continue
 				}
-				inProgressTickets, ipErr := client.FetchInProgressTickets(ctx, proj, statusMap, "")
+				inProgressTickets, ipErr := client.FetchInProgressTickets(ctx, proj, statusMap, typeFilter)
 				if ipErr != nil {
 					result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
 						Key:    proj.Key + ":*",
@@ -216,16 +216,6 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 					})
 				} else {
 					todoTickets = append(todoTickets, inProgressTickets...)
-				}
-				// Apply optional issue-type filter.
-				if typeFilter != "" {
-					filtered := todoTickets[:0]
-					for _, t := range todoTickets {
-						if strings.EqualFold(t.IssueType, typeFilter) {
-							filtered = append(filtered, t)
-						}
-					}
-					todoTickets = filtered
 				}
 
 				graph := jira.BuildDependencyGraph(todoTickets)
@@ -265,7 +255,7 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 					})
 				}
 
-				reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap, "")
+				reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap, typeFilter)
 				if err != nil {
 					result.SkippedTickets = append(result.SkippedTickets, jiraPreviewSkipped{
 						Key:    proj.Key + ":*review*",

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -260,24 +260,22 @@ func runSingleTicket(
 			return false, err
 		}
 
-		todoTickets, err := client.FetchTodoTickets(ctx, proj)
+		todoTickets, err := client.FetchTodoTickets(ctx, proj, typeFilter)
 		if err != nil {
 			return false, fmt.Errorf("fetch tickets: %w", err)
 		}
-		inProgressTickets, err := client.FetchInProgressTickets(ctx, proj, statusMap)
+		inProgressTickets, err := client.FetchInProgressTickets(ctx, proj, statusMap, typeFilter)
 		if err != nil {
 			return false, fmt.Errorf("fetch in-progress tickets: %w", err)
 		}
-		reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap)
+		reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap, typeFilter)
 		if err != nil {
 			return false, fmt.Errorf("fetch review tickets: %w", err)
 		}
 
+		// Check for exact key match in TODO/in-progress tickets
 		for _, t := range append(todoTickets, inProgressTickets...) {
 			if t.Key != key {
-				continue
-			}
-			if typeFilter != "" && !strings.EqualFold(t.IssueType, typeFilter) {
 				continue
 			}
 			found = true
@@ -297,11 +295,9 @@ func runSingleTicket(
 			return found, nil
 		}
 
+		// Check for exact key match in review tickets
 		for _, t := range reviewTickets {
 			if t.Key != key {
-				continue
-			}
-			if typeFilter != "" && !strings.EqualFold(t.IssueType, typeFilter) {
 				continue
 			}
 			found = true
@@ -320,6 +316,34 @@ func runSingleTicket(
 			}
 			return found, nil
 		}
+
+		// If type filter is active, check if the ticket exists but doesn't match the type filter
+		if typeFilter != "" {
+			unfilteredTodo, err := client.FetchTodoTickets(ctx, proj, "")
+			if err == nil {
+				for _, t := range unfilteredTodo {
+					if t.Key == key {
+						return false, fmt.Errorf("ticket %s found but does not match type filter %q (actual type: %q)", key, typeFilter, t.IssueType)
+					}
+				}
+			}
+			unfilteredInProgress, err := client.FetchInProgressTickets(ctx, proj, statusMap, "")
+			if err == nil {
+				for _, t := range unfilteredInProgress {
+					if t.Key == key {
+						return false, fmt.Errorf("ticket %s found but does not match type filter %q (actual type: %q)", key, typeFilter, t.IssueType)
+					}
+				}
+			}
+			unfilteredReview, err := client.FetchReviewTickets(ctx, proj, statusMap, "")
+			if err == nil {
+				for _, t := range unfilteredReview {
+					if t.Key == key {
+						return false, fmt.Errorf("ticket %s found but does not match type filter %q (actual type: %q)", key, typeFilter, t.IssueType)
+					}
+				}
+			}
+		}
 	}
 	return false, nil
 }
@@ -335,24 +359,15 @@ func runTodoPhase(
 	typeFilter string,
 	results *[]jira.TicketResult,
 ) error {
-	todoTickets, err := client.FetchTodoTickets(ctx, proj)
+	todoTickets, err := client.FetchTodoTickets(ctx, proj, typeFilter)
 	if err != nil {
 		return fmt.Errorf("fetch todo tickets: %w", err)
 	}
-	inProgressTickets, err := client.FetchInProgressTickets(ctx, proj, statusMap)
+	inProgressTickets, err := client.FetchInProgressTickets(ctx, proj, statusMap, typeFilter)
 	if err != nil {
 		return fmt.Errorf("fetch in-progress tickets: %w", err)
 	}
 	allTickets := append(todoTickets, inProgressTickets...)
-	if typeFilter != "" {
-		filtered := allTickets[:0]
-		for _, t := range allTickets {
-			if strings.EqualFold(t.IssueType, typeFilter) {
-				filtered = append(filtered, t)
-			}
-		}
-		allTickets = filtered
-	}
 	log.Infof("todo tickets [%s]: %d found (%d in-progress)", proj.Key, len(allTickets), len(inProgressTickets))
 
 	graph := jira.BuildDependencyGraph(allTickets)
@@ -404,18 +419,9 @@ func runReviewPhase(
 	typeFilter string,
 	feedbackResults *[]jira.FeedbackResult,
 ) error {
-	reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap)
+	reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap, typeFilter)
 	if err != nil {
 		return fmt.Errorf("fetch review tickets: %w", err)
-	}
-	if typeFilter != "" {
-		filtered := reviewTickets[:0]
-		for _, t := range reviewTickets {
-			if strings.EqualFold(t.IssueType, typeFilter) {
-				filtered = append(filtered, t)
-			}
-		}
-		reviewTickets = filtered
 	}
 	log.Infof("review tickets [%s]: %d found", proj.Key, len(reviewTickets))
 

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -37,6 +37,7 @@ func init() {
 	jiraRunCmd.Flags().Bool("skip-validation", false, "Skip LLM ticket validation step")
 	jiraRunCmd.Flags().Bool("todo-only", false, "Only process TODO tickets (skip feedback loop)")
 	jiraRunCmd.Flags().Bool("review-only", false, "Only process ON REVIEW feedback (skip TODO)")
+	jiraRunCmd.Flags().String("type", "", "Filter tickets by issue type (e.g. Bug, Story)")
 }
 
 func runJira(cmd *cobra.Command, _ []string) error {
@@ -67,6 +68,7 @@ func runJira(cmd *cobra.Command, _ []string) error {
 	todoOnly, _ := cmd.Flags().GetBool("todo-only")
 	reviewOnly, _ := cmd.Flags().GetBool("review-only")
 	singleTicket, _ := cmd.Flags().GetString("ticket")
+	typeFilter, _ := cmd.Flags().GetString("type")
 
 	if todoOnly && reviewOnly {
 		return fmt.Errorf("--todo-only and --review-only are mutually exclusive")
@@ -106,14 +108,14 @@ func runJira(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("discover statuses: %w", err)
 	}
 
-	printJiraPreflightSummary(cfg.Jira, skipValidation, statusMap)
+	printJiraPreflightSummary(cfg.Jira, skipValidation, typeFilter, statusMap)
 
 	var results []jira.TicketResult
 	var feedbackResults []jira.FeedbackResult
 	start := time.Now()
 
 	if singleTicket != "" {
-		found, err := runSingleTicket(ctx, log, client, cfg, statusMap, singleTicket, skipValidation, runDB, runID, &results, &feedbackResults)
+		found, err := runSingleTicket(ctx, log, client, cfg, statusMap, singleTicket, typeFilter, skipValidation, runDB, runID, &results, &feedbackResults)
 		if err != nil {
 			return err
 		}
@@ -127,12 +129,12 @@ func runJira(cmd *cobra.Command, _ []string) error {
 				return err
 			}
 			if !reviewOnly {
-				if err := runTodoPhase(ctx, log, orch, client, cfg.Jira, proj, statusMap, &results); err != nil {
+				if err := runTodoPhase(ctx, log, orch, client, cfg.Jira, proj, statusMap, typeFilter, &results); err != nil {
 					return err
 				}
 			}
 			if !todoOnly {
-				if err := runReviewPhase(ctx, log, orch, client, cfg.Jira, proj, statusMap, &feedbackResults); err != nil {
+				if err := runReviewPhase(ctx, log, orch, client, cfg.Jira, proj, statusMap, typeFilter, &feedbackResults); err != nil {
 					return err
 				}
 			}
@@ -232,6 +234,7 @@ func runSingleTicket(
 	cfg *config.Config,
 	statusMap *jira.StatusMap,
 	key string,
+	typeFilter string,
 	skipValidation bool,
 	runDB *db.DB,
 	runID string,
@@ -274,6 +277,9 @@ func runSingleTicket(
 			if t.Key != key {
 				continue
 			}
+			if typeFilter != "" && !strings.EqualFold(t.IssueType, typeFilter) {
+				continue
+			}
 			found = true
 			ws, err := jira.SetupWorkspace(ctx, jiracfg, proj, t.Key)
 			if err != nil {
@@ -293,6 +299,9 @@ func runSingleTicket(
 
 		for _, t := range reviewTickets {
 			if t.Key != key {
+				continue
+			}
+			if typeFilter != "" && !strings.EqualFold(t.IssueType, typeFilter) {
 				continue
 			}
 			found = true
@@ -323,6 +332,7 @@ func runTodoPhase(
 	jiracfg jira.JiraConfig,
 	proj jira.ProjectConfig,
 	statusMap *jira.StatusMap,
+	typeFilter string,
 	results *[]jira.TicketResult,
 ) error {
 	todoTickets, err := client.FetchTodoTickets(ctx, proj)
@@ -334,6 +344,15 @@ func runTodoPhase(
 		return fmt.Errorf("fetch in-progress tickets: %w", err)
 	}
 	allTickets := append(todoTickets, inProgressTickets...)
+	if typeFilter != "" {
+		filtered := allTickets[:0]
+		for _, t := range allTickets {
+			if strings.EqualFold(t.IssueType, typeFilter) {
+				filtered = append(filtered, t)
+			}
+		}
+		allTickets = filtered
+	}
 	log.Infof("todo tickets [%s]: %d found (%d in-progress)", proj.Key, len(allTickets), len(inProgressTickets))
 
 	graph := jira.BuildDependencyGraph(allTickets)
@@ -382,11 +401,21 @@ func runReviewPhase(
 	jiracfg jira.JiraConfig,
 	proj jira.ProjectConfig,
 	statusMap *jira.StatusMap,
+	typeFilter string,
 	feedbackResults *[]jira.FeedbackResult,
 ) error {
 	reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap)
 	if err != nil {
 		return fmt.Errorf("fetch review tickets: %w", err)
+	}
+	if typeFilter != "" {
+		filtered := reviewTickets[:0]
+		for _, t := range reviewTickets {
+			if strings.EqualFold(t.IssueType, typeFilter) {
+				filtered = append(filtered, t)
+			}
+		}
+		reviewTickets = filtered
 	}
 	log.Infof("review tickets [%s]: %d found", proj.Key, len(reviewTickets))
 
@@ -479,11 +508,14 @@ func createJiraAgent(cfg *config.Config, phase jira.PhaseConfig) (agents.Agent, 
 	}
 }
 
-func printJiraPreflightSummary(cfg jira.JiraConfig, skipValidation bool, _ *jira.StatusMap) {
+func printJiraPreflightSummary(cfg jira.JiraConfig, skipValidation bool, typeFilter string, _ *jira.StatusMap) {
 	fmt.Println("🌙 Nightshift Jira Run")
 	fmt.Println("──────────────────────────────")
 	fmt.Printf("  Site:         %s.atlassian.net\n", cfg.Site)
 	fmt.Printf("  Max tickets:  %d\n", cfg.MaxTickets)
+	if typeFilter != "" {
+		fmt.Printf("  Type filter:  %s\n", typeFilter)
+	}
 	for _, p := range cfg.Projects {
 		fmt.Printf("  Project: %s  [label: %s]\n", p.Key, p.Label)
 		if skipValidation {

--- a/cmd/nightshift/commands/jira_run_e2e_test.go
+++ b/cmd/nightshift/commands/jira_run_e2e_test.go
@@ -67,7 +67,7 @@ func TestJiraRun_E2E_DiscoverStatuses(t *testing.T) {
 // TestJiraRun_E2E_FetchTickets verifies that ticket fetching works without mutations.
 // Read-only: no ticket mutations.
 func TestJiraRun_E2E_FetchTickets(t *testing.T) {
-	client, _ := e2eJiraClient(t)
+	client, cfg := e2eJiraClient(t)
 	ctx := context.Background()
 
 	statusMap, err := client.DiscoverStatuses(ctx)
@@ -75,13 +75,19 @@ func TestJiraRun_E2E_FetchTickets(t *testing.T) {
 		t.Fatalf("DiscoverStatuses: %v", err)
 	}
 
-	todoTickets, err := client.FetchTodoTickets(ctx)
+	cfg.Defaults()
+	if len(cfg.Projects) == 0 {
+		t.Fatal("no projects configured")
+	}
+	proj := cfg.Projects[0]
+
+	todoTickets, err := client.FetchTodoTickets(ctx, proj, "")
 	if err != nil {
 		t.Fatalf("FetchTodoTickets: %v", err)
 	}
 	t.Logf("todo tickets: %d", len(todoTickets))
 
-	reviewTickets, err := client.FetchReviewTickets(ctx, statusMap)
+	reviewTickets, err := client.FetchReviewTickets(ctx, proj, statusMap, "")
 	if err != nil {
 		t.Fatalf("FetchReviewTickets: %v", err)
 	}

--- a/cmd/nightshift/commands/jira_run_test.go
+++ b/cmd/nightshift/commands/jira_run_test.go
@@ -23,7 +23,7 @@ func TestPrintJiraPreflightSummary(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		printJiraPreflightSummary(cfg, false, nil)
+		printJiraPreflightSummary(cfg, false, "", nil)
 	})
 
 	checks := []string{
@@ -51,7 +51,7 @@ func TestPrintJiraPreflightSummary_SkippedValidation(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		printJiraPreflightSummary(cfg, true, nil)
+		printJiraPreflightSummary(cfg, true, "", nil)
 	})
 
 	if !strings.Contains(out, "Validation:   skipped") {
@@ -97,7 +97,7 @@ func TestPrintJiraRunSummary_Skipped(t *testing.T) {
 }
 
 func TestRunJira_FlagParsing(t *testing.T) {
-	flags := []string{"max-tickets", "ticket", "skip-validation", "todo-only", "review-only"}
+	flags := []string{"max-tickets", "ticket", "skip-validation", "todo-only", "review-only", "type"}
 	for _, name := range flags {
 		if jiraRunCmd.Flags().Lookup(name) == nil {
 			t.Errorf("flag --%s not registered on jira run command", name)

--- a/cmd/nightshift/commands/jira_run_test.go
+++ b/cmd/nightshift/commands/jira_run_test.go
@@ -59,6 +59,25 @@ func TestPrintJiraPreflightSummary_SkippedValidation(t *testing.T) {
 	}
 }
 
+func TestPrintJiraPreflightSummary_TypeFilter(t *testing.T) {
+	cfg := jira.JiraConfig{
+		Site:       "testsite",
+		MaxTickets: 5,
+		Validation: jira.PhaseConfig{Provider: "claude", Model: "claude-haiku-4.5"},
+		Projects: []jira.ProjectConfig{
+			{Key: "PROJ", Label: "nightshift", Repos: []jira.RepoConfig{{Name: "repo", URL: "git@github.com:org/repo.git"}}},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		printJiraPreflightSummary(cfg, false, "Bug", nil)
+	})
+
+	if !strings.Contains(out, "Type filter:  Bug") {
+		t.Errorf("preflight summary should show type filter\nfull output:\n%s", out)
+	}
+}
+
 func TestPrintJiraRunSummary(t *testing.T) {
 	results := []jira.TicketResult{
 		{TicketKey: "P-1", Status: jira.TicketCompleted},

--- a/internal/jira/e2e_test.go
+++ b/internal/jira/e2e_test.go
@@ -78,7 +78,7 @@ func TestE2E_FetchTodoTickets(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	tickets, err := client.FetchTodoTickets(ctx, e2eProject())
+	tickets, err := client.FetchTodoTickets(ctx, e2eProject(), "")
 	if err != nil {
 		t.Fatalf("FetchTodoTickets: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestE2E_FetchReviewTickets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DiscoverStatuses: %v", err)
 	}
-	tickets, err := client.FetchReviewTickets(ctx, e2eProject(), sm)
+	tickets, err := client.FetchReviewTickets(ctx, e2eProject(), sm, "")
 	if err != nil {
 		t.Fatalf("FetchReviewTickets: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestE2E_FetchReviewTickets_NilStatusMap(t *testing.T) {
 	defer cancel()
 
 	// nil statusMap must not panic and must return (nil, nil)
-	tickets, err := client.FetchReviewTickets(ctx, e2eProject(), nil)
+	tickets, err := client.FetchReviewTickets(ctx, e2eProject(), nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error with nil statusMap: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestE2E_DependencyGraph(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	tickets, err := client.FetchTodoTickets(ctx, e2eProject())
+	tickets, err := client.FetchTodoTickets(ctx, e2eProject(), "")
 	if err != nil {
 		t.Fatalf("FetchTodoTickets: %v", err)
 	}
@@ -339,7 +339,7 @@ func TestE2E_VC6_ValidateTicket_WithStubAgent(t *testing.T) {
 	defer cancel()
 
 	// Fetch a real ticket from Jira to validate the full pipeline.
-	tickets, err := client.FetchTodoTickets(ctx, e2eProject())
+	tickets, err := client.FetchTodoTickets(ctx, e2eProject(), "")
 	if err != nil {
 		t.Fatalf("FetchTodoTickets: %v", err)
 	}
@@ -369,7 +369,7 @@ func TestE2E_VC6_ValidateTicket_RejectedFlow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	tickets, err := client.FetchTodoTickets(ctx, e2eProject())
+	tickets, err := client.FetchTodoTickets(ctx, e2eProject(), "")
 	if err != nil {
 		t.Fatalf("FetchTodoTickets: %v", err)
 	}
@@ -580,7 +580,7 @@ func TestE2E_VC8_ProcessTicket_WithStubAgents(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	tickets, err := client.FetchTodoTickets(ctx, e2eProject())
+	tickets, err := client.FetchTodoTickets(ctx, e2eProject(), "")
 	if err != nil {
 		t.Fatalf("FetchTodoTickets: %v", err)
 	}
@@ -765,7 +765,7 @@ func TestE2E_VC10_BuildReworkPrompt_RealTicket(t *testing.T) {
 		t.Fatalf("DiscoverStatuses: %v", err)
 	}
 
-	tickets, err := client.FetchReviewTickets(ctx, e2eProject(), sm)
+	tickets, err := client.FetchReviewTickets(ctx, e2eProject(), sm, "")
 	if err != nil {
 		t.Fatalf("FetchReviewTickets: %v", err)
 	}

--- a/internal/jira/mock_server_test.go
+++ b/internal/jira/mock_server_test.go
@@ -453,7 +453,7 @@ func TestFetchTodoTickets_Empty(t *testing.T) {
 	client, srv := newMockJiraClient(t, defaultMockConfig())
 	defer srv.Close()
 
-	tickets, err := client.FetchTodoTickets(testCtx(t), mockProject())
+	tickets, err := client.FetchTodoTickets(testCtx(t), mockProject(), "")
 	if err != nil {
 		t.Fatalf("FetchTodoTickets() error = %v", err)
 	}
@@ -478,7 +478,7 @@ func TestFetchTodoTickets_WithResults(t *testing.T) {
 	client, srv := newMockJiraClient(t, cfg)
 	defer srv.Close()
 
-	tickets, err := client.FetchTodoTickets(testCtx(t), mockProject())
+	tickets, err := client.FetchTodoTickets(testCtx(t), mockProject(), "")
 	if err != nil {
 		t.Fatalf("FetchTodoTickets() error = %v", err)
 	}
@@ -497,7 +497,7 @@ func TestFetchReviewTickets_NilStatusMap(t *testing.T) {
 	client, srv := newMockJiraClient(t, defaultMockConfig())
 	defer srv.Close()
 
-	tickets, err := client.FetchReviewTickets(testCtx(t), mockProject(), nil)
+	tickets, err := client.FetchReviewTickets(testCtx(t), mockProject(), nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -518,7 +518,7 @@ func TestFetchReviewTickets_WithStatusMap(t *testing.T) {
 		t.Fatalf("DiscoverStatuses: %v", err)
 	}
 
-	tickets, err := client.FetchReviewTickets(testCtx(t), mockProject(), sm)
+	tickets, err := client.FetchReviewTickets(testCtx(t), mockProject(), sm, "")
 	if err != nil {
 		t.Fatalf("FetchReviewTickets() error = %v", err)
 	}

--- a/internal/jira/tickets.go
+++ b/internal/jira/tickets.go
@@ -49,11 +49,16 @@ const searchPageSize = 50
 const acKeyword = "acceptance criteria"
 
 // FetchTodoTickets fetches issues in the "To Do" status category filtered by the project's label.
-func (c *Client) FetchTodoTickets(ctx context.Context, proj ProjectConfig) ([]Ticket, error) {
+// If issueType is non-empty, further filters by issue type (case-insensitive).
+func (c *Client) FetchTodoTickets(ctx context.Context, proj ProjectConfig, issueType string) ([]Ticket, error) {
 	jql := fmt.Sprintf(
-		`project = "%s" AND statusCategory = "To Do" AND labels = "%s" ORDER BY created ASC`,
+		`project = "%s" AND statusCategory = "To Do" AND labels = "%s"`,
 		proj.Key, proj.Label,
 	)
+	if issueType != "" {
+		jql += fmt.Sprintf(` AND issuetype = "%s"`, issueType)
+	}
+	jql += " ORDER BY created ASC"
 	tickets, err := c.fetchTickets(ctx, jql)
 	if err != nil {
 		return nil, err
@@ -64,7 +69,8 @@ func (c *Client) FetchTodoTickets(ctx context.Context, proj ProjectConfig) ([]Ti
 // FetchInProgressTickets fetches issues that are in a non-review "indeterminate" status,
 // filtered by the project's label. These are tickets that were started by nightshift but
 // failed mid-run (e.g. during plan or implement) and need to be resumed.
-func (c *Client) FetchInProgressTickets(ctx context.Context, proj ProjectConfig, statusMap *StatusMap) ([]Ticket, error) {
+// If issueType is non-empty, further filters by issue type (case-insensitive).
+func (c *Client) FetchInProgressTickets(ctx context.Context, proj ProjectConfig, statusMap *StatusMap, issueType string) ([]Ticket, error) {
 	if statusMap == nil || len(statusMap.InProgressStatuses) == 0 {
 		return nil, nil
 	}
@@ -73,9 +79,13 @@ func (c *Client) FetchInProgressTickets(ctx context.Context, proj ProjectConfig,
 		names[i] = fmt.Sprintf(`"%s"`, s.Name)
 	}
 	jql := fmt.Sprintf(
-		`project = "%s" AND status in (%s) AND labels = "%s" ORDER BY created ASC`,
+		`project = "%s" AND status in (%s) AND labels = "%s"`,
 		proj.Key, strings.Join(names, ", "), proj.Label,
 	)
+	if issueType != "" {
+		jql += fmt.Sprintf(` AND issuetype = "%s"`, issueType)
+	}
+	jql += " ORDER BY created ASC"
 	tickets, err := c.fetchTickets(ctx, jql)
 	if err != nil {
 		return nil, err
@@ -84,7 +94,8 @@ func (c *Client) FetchInProgressTickets(ctx context.Context, proj ProjectConfig,
 }
 
 // FetchReviewTickets fetches issues that are in a review status, filtered by the project's label.
-func (c *Client) FetchReviewTickets(ctx context.Context, proj ProjectConfig, statusMap *StatusMap) ([]Ticket, error) {
+// If issueType is non-empty, further filters by issue type (case-insensitive).
+func (c *Client) FetchReviewTickets(ctx context.Context, proj ProjectConfig, statusMap *StatusMap, issueType string) ([]Ticket, error) {
 	if statusMap == nil || len(statusMap.ReviewStatuses) == 0 {
 		return nil, nil
 	}
@@ -93,9 +104,13 @@ func (c *Client) FetchReviewTickets(ctx context.Context, proj ProjectConfig, sta
 		names[i] = fmt.Sprintf(`"%s"`, s.Name)
 	}
 	jql := fmt.Sprintf(
-		`project = "%s" AND status in (%s) AND labels = "%s" ORDER BY created ASC`,
+		`project = "%s" AND status in (%s) AND labels = "%s"`,
 		proj.Key, strings.Join(names, ", "), proj.Label,
 	)
+	if issueType != "" {
+		jql += fmt.Sprintf(` AND issuetype = "%s"`, issueType)
+	}
+	jql += " ORDER BY created ASC"
 	tickets, err := c.fetchTickets(ctx, jql)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## VC-61 — jira run missing --type flag present in jira preview

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-61

### Description

Bug
nightshift jira preview has --type string (filter tickets by issue type e.g. Bug, Story) but nightshift jira run does not. The flags are inconsistent between the two commands.
Expected Behaviour
nightshift jira run --type Bug filters the fetched TODO tickets to only the specified issue type, matching the behaviour of jira preview --type.
Actual Behaviour
--type flag is absent from jira run. No way to restrict a run to a specific issue type.
Fix
Add --type string flag to cmd/nightshift/commands/jira_run.go (same declaration as in jira_preview.go)
Pass the type filter into FetchTodoTickets and FetchReviewTickets JQL (add AND issuetype = "<type>" when non-empty)
Verify jira preview and jira run share the same JQL filtering logic to prevent future drift

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
