### PR TITLE
fix(jira): log raw LLM output on validation parse failure, add phase progress output, fix float score

### DIFF
--- a/cmd/nightshift/commands/jira_preview.go
+++ b/cmd/nightshift/commands/jira_preview.go
@@ -75,7 +75,7 @@ type jiraPreviewTicket struct {
 	Dependencies    []string `json:"dependencies,omitempty"`
 	Blocks          []string `json:"blocks,omitempty"`
 	BranchName      string   `json:"branch_name"`
-	ValidationScore *int     `json:"validation_score,omitempty"`
+	ValidationScore *float64 `json:"validation_score,omitempty"`
 	ValidationMsg   string   `json:"validation_msg,omitempty"`
 }
 
@@ -231,7 +231,7 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 							score := vr.Score
 							pt.ValidationScore = &score
 							if !vr.Valid {
-								pt.ValidationMsg = fmt.Sprintf("score %d/10 — below threshold", vr.Score)
+								pt.ValidationMsg = fmt.Sprintf("score %.1f/10 — below threshold", vr.Score)
 							}
 						}
 					}

--- a/cmd/nightshift/commands/jira_preview_output.go
+++ b/cmd/nightshift/commands/jira_preview_output.go
@@ -97,7 +97,7 @@ func renderJiraPreviewText(result *jiraPreviewResult, opts jiraPreviewTextOption
 				if t.ValidationMsg != "" {
 					scoreStyle = styles.Warn
 				}
-				fmt.Fprintf(b, "     Validation: %s\n", scoreStyle.Render(fmt.Sprintf("score %d/10", *t.ValidationScore)))
+				fmt.Fprintf(b, "     Validation: %s\n", scoreStyle.Render(fmt.Sprintf("score %.1f/10", *t.ValidationScore)))
 			}
 			if len(t.Dependencies) > 0 {
 				fmt.Fprintf(b, "     Blocked by: %s\n", strings.Join(t.Dependencies, ", "))

--- a/cmd/nightshift/commands/jira_preview_test.go
+++ b/cmd/nightshift/commands/jira_preview_test.go
@@ -50,7 +50,7 @@ func TestRenderJiraPreviewText_ConnectionFailed(t *testing.T) {
 }
 
 func TestRenderJiraPreviewText_TodoTickets(t *testing.T) {
-	score := 8
+	score := float64(8)
 	result := &jiraPreviewResult{
 		GeneratedAt:  time.Now(),
 		JiraProject:  "PROJ",
@@ -68,7 +68,7 @@ func TestRenderJiraPreviewText_TodoTickets(t *testing.T) {
 		Phases:         []jiraPreviewPhase{},
 	}
 	out := renderJiraPreviewText(result, jiraPreviewTextOptions{})
-	for _, want := range []string{"PROJ-1", "Fix the thing", "feature/PROJ-1", "score 8/10"} {
+	for _, want := range []string{"PROJ-1", "Fix the thing", "feature/PROJ-1", "score 8.0/10"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q in output:\n%s", want, out)
 		}
@@ -237,7 +237,7 @@ func TestRenderJiraPreviewText_PhaseAssignments(t *testing.T) {
 // ── writeJiraPreviewJSON ──────────────────────────────────────────────────────
 
 func TestWriteJiraPreviewJSON(t *testing.T) {
-	score := 7
+	score := float64(7)
 	now := time.Now().Truncate(time.Second)
 	result := &jiraPreviewResult{
 		GeneratedAt:  now,

--- a/internal/jira/e2e_test.go
+++ b/internal/jira/e2e_test.go
@@ -384,9 +384,9 @@ func TestE2E_VC6_ValidateTicket_WithStubAgent(t *testing.T) {
 		t.Fatalf("ValidateTicket: %v", err)
 	}
 	if result.Score != 8 {
-		t.Errorf("Score = %d, want 8", result.Score)
+		t.Errorf("Score = %.1f, want 8", result.Score)
 	}
-	t.Logf("ValidateTicket(%s): valid=%v score=%d issues=%v", ticket.Key, result.Valid, result.Score, result.Issues)
+	t.Logf("ValidateTicket(%s): valid=%v score=%.1f issues=%v", ticket.Key, result.Valid, result.Score, result.Issues)
 }
 
 func TestE2E_VC6_ValidateTicket_RejectedFlow(t *testing.T) {
@@ -417,9 +417,9 @@ func TestE2E_VC6_ValidateTicket_RejectedFlow(t *testing.T) {
 		t.Error("expected Valid=false for stubbed low-score response")
 	}
 	if result.Score != 3 {
-		t.Errorf("Score = %d, want 3", result.Score)
+		t.Errorf("Score = %.1f, want 3", result.Score)
 	}
-	t.Logf("ValidateTicket(%s) correctly flagged as invalid: score=%d issues=%v", ticket.Key, result.Score, result.Issues)
+	t.Logf("ValidateTicket(%s) correctly flagged as invalid: score=%.1f issues=%v", ticket.Key, result.Score, result.Issues)
 }
 
 // ── VC-7: Per-ticket workspace & branch management ───────────────────────────

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -403,7 +403,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			}
 			o.savePhaseLog(ctx, ticket.Key, PhaseValidate, valCfg.Provider, valCfg.Model, validateStart, true, strings.Join(vr.Suggestions, "; "), "")
 			o.postPhaseComment(ctx, ticket.Key, CommentValidation,
-				fmt.Sprintf("Ticket validated (score %.1f/10).", vr.Score), time.Since(start))
+				buildValidationComment(vr), time.Since(start))
 			o.log.Infof("ticket %s validated (score %.1f/10)", ticket.Key, vr.Score)
 			if o.progressf != nil {
 				o.progressf("validate      ✓ score %.1f/10", vr.Score)

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -387,26 +387,26 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			}
 			if !vr.Valid {
 				issues := strings.Join(vr.Issues, "; ")
-				o.savePhaseLog(ctx, ticket.Key, PhaseValidate, valCfg.Provider, valCfg.Model, validateStart, false, issues, fmt.Sprintf("score %d/10: %s", vr.Score, issues))
+				o.savePhaseLog(ctx, ticket.Key, PhaseValidate, valCfg.Provider, valCfg.Model, validateStart, false, issues, fmt.Sprintf("score %.1f/10: %s", vr.Score, issues))
 				if hErr := o.client.HandleInvalidTicket(ctx, ticket.Key, vr); hErr != nil {
 					o.log.Errorf("ticket %s: handle invalid: %v", ticket.Key, hErr)
 				}
 				result.Status = TicketRejected
-				result.Summary = fmt.Sprintf("rejected: score %d/10", vr.Score)
+				result.Summary = fmt.Sprintf("rejected: score %.1f/10", vr.Score)
 				result.Duration = time.Since(start)
-				o.log.Infof("ticket %s rejected (score %d/10)", ticket.Key, vr.Score)
+				o.log.Infof("ticket %s rejected (score %.1f/10)", ticket.Key, vr.Score)
 				if o.progressf != nil {
-					o.progressf("validate      ✗ rejected (score %d/10): %s", vr.Score, strings.Join(vr.Issues, "; "))
+					o.progressf("validate      ✗ rejected (score %.1f/10): %s", vr.Score, strings.Join(vr.Issues, "; "))
 				}
 				o.notifyPhase(ticket.Key, PhaseValidate, true)
 				return result, nil
 			}
 			o.savePhaseLog(ctx, ticket.Key, PhaseValidate, valCfg.Provider, valCfg.Model, validateStart, true, strings.Join(vr.Suggestions, "; "), "")
 			o.postPhaseComment(ctx, ticket.Key, CommentValidation,
-				fmt.Sprintf("Ticket validated (score %d/10).", vr.Score), time.Since(start))
-			o.log.Infof("ticket %s validated (score %d/10)", ticket.Key, vr.Score)
+				fmt.Sprintf("Ticket validated (score %.1f/10).", vr.Score), time.Since(start))
+			o.log.Infof("ticket %s validated (score %.1f/10)", ticket.Key, vr.Score)
 			if o.progressf != nil {
-				o.progressf("validate      ✓ score %d/10", vr.Score)
+				o.progressf("validate      ✓ score %.1f/10", vr.Score)
 			}
 		} else {
 			o.log.Infof("ticket %s: validation skipped", ticket.Key)

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -379,6 +379,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				result.Error = err.Error()
 				result.Duration = time.Since(start)
 				o.log.Errorf("ticket %s: validation failed: %v", ticket.Key, err)
+				if o.progressf != nil {
+					o.progressf("validate      ✗ failed: %v", err)
+				}
 				o.notifyPhase(ticket.Key, PhaseValidate, true)
 				return result, nil
 			}
@@ -392,6 +395,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				result.Summary = fmt.Sprintf("rejected: score %d/10", vr.Score)
 				result.Duration = time.Since(start)
 				o.log.Infof("ticket %s rejected (score %d/10)", ticket.Key, vr.Score)
+				if o.progressf != nil {
+					o.progressf("validate      ✗ rejected (score %d/10): %s", vr.Score, strings.Join(vr.Issues, "; "))
+				}
 				o.notifyPhase(ticket.Key, PhaseValidate, true)
 				return result, nil
 			}
@@ -399,8 +405,14 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			o.postPhaseComment(ctx, ticket.Key, CommentValidation,
 				fmt.Sprintf("Ticket validated (score %d/10).", vr.Score), time.Since(start))
 			o.log.Infof("ticket %s validated (score %d/10)", ticket.Key, vr.Score)
+			if o.progressf != nil {
+				o.progressf("validate      ✓ score %d/10", vr.Score)
+			}
 		} else {
 			o.log.Infof("ticket %s: validation skipped", ticket.Key)
+			if o.progressf != nil {
+				o.progressf("validate      skipped")
+			}
 		}
 
 		// Transition to In Progress
@@ -438,6 +450,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			result.Error = err.Error()
 			result.Duration = time.Since(start)
 			o.log.Errorf("ticket %s: plan failed: %v", ticket.Key, err)
+			if o.progressf != nil {
+				o.progressf("plan          ✗ failed: %v", err)
+			}
 			o.notifyPhase(ticket.Key, PhasePlan, true)
 			return result, nil
 		}
@@ -446,6 +461,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 		o.emit("📝 posting plan to Jira %s", ticket.Key)
 		o.postPhaseComment(ctx, ticket.Key, CommentPlan, planResult.Output, time.Since(planStart))
 		o.log.Infof("ticket %s: plan complete", ticket.Key)
+		if o.progressf != nil {
+			o.progressf("plan          ✓ done")
+		}
 		o.notifyPhase(ticket.Key, PhasePlan, true)
 	}
 
@@ -474,6 +492,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			result.Error = err.Error()
 			result.Duration = time.Since(start)
 			o.log.Errorf("ticket %s: implement failed: %v", ticket.Key, err)
+			if o.progressf != nil {
+				o.progressf("implement     ✗ failed: %v", err)
+			}
 			o.notifyPhase(ticket.Key, PhaseImplement, true)
 			return result, nil
 		}
@@ -482,6 +503,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 		o.emit("📝 posting implementation summary to Jira %s", ticket.Key)
 		o.postPhaseComment(ctx, ticket.Key, CommentImplement, implResult.Output, time.Since(implStart))
 		o.log.Infof("ticket %s: implementation complete", ticket.Key)
+		if o.progressf != nil {
+			o.progressf("implement     ✓ done")
+		}
 		o.notifyPhase(ticket.Key, PhaseImplement, true)
 	}
 
@@ -552,6 +576,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				changedRepos = append(changedRepos, repo)
 			}
 		}
+		if o.progressf != nil {
+			o.progressf("commit        ✓ %d repo(s) committed", len(changedRepos))
+		}
 		o.notifyPhase(ticket.Key, PhaseCommit, true)
 		// Persist commit phase log (non-agent phase: no provider/model/output).
 		o.savePhaseLog(ctx, ticket.Key, PhaseCommit, "", "", commitStart, true, "", "")
@@ -588,6 +615,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			result.Error = implErr.Error()
 			result.Duration = time.Since(start)
 			o.log.Errorf("ticket %s: %v", ticket.Key, implErr)
+			if o.progressf != nil {
+				o.progressf("commit        ✗ no changes produced")
+			}
 			o.notifyPhase(ticket.Key, PhaseCommit, true)
 			return result, nil
 		}
@@ -612,6 +642,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				result.Status = TicketFailed
 				result.Error = err.Error()
 				result.Duration = time.Since(start)
+				if o.progressf != nil {
+					o.progressf("pr            ✗ failed: %v", err)
+				}
 				o.notifyPhase(ticket.Key, PhasePR, true)
 				return result, nil
 			}
@@ -666,6 +699,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 				}
 			}
 		}
+		if o.progressf != nil {
+			o.progressf("pr            ✓ %d PR(s): %s", len(result.PRURLs), strings.Join(result.PRURLs, ", "))
+		}
 		o.notifyPhase(ticket.Key, PhasePR, true)
 		// Persist PR phase log (non-agent phase: no provider/model/output).
 		o.savePhaseLog(ctx, ticket.Key, PhasePR, "", "", prStart, true, "", "")
@@ -702,9 +738,15 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 			result.Status = TicketFailed
 			result.Error = err.Error()
 			result.Duration = time.Since(start)
+			if o.progressf != nil {
+				o.progressf("status        ✗ Jira transition failed: %v", err)
+			}
 			o.notifyPhase(ticket.Key, PhaseStatus, true)
 			o.savePhaseLog(ctx, ticket.Key, PhaseStatus, "", "", statusStart, false, "", err.Error())
 			return result, nil
+		}
+		if o.progressf != nil {
+			o.progressf("status        ✓ transitioned to review")
 		}
 		o.notifyPhase(ticket.Key, PhaseStatus, true)
 		// Persist status phase log (non-agent phase: no provider/model/output).
@@ -721,6 +763,9 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 	}
 	o.postPhaseComment(ctx, ticket.Key, CommentStatusChange, statusBody, result.Duration)
 	o.log.Infof("ticket %s: completed in %s", ticket.Key, result.Duration.Round(time.Second))
+	if o.progressf != nil {
+		o.progressf("✓ completed in %s", result.Duration.Round(time.Second))
+	}
 	return result, nil
 }
 

--- a/internal/jira/validation.go
+++ b/internal/jira/validation.go
@@ -103,36 +103,39 @@ func parseValidationResponse(output string) (*ValidationResult, error) {
 	return &vr, nil
 }
 
-// HandleInvalidTicket posts a structured rejection comment and transitions
-// the ticket to the NEEDS INFO status.
-func (c *Client) HandleInvalidTicket(ctx context.Context, ticketKey string, result *ValidationResult) error {
-	// Build comment as plain text paragraphs (no markdown) so it renders
-	// correctly in Jira's ADF-based comment renderer.
+// buildValidationComment formats a validation result as a Jira comment body.
+func buildValidationComment(vr *ValidationResult) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "❌ Nightshift — Ticket Rejected\nReason: Not enough information for autonomous execution.\nQuality score: %.1f/10", result.Score)
-
-	if len(result.Issues) > 0 {
+	if vr.Valid {
+		fmt.Fprintf(&sb, "✅ Nightshift — Ticket Validated\nQuality score: %.1f/10", vr.Score)
+	} else {
+		fmt.Fprintf(&sb, "❌ Nightshift — Ticket Rejected\nReason: Not enough information for autonomous execution.\nQuality score: %.1f/10", vr.Score)
+	}
+	if len(vr.Issues) > 0 {
 		sb.WriteString("\n\nIssues found:\n")
-		for _, issue := range result.Issues {
+		for _, issue := range vr.Issues {
 			fmt.Fprintf(&sb, "• %s\n", issue)
 		}
 	}
-
-	if len(result.Missing) > 0 {
+	if len(vr.Missing) > 0 {
 		sb.WriteString("\n\nTo fix, please add:\n")
-		for _, m := range result.Missing {
+		for _, m := range vr.Missing {
 			fmt.Fprintf(&sb, "• %s\n", m)
 		}
 	}
-
-	if len(result.Suggestions) > 0 {
+	if len(vr.Suggestions) > 0 {
 		sb.WriteString("\n\nSuggestions:\n")
-		for _, s := range result.Suggestions {
+		for _, s := range vr.Suggestions {
 			fmt.Fprintf(&sb, "• %s\n", s)
 		}
 	}
+	return sb.String()
+}
 
-	if err := c.AddComment(ctx, ticketKey, sb.String()); err != nil {
+// HandleInvalidTicket posts a structured rejection comment and transitions
+// the ticket to the NEEDS INFO status.
+func (c *Client) HandleInvalidTicket(ctx context.Context, ticketKey string, result *ValidationResult) error {
+	if err := c.AddComment(ctx, ticketKey, buildValidationComment(result)); err != nil {
 		return fmt.Errorf("jira: handle invalid ticket %s: %w", ticketKey, err)
 	}
 	if err := c.TransitionToNeedsInfo(ctx, ticketKey); err != nil {

--- a/internal/jira/validation.go
+++ b/internal/jira/validation.go
@@ -15,7 +15,7 @@ const validationTimeout = 2 * time.Minute
 // ValidationResult holds the outcome of LLM-based ticket quality evaluation.
 type ValidationResult struct {
 	Valid       bool     `json:"valid"`
-	Score       int      `json:"score"`
+	Score       float64  `json:"score"`
 	Issues      []string `json:"issues"`
 	Missing     []string `json:"missing"`
 	Suggestions []string `json:"suggestions"`
@@ -109,7 +109,7 @@ func (c *Client) HandleInvalidTicket(ctx context.Context, ticketKey string, resu
 	// Build comment as plain text paragraphs (no markdown) so it renders
 	// correctly in Jira's ADF-based comment renderer.
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "❌ Nightshift — Ticket Rejected\nReason: Not enough information for autonomous execution.\nQuality score: %d/10", result.Score)
+	fmt.Fprintf(&sb, "❌ Nightshift — Ticket Rejected\nReason: Not enough information for autonomous execution.\nQuality score: %.1f/10", result.Score)
 
 	if len(result.Issues) > 0 {
 		sb.WriteString("\n\nIssues found:\n")

--- a/internal/jira/validation.go
+++ b/internal/jira/validation.go
@@ -37,7 +37,7 @@ func ValidateTicket(ctx context.Context, agent agents.Agent, ticket Ticket) (*Va
 	}
 	vr, err := parseValidationResponse(result.Output)
 	if err != nil {
-		return nil, fmt.Errorf("jira: parse validation response for %s: %w", ticket.Key, err)
+		return nil, fmt.Errorf("jira: parse validation response for %s: %w\nraw output:\n%s", ticket.Key, err, result.Output)
 	}
 	return vr, nil
 }

--- a/internal/jira/validation_test.go
+++ b/internal/jira/validation_test.go
@@ -33,7 +33,7 @@ func TestParseValidationResponse(t *testing.T) {
 		name      string
 		input     string
 		wantValid bool
-		wantScore int
+		wantScore float64
 		wantErr   bool
 	}{
 		{
@@ -115,7 +115,7 @@ func TestParseValidationResponse(t *testing.T) {
 				t.Errorf("Valid = %v, want %v", got.Valid, tt.wantValid)
 			}
 			if got.Score != tt.wantScore {
-				t.Errorf("Score = %d, want %d", got.Score, tt.wantScore)
+				t.Errorf("Score = %.1f, want %.1f", got.Score, tt.wantScore)
 			}
 		})
 	}
@@ -199,7 +199,7 @@ func TestValidateTicket_Success(t *testing.T) {
 		t.Error("expected Valid=true")
 	}
 	if result.Score != 8 {
-		t.Errorf("Score = %d, want 8", result.Score)
+		t.Errorf("Score = %.1f, want 8", result.Score)
 	}
 }
 


### PR DESCRIPTION
## Summary

- On validation parse failure, raw LLM output is embedded in the error message for easier debugging
- All orchestrator phases (validate, plan, implement, commit, pr, status) now call `progressf` on both success and failure paths
- `ValidationResult.Score` changed from `int` to `float64` — fixes parse crash when LLM returns `7.5` instead of an integer (discovered from live Nightshift comment on VC-63)

## Test plan

- [ ] Trigger a validation parse failure — confirm raw LLM output appears in log alongside the error
- [ ] Run `nightshift jira run` and verify each phase prints a `✓`/`✗` line with relevant details
- [ ] Confirm fractional scores like `7.5` no longer cause a parse error