### PR TITLE
feat(setup): add tracking mode field to budget setup wizard

### DIFF
--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -1027,7 +1027,7 @@ func (m *setupModel) handleBudgetInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.budgetCursor--
 		}
 	case "down", "j":
-		if m.budgetCursor < 6 {
+		if m.budgetCursor < 7 {
 			m.budgetCursor++
 		}
 	case "e":
@@ -1259,6 +1259,9 @@ func (m *setupModel) applyBudgetDefaults() {
 	if m.cfg.Budget.WeeklyTokens == 0 {
 		m.cfg.Budget.WeeklyTokens = config.DefaultWeeklyTokens
 	}
+	if m.cfg.Budget.Tracking == "" {
+		m.cfg.Budget.Tracking = config.DefaultTrackingMode
+	}
 }
 
 func (m *setupModel) budgetFieldValue() string {
@@ -1277,6 +1280,8 @@ func (m *setupModel) budgetFieldValue() string {
 		return m.cfg.Budget.SnapshotInterval
 	case 6:
 		return m.cfg.Budget.WeekStartDay
+	case 7:
+		return m.cfg.Budget.Tracking
 	default:
 		return ""
 	}
@@ -1323,6 +1328,11 @@ func (m *setupModel) applyBudgetEdit() error {
 			return fmt.Errorf("week_start_day must be monday or sunday")
 		}
 		m.cfg.Budget.WeekStartDay = value
+	case 7:
+		if value != "passive" && value != "active" && value != "hybrid" {
+			return fmt.Errorf("tracking must be passive, active, or hybrid")
+		}
+		m.cfg.Budget.Tracking = value
 	}
 	return nil
 }
@@ -1807,6 +1817,7 @@ func renderBudgetFields(b *strings.Builder, m *setupModel) {
 		fmt.Sprintf("Calibrate enabled: %t", m.cfg.Budget.CalibrateEnabled),
 		fmt.Sprintf("Snapshot interval: %s", m.cfg.Budget.SnapshotInterval),
 		fmt.Sprintf("Week start day: %s", m.cfg.Budget.WeekStartDay),
+		fmt.Sprintf("Tracking: %s", m.cfg.Budget.Tracking),
 	}
 	for i, field := range fields {
 		cursor := " "
@@ -2300,6 +2311,7 @@ func writeGlobalConfigToPath(cfg *config.Config, configPath string) error {
 	v.Set("budget.snapshot_interval", cfg.Budget.SnapshotInterval)
 	v.Set("budget.snapshot_retention_days", cfg.Budget.SnapshotRetentionDays)
 	v.Set("budget.week_start_day", cfg.Budget.WeekStartDay)
+	v.Set("budget.tracking", cfg.Budget.Tracking)
 
 	// Providers: set fields individually to match mapstructure tag names (fixes #20)
 	v.Set("providers.claude.enabled", cfg.Providers.Claude.Enabled)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,19 +47,19 @@ type WindowConfig struct {
 
 // BudgetConfig controls token budget allocation.
 type BudgetConfig struct {
-	Mode                  string         `mapstructure:"mode"`                    // daily | weekly
-	MaxPercent            int            `mapstructure:"max_percent"`             // Max % of budget per run
-	AggressiveEndOfWeek   bool           `mapstructure:"aggressive_end_of_week"`  // Ramp up in last 2 days
-	ReservePercent        int            `mapstructure:"reserve_percent"`         // Always keep in reserve
-	WeeklyTokens          int            `mapstructure:"weekly_tokens"`           // Fallback weekly budget
-	PerProvider           map[string]int `mapstructure:"per_provider"`            // Per-provider overrides
-	BillingMode           string         `mapstructure:"billing_mode"`            // subscription | api
-	CalibrateEnabled      bool           `mapstructure:"calibrate_enabled"`       // Enable budget calibration
-	SnapshotInterval      string         `mapstructure:"snapshot_interval"`       // Interval for snapshots
-	SnapshotRetentionDays int            `mapstructure:"snapshot_retention_days"` // Snapshot retention in days
-	WeekStartDay          string         `mapstructure:"week_start_day"`          // monday | sunday
-	DBPath                string         `mapstructure:"db_path"`                 // Override DB path
-	Tracking              string         `mapstructure:"tracking"`                // passive | active | hybrid
+	Mode                  string         `json:"mode" yaml:"mode" mapstructure:"mode"`                    // daily | weekly
+	MaxPercent            int            `json:"max_percent" yaml:"max_percent" mapstructure:"max_percent"`             // Max % of budget per run
+	AggressiveEndOfWeek   bool           `json:"aggressive_end_of_week" yaml:"aggressive_end_of_week" mapstructure:"aggressive_end_of_week"`  // Ramp up in last 2 days
+	ReservePercent        int            `json:"reserve_percent" yaml:"reserve_percent" mapstructure:"reserve_percent"`         // Always keep in reserve
+	WeeklyTokens          int            `json:"weekly_tokens" yaml:"weekly_tokens" mapstructure:"weekly_tokens"`           // Fallback weekly budget
+	PerProvider           map[string]int `json:"per_provider" yaml:"per_provider" mapstructure:"per_provider"`            // Per-provider overrides
+	BillingMode           string         `json:"billing_mode" yaml:"billing_mode" mapstructure:"billing_mode"`            // subscription | api
+	CalibrateEnabled      bool           `json:"calibrate_enabled" yaml:"calibrate_enabled" mapstructure:"calibrate_enabled"`       // Enable budget calibration
+	SnapshotInterval      string         `json:"snapshot_interval" yaml:"snapshot_interval" mapstructure:"snapshot_interval"`       // Interval for snapshots
+	SnapshotRetentionDays int            `json:"snapshot_retention_days" yaml:"snapshot_retention_days" mapstructure:"snapshot_retention_days"` // Snapshot retention in days
+	WeekStartDay          string         `json:"week_start_day" yaml:"week_start_day" mapstructure:"week_start_day"`          // monday | sunday
+	DBPath                string         `json:"db_path" yaml:"db_path" mapstructure:"db_path"`                 // Override DB path
+	Tracking              string         `json:"tracking" yaml:"tracking" mapstructure:"tracking"`                // passive | active | hybrid
 }
 
 // ProvidersConfig defines AI provider settings.
@@ -156,6 +156,7 @@ const (
 	DefaultSnapshotInterval  = "30m"
 	DefaultSnapshotRetention = 90
 	DefaultWeekStartDay      = "monday"
+	DefaultTrackingMode      = "passive"
 	DefaultLogLevel          = "info"
 	DefaultLogFormat         = "json"
 	DefaultClaudeDataPath    = "~/.claude"
@@ -259,7 +260,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("budget.snapshot_retention_days", DefaultSnapshotRetention)
 	v.SetDefault("budget.week_start_day", DefaultWeekStartDay)
 	v.SetDefault("budget.db_path", DefaultDBPath())
-	v.SetDefault("budget.tracking", "passive")
+	v.SetDefault("budget.tracking", DefaultTrackingMode)
 
 	// Provider defaults
 	v.SetDefault("providers.preference", []string{"claude", "codex", "copilot"})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,7 @@ type BudgetConfig struct {
 	SnapshotRetentionDays int            `mapstructure:"snapshot_retention_days"` // Snapshot retention in days
 	WeekStartDay          string         `mapstructure:"week_start_day"`          // monday | sunday
 	DBPath                string         `mapstructure:"db_path"`                 // Override DB path
+	Tracking              string         `mapstructure:"tracking"`                // passive | active | hybrid
 }
 
 // ProvidersConfig defines AI provider settings.
@@ -258,6 +259,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("budget.snapshot_retention_days", DefaultSnapshotRetention)
 	v.SetDefault("budget.week_start_day", DefaultWeekStartDay)
 	v.SetDefault("budget.db_path", DefaultDBPath())
+	v.SetDefault("budget.tracking", "passive")
 
 	// Provider defaults
 	v.SetDefault("providers.preference", []string{"claude", "codex", "copilot"})
@@ -314,6 +316,7 @@ func bindEnvVars(v *viper.Viper) {
 	// Explicit bindings for nested config
 	_ = v.BindEnv("budget.max_percent", "NIGHTSHIFT_BUDGET_MAX_PERCENT")
 	_ = v.BindEnv("budget.mode", "NIGHTSHIFT_BUDGET_MODE")
+	_ = v.BindEnv("budget.tracking", "NIGHTSHIFT_BUDGET_TRACKING")
 	_ = v.BindEnv("logging.level", "NIGHTSHIFT_LOG_LEVEL")
 	_ = v.BindEnv("logging.path", "NIGHTSHIFT_LOG_PATH")
 }
@@ -342,6 +345,7 @@ var (
 	ErrInvalidLogLevel          = errors.New("log level must be debug, info, warn, or error")
 	ErrInvalidLogFormat         = errors.New("log format must be json or text")
 	ErrNoSchedule               = errors.New("either cron or interval must be specified")
+	ErrInvalidTrackingMode      = errors.New("tracking mode must be 'passive', 'active', or 'hybrid'")
 
 	ErrCustomTaskMissingType        = errors.New("custom task: type is required")
 	ErrCustomTaskMissingName        = errors.New("custom task: name is required")
@@ -365,6 +369,14 @@ func Validate(cfg *Config) error {
 	// Budget mode validation
 	if cfg.Budget.Mode != "" && cfg.Budget.Mode != "daily" && cfg.Budget.Mode != "weekly" {
 		return ErrInvalidBudgetMode
+	}
+
+	// Tracking mode validation
+	if cfg.Budget.Tracking != "" {
+		t := strings.ToLower(cfg.Budget.Tracking)
+		if t != "passive" && t != "active" && t != "hybrid" {
+			return ErrInvalidTrackingMode
+		}
 	}
 
 	// Billing mode validation

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,6 +46,21 @@ func TestValidate_InvalidBillingMode(t *testing.T) {
 	}
 }
 
+func TestValidate_TrackingMode(t *testing.T) {
+	valid := []string{"passive", "active", "hybrid", ""}
+	for _, mode := range valid {
+		cfg := &Config{Budget: BudgetConfig{Tracking: mode}}
+		if err := Validate(cfg); err == ErrInvalidTrackingMode {
+			t.Errorf("tracking=%q: unexpected ErrInvalidTrackingMode", mode)
+		}
+	}
+
+	cfg := &Config{Budget: BudgetConfig{Tracking: "foobar"}}
+	if err := Validate(cfg); !errors.Is(err, ErrInvalidTrackingMode) {
+		t.Errorf("tracking=foobar: expected ErrInvalidTrackingMode, got %v", err)
+	}
+}
+
 func TestValidate_InvalidWeekStartDay(t *testing.T) {
 	cfg := &Config{
 		Budget: BudgetConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -50,8 +50,8 @@ func TestValidate_TrackingMode(t *testing.T) {
 	valid := []string{"passive", "active", "hybrid", ""}
 	for _, mode := range valid {
 		cfg := &Config{Budget: BudgetConfig{Tracking: mode}}
-		if err := Validate(cfg); err == ErrInvalidTrackingMode {
-			t.Errorf("tracking=%q: unexpected ErrInvalidTrackingMode", mode)
+		if err := Validate(cfg); err != nil {
+			t.Errorf("tracking=%q: expected nil, got %v", mode, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds `Tracking` field to `BudgetConfig` (`passive` | `active` | `hybrid`), with `json`/`yaml`/`mapstructure` tags
- `DefaultTrackingMode = "passive"`, viper default + `NIGHTSHIFT_BUDGET_TRACKING` env binding
- `Validate()` rejects unknown tracking modes with `ErrInvalidTrackingMode`
- Exposes field as cursor 7 in the setup wizard budget step (navigate, edit, validate, persist)
- Unit test covers valid modes and invalid rejection

## Test plan

- [ ] `go test ./internal/config/... ./cmd/nightshift/...` passes
- [ ] `nightshift setup` → Budget step → `j` to field 8 → `e` → enter invalid value → error shown
- [ ] Enter `active` or `hybrid` → accepted → saved as `budget.tracking` in config YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)