### PR TITLE
[VC-59] Dynamic model list for provider selection in setup wizard

### DIFF
--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -113,9 +113,10 @@ var claudeModels = []modelOption{
 
 // codexModels lists available Codex/GPT models (static fallback).
 // Updated at runtime via FetchOpenAIModels when OPENAI_API_KEY is set.
-// Source: https://platform.openai.com/docs/models
+// Source: https://developers.openai.com/api/docs/models
 var codexModels = []modelOption{
 	{label: "default", value: ""},
+	{label: "gpt-5.5", value: "gpt-5.5"},
 	{label: "gpt-5.4", value: "gpt-5.4"},
 	{label: "gpt-5.4-mini", value: "gpt-5.4-mini"},
 	{label: "gpt-5.4-nano", value: "gpt-5.4-nano"},

--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -124,30 +124,38 @@ var codexModels = []modelOption{
 	{label: "gpt-4.1", value: "gpt-4.1"},
 }
 
-// copilotModels lists available Copilot models (hardcoded — no API exists).
-// Source: https://docs.github.com/en/copilot/reference/ai-models/supported-models (2026-05-10)
-var copilotModels = []modelOption{
-	{label: "default", value: ""},
-	{label: "claude-haiku-4.5", value: "claude-haiku-4.5"},
-	{label: "claude-opus-4.5", value: "claude-opus-4.5"},
-	{label: "claude-opus-4.6", value: "claude-opus-4.6"},
-	{label: "claude-opus-4.7", value: "claude-opus-4.7"},
-	{label: "claude-sonnet-4.5", value: "claude-sonnet-4.5"},
-	{label: "claude-sonnet-4.6", value: "claude-sonnet-4.6"},
-	{label: "gemini-2.5-pro", value: "gemini-2.5-pro"},
-	{label: "gemini-3-flash", value: "gemini-3-flash"},
-	{label: "gemini-3.1-pro", value: "gemini-3.1-pro"},
-	{label: "gpt-4.1", value: "gpt-4.1"},
-	{label: "gpt-5-mini", value: "gpt-5-mini"},
-	{label: "gpt-5.2", value: "gpt-5.2"},
-	{label: "gpt-5.2-codex", value: "gpt-5.2-codex"},
-	{label: "gpt-5.3-codex", value: "gpt-5.3-codex"},
-	{label: "gpt-5.4", value: "gpt-5.4"},
-	{label: "gpt-5.4-mini", value: "gpt-5.4-mini"},
-	{label: "gpt-5.4-nano", value: "gpt-5.4-nano"},
-	{label: "gpt-5.5", value: "gpt-5.5"},
-	{label: "grok-code-fast-1", value: "grok-code-fast-1"},
+// initCopilotModels generates the copilot model list from providers.CopilotModels(),
+// reordering to place sonnet models first (followed by others) for better default selection.
+func initCopilotModels() []modelOption {
+	opts := []modelOption{{label: "default", value: ""}}
+	models := providers.CopilotModels()
+
+	// Partition: sonnet models first, then rest
+	var sonnetModels []string
+	var otherModels []string
+
+	for _, m := range models {
+		if strings.Contains(m, "sonnet") {
+			sonnetModels = append(sonnetModels, m)
+		} else {
+			otherModels = append(otherModels, m)
+		}
+	}
+
+	// Combine: sonnet first, then others
+	for _, m := range sonnetModels {
+		opts = append(opts, modelOption{label: m, value: m})
+	}
+	for _, m := range otherModels {
+		opts = append(opts, modelOption{label: m, value: m})
+	}
+
+	return opts
 }
+
+// copilotModels lists available Copilot models, generated from providers.CopilotModels()
+// with sonnet models prioritized as better defaults.
+var copilotModels = initCopilotModels()
 
 type setupModel struct {
 	step setupStep

--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -97,51 +97,56 @@ func modelOptionValues(opts []modelOption) []string {
 	return vals
 }
 
-// claudeModels lists available Claude models.
-// Source: https://platform.claude.com/docs/en/about-claude/models/overview (Claude API aliases)
+// claudeModels lists available Claude models (static fallback).
+// Updated at runtime via FetchAnthropicModels when ANTHROPIC_API_KEY is set.
+// Source: https://platform.claude.com/docs/en/about-claude/models/overview
 var claudeModels = []modelOption{
 	{label: "default", value: ""},
-	{label: "claude-opus-4-6", value: "claude-opus-4-6"},
-	{label: "claude-sonnet-4-6", value: "claude-sonnet-4-6"},
-	{label: "claude-haiku-4-5", value: "claude-haiku-4-5"},
+	{label: "claude-opus-4-7-20250805", value: "claude-opus-4-7-20250805"},
+	{label: "claude-opus-4-6-20250514", value: "claude-opus-4-6-20250514"},
+	{label: "claude-sonnet-4-6-20250514", value: "claude-sonnet-4-6-20250514"},
+	{label: "claude-sonnet-4-5-20250514", value: "claude-sonnet-4-5-20250514"},
+	{label: "claude-haiku-4-5-20251001", value: "claude-haiku-4-5-20251001"},
 }
 
-// codexModels lists available Codex models.
-// Source: https://developers.openai.com/codex/models/
+// codexModels lists available Codex/GPT models (static fallback).
+// Updated at runtime via FetchOpenAIModels when OPENAI_API_KEY is set.
+// Source: https://platform.openai.com/docs/models
 var codexModels = []modelOption{
 	{label: "default", value: ""},
-	{label: "gpt-5.3-codex", value: "gpt-5.3-codex"},
-	{label: "gpt-5.3-codex-spark", value: "gpt-5.3-codex-spark"},
-	{label: "gpt-5.2-codex", value: "gpt-5.2-codex"},
-	{label: "gpt-5.2", value: "gpt-5.2"},
-	{label: "gpt-5.1-codex-max", value: "gpt-5.1-codex-max"},
-	{label: "gpt-5.1-codex", value: "gpt-5.1-codex"},
-	{label: "gpt-5.1", value: "gpt-5.1"},
-	{label: "gpt-5-codex", value: "gpt-5-codex"},
-	{label: "gpt-5", value: "gpt-5"},
-}
-
-// copilotModels lists available Copilot models.
-// Source: `copilot --help`, see the --model flag description for the full list.
-var copilotModels = []modelOption{
-	{label: "default", value: ""},
-	{label: "claude-sonnet-4.6", value: "claude-sonnet-4.6"},
-	{label: "claude-sonnet-4.5", value: "claude-sonnet-4.5"},
-	{label: "claude-haiku-4.5", value: "claude-haiku-4.5"},
-	{label: "claude-opus-4.6", value: "claude-opus-4.6"},
-	{label: "claude-opus-4.6-fast", value: "claude-opus-4.6-fast"},
-	{label: "claude-opus-4.5", value: "claude-opus-4.5"},
-	{label: "claude-sonnet-4", value: "claude-sonnet-4"},
-	{label: "gemini-3-pro-preview", value: "gemini-3-pro-preview"},
+	{label: "gpt-5.4", value: "gpt-5.4"},
+	{label: "gpt-5.4-mini", value: "gpt-5.4-mini"},
+	{label: "gpt-5.4-nano", value: "gpt-5.4-nano"},
 	{label: "gpt-5.3-codex", value: "gpt-5.3-codex"},
 	{label: "gpt-5.2-codex", value: "gpt-5.2-codex"},
 	{label: "gpt-5.2", value: "gpt-5.2"},
-	{label: "gpt-5.1-codex-max", value: "gpt-5.1-codex-max"},
-	{label: "gpt-5.1-codex", value: "gpt-5.1-codex"},
-	{label: "gpt-5.1", value: "gpt-5.1"},
-	{label: "gpt-5.1-codex-mini", value: "gpt-5.1-codex-mini"},
 	{label: "gpt-5-mini", value: "gpt-5-mini"},
 	{label: "gpt-4.1", value: "gpt-4.1"},
+}
+
+// copilotModels lists available Copilot models (hardcoded — no API exists).
+// Source: https://docs.github.com/en/copilot/reference/ai-models/supported-models (2026-05-10)
+var copilotModels = []modelOption{
+	{label: "default", value: ""},
+	{label: "claude-haiku-4.5", value: "claude-haiku-4.5"},
+	{label: "claude-opus-4.5", value: "claude-opus-4.5"},
+	{label: "claude-opus-4.6", value: "claude-opus-4.6"},
+	{label: "claude-opus-4.7", value: "claude-opus-4.7"},
+	{label: "claude-sonnet-4.5", value: "claude-sonnet-4.5"},
+	{label: "claude-sonnet-4.6", value: "claude-sonnet-4.6"},
+	{label: "gemini-2.5-pro", value: "gemini-2.5-pro"},
+	{label: "gemini-3-flash", value: "gemini-3-flash"},
+	{label: "gemini-3.1-pro", value: "gemini-3.1-pro"},
+	{label: "gpt-4.1", value: "gpt-4.1"},
+	{label: "gpt-5-mini", value: "gpt-5-mini"},
+	{label: "gpt-5.2", value: "gpt-5.2"},
+	{label: "gpt-5.2-codex", value: "gpt-5.2-codex"},
+	{label: "gpt-5.3-codex", value: "gpt-5.3-codex"},
+	{label: "gpt-5.4", value: "gpt-5.4"},
+	{label: "gpt-5.4-mini", value: "gpt-5.4-mini"},
+	{label: "gpt-5.4-nano", value: "gpt-5.4-nano"},
+	{label: "gpt-5.5", value: "gpt-5.5"},
+	{label: "grok-code-fast-1", value: "grok-code-fast-1"},
 }
 
 type setupModel struct {
@@ -172,6 +177,7 @@ type setupModel struct {
 	claudeModelIdx  int
 	codexModelIdx   int
 	copilotModelIdx int
+	modelsLoading   int // counts pending dynamic-fetch goroutines (0 = done)
 
 	taskPresetCursor int
 	taskCursor       int
@@ -266,6 +272,16 @@ type jiraPingMsg struct {
 	err string
 }
 
+type anthropicModelsFetchedMsg struct {
+	models []string
+	err    error
+}
+
+type openaiModelsFetchedMsg struct {
+	models []string
+	err    error
+}
+
 type jiraRepoEntry struct {
 	URL        string
 	BaseBranch string
@@ -340,6 +356,14 @@ func newSetupModel() (*setupModel, error) {
 	nightshiftInPath := err == nil
 	includePathStep := !nightshiftInPath
 
+	pendingFetches := 0
+	if os.Getenv("ANTHROPIC_API_KEY") != "" {
+		pendingFetches++
+	}
+	if os.Getenv("OPENAI_API_KEY") != "" {
+		pendingFetches++
+	}
+
 	model := &setupModel{
 		step:              stepWelcome,
 		cfg:               cfg,
@@ -359,6 +383,7 @@ func newSetupModel() (*setupModel, error) {
 		scheduleInput:     scheduleInput,
 		spinner:           spin,
 		nightshiftInPath:  nightshiftInPath,
+		modelsLoading:     pendingFetches,
 		claudeModelIdx:    modelIndex(claudeModels, cfg.Providers.Claude.Model),
 		codexModelIdx:     modelIndex(codexModels, cfg.Providers.Codex.Model),
 		copilotModelIdx:   modelIndex(copilotModels, cfg.Providers.Copilot.Model),
@@ -417,7 +442,27 @@ func newSetupModel() (*setupModel, error) {
 
 // Init implements tea.Model.
 func (m *setupModel) Init() tea.Cmd {
-	return m.spinner.Tick
+	cmds := []tea.Cmd{m.spinner.Tick}
+
+	if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
+		cmds = append(cmds, func() tea.Msg {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			ids, err := providers.FetchAnthropicModels(ctx, key)
+			return anthropicModelsFetchedMsg{models: ids, err: err}
+		})
+	}
+
+	if key := os.Getenv("OPENAI_API_KEY"); key != "" {
+		cmds = append(cmds, func() tea.Msg {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			ids, err := providers.FetchOpenAIModels(ctx, key)
+			return openaiModelsFetchedMsg{models: ids, err: err}
+		})
+	}
+
+	return tea.Batch(cmds...)
 }
 
 // Update implements tea.Model.
@@ -489,6 +534,30 @@ func (m *setupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.jiraPinging = false
 		m.jiraPingOK = msg.ok
 		m.jiraPingErr = msg.err
+	case anthropicModelsFetchedMsg:
+		if m.modelsLoading > 0 {
+			m.modelsLoading--
+		}
+		if msg.err == nil && len(msg.models) > 0 {
+			opts := []modelOption{{label: "default", value: ""}}
+			for _, id := range msg.models {
+				opts = append(opts, modelOption{label: id, value: id})
+			}
+			claudeModels = opts
+			m.claudeModelIdx = modelIndex(claudeModels, m.cfg.Providers.Claude.Model)
+		}
+	case openaiModelsFetchedMsg:
+		if m.modelsLoading > 0 {
+			m.modelsLoading--
+		}
+		if msg.err == nil && len(msg.models) > 0 {
+			opts := []modelOption{{label: "default", value: ""}}
+			for _, id := range msg.models {
+				opts = append(opts, modelOption{label: id, value: id})
+			}
+			codexModels = opts
+			m.codexModelIdx = modelIndex(codexModels, m.cfg.Providers.Codex.Model)
+		}
 	}
 
 	return m, cmd
@@ -1804,6 +1873,10 @@ func renderModelFields(b *strings.Builder, m *setupModel) {
 	}
 	b.WriteString(styleNote.Render("Tip: 'default' lets the CLI pick its built-in model."))
 	b.WriteString("\n")
+	if m.modelsLoading > 0 {
+		b.WriteString(styleDim.Render(m.spinner.View() + " Fetching live model list…"))
+		b.WriteString("\n")
+	}
 }
 
 func (m *setupModel) handleModelInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -102,11 +102,13 @@ func modelOptionValues(opts []modelOption) []string {
 // Source: https://platform.claude.com/docs/en/about-claude/models/overview
 var claudeModels = []modelOption{
 	{label: "default", value: ""},
-	{label: "claude-opus-4-7-20250805", value: "claude-opus-4-7-20250805"},
-	{label: "claude-opus-4-6-20250514", value: "claude-opus-4-6-20250514"},
-	{label: "claude-sonnet-4-6-20250514", value: "claude-sonnet-4-6-20250514"},
-	{label: "claude-sonnet-4-5-20250514", value: "claude-sonnet-4-5-20250514"},
+	{label: "claude-opus-4-7", value: "claude-opus-4-7"},
+	{label: "claude-sonnet-4-6", value: "claude-sonnet-4-6"},
 	{label: "claude-haiku-4-5-20251001", value: "claude-haiku-4-5-20251001"},
+	{label: "claude-opus-4-6", value: "claude-opus-4-6"},
+	{label: "claude-sonnet-4-5-20250929", value: "claude-sonnet-4-5-20250929"},
+	{label: "claude-opus-4-5-20251101", value: "claude-opus-4-5-20251101"},
+	{label: "claude-opus-4-1-20250805", value: "claude-opus-4-1-20250805"},
 }
 
 // codexModels lists available Codex/GPT models (static fallback).

--- a/internal/providers/models.go
+++ b/internal/providers/models.go
@@ -1,0 +1,129 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// FetchAnthropicModels fetches available model IDs from the Anthropic API.
+// Returns an error when the API is unreachable or the key is invalid; callers
+// should fall back to a static list on error.
+func FetchAnthropicModels(ctx context.Context, apiKey string) ([]string, error) {
+	var ids []string
+	afterID := ""
+
+	for {
+		url := "https://api.anthropic.com/v1/models"
+		if afterID != "" {
+			url += "?after_id=" + afterID
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("X-Api-Key", apiKey)
+		req.Header.Set("anthropic-version", "2023-06-01")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetch anthropic models: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("anthropic models API status %d", resp.StatusCode)
+		}
+
+		var page struct {
+			Data    []struct{ ID string `json:"id"` } `json:"data"`
+			HasMore bool                              `json:"has_more"`
+			LastID  string                            `json:"last_id"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+			return nil, fmt.Errorf("decode anthropic models: %w", err)
+		}
+
+		for _, m := range page.Data {
+			if m.ID != "" {
+				ids = append(ids, m.ID)
+			}
+		}
+
+		if !page.HasMore {
+			break
+		}
+		afterID = page.LastID
+	}
+
+	sort.Strings(ids)
+	return ids, nil
+}
+
+// FetchOpenAIModels fetches available model IDs from the OpenAI API, filtered
+// to gpt- and codex- prefixes. Returns an error on failure; callers should
+// fall back to a static list.
+func FetchOpenAIModels(ctx context.Context, apiKey string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.openai.com/v1/models", nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch openai models: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("openai models API status %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Data []struct{ ID string `json:"id"` } `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decode openai models: %w", err)
+	}
+
+	var ids []string
+	for _, m := range body.Data {
+		if strings.HasPrefix(m.ID, "gpt-") || strings.HasPrefix(m.ID, "codex-") {
+			ids = append(ids, m.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+// CopilotModels returns the hardcoded list of Copilot CLI model IDs.
+// No programmatic API exists for Copilot model listing.
+// Source: https://docs.github.com/en/copilot/reference/ai-models/supported-models (2026-05-10)
+func CopilotModels() []string {
+	return []string{
+		"claude-haiku-4.5",
+		"claude-opus-4.5",
+		"claude-opus-4.6",
+		"claude-opus-4.7",
+		"claude-sonnet-4.5",
+		"claude-sonnet-4.6",
+		"gemini-2.5-pro",
+		"gemini-3-flash",
+		"gemini-3.1-pro",
+		"gpt-4.1",
+		"gpt-5-mini",
+		"gpt-5.2",
+		"gpt-5.2-codex",
+		"gpt-5.3-codex",
+		"gpt-5.4",
+		"gpt-5.4-mini",
+		"gpt-5.4-nano",
+		"gpt-5.5",
+		"grok-code-fast-1",
+	}
+}

--- a/internal/providers/models.go
+++ b/internal/providers/models.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 )
+
+var httpClient = http.DefaultClient
 
 // FetchAnthropicModels fetches available model IDs from the Anthropic API.
 // Returns an error when the API is unreachable or the key is invalid; callers
@@ -17,25 +20,28 @@ func FetchAnthropicModels(ctx context.Context, apiKey string) ([]string, error) 
 	afterID := ""
 
 	for {
-		url := "https://api.anthropic.com/v1/models"
+		baseURL := "https://api.anthropic.com/v1/models"
+		fetchURL := baseURL
 		if afterID != "" {
-			url += "?after_id=" + afterID
+			q := url.Values{}
+			q.Set("after_id", afterID)
+			fetchURL = baseURL + "?" + q.Encode()
 		}
 
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
 		if err != nil {
 			return nil, fmt.Errorf("build request: %w", err)
 		}
 		req.Header.Set("X-Api-Key", apiKey)
 		req.Header.Set("anthropic-version", "2023-06-01")
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("fetch anthropic models: %w", err)
 		}
-		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
 			return nil, fmt.Errorf("anthropic models API status %d", resp.StatusCode)
 		}
 
@@ -45,8 +51,10 @@ func FetchAnthropicModels(ctx context.Context, apiKey string) ([]string, error) 
 			LastID  string                            `json:"last_id"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+			resp.Body.Close()
 			return nil, fmt.Errorf("decode anthropic models: %w", err)
 		}
+		resp.Body.Close()
 
 		for _, m := range page.Data {
 			if m.ID != "" {
@@ -74,7 +82,7 @@ func FetchOpenAIModels(ctx context.Context, apiKey string) ([]string, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch openai models: %w", err)
 	}

--- a/internal/providers/models_test.go
+++ b/internal/providers/models_test.go
@@ -1,0 +1,181 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchAnthropicModels_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Api-Key") == "" {
+			t.Error("missing X-Api-Key header")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data":     []map[string]any{{"id": "claude-opus-4-7"}, {"id": "claude-sonnet-4-6"}},
+			"has_more": false,
+			"last_id":  "",
+		})
+	}))
+	defer srv.Close()
+
+	// Patch default client base URL by injecting a test transport.
+	origClient := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: rewriteHostTransport{target: srv.URL, inner: http.DefaultTransport},
+	}
+	defer func() { http.DefaultClient = origClient }()
+
+	ids, err := FetchAnthropicModels(context.Background(), "test-key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("want 2 models, got %d", len(ids))
+	}
+}
+
+func TestFetchAnthropicModels_Paginated(t *testing.T) {
+	page := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if page == 0 {
+			page++
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data":     []map[string]any{{"id": "model-a"}},
+				"has_more": true,
+				"last_id":  "model-a",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data":     []map[string]any{{"id": "model-b"}},
+			"has_more": false,
+			"last_id":  "",
+		})
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: rewriteHostTransport{target: srv.URL, inner: http.DefaultTransport},
+	}
+	defer func() { http.DefaultClient = origClient }()
+
+	ids, err := FetchAnthropicModels(context.Background(), "key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("want 2 paginated models, got %d", len(ids))
+	}
+}
+
+func TestFetchAnthropicModels_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: rewriteHostTransport{target: srv.URL, inner: http.DefaultTransport},
+	}
+	defer func() { http.DefaultClient = origClient }()
+
+	_, err := FetchAnthropicModels(context.Background(), "bad-key")
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+}
+
+func TestFetchOpenAIModels_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"id": "gpt-4.1"},
+				{"id": "gpt-5-mini"},
+				{"id": "codex-mini"},
+				{"id": "whisper-1"}, // should be filtered out
+			},
+		})
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: rewriteHostTransport{target: srv.URL, inner: http.DefaultTransport},
+	}
+	defer func() { http.DefaultClient = origClient }()
+
+	ids, err := FetchOpenAIModels(context.Background(), "test-key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 3 {
+		t.Fatalf("want 3 filtered models, got %d: %v", len(ids), ids)
+	}
+	for _, id := range ids {
+		if id == "whisper-1" {
+			t.Error("whisper-1 should have been filtered out")
+		}
+	}
+}
+
+func TestFetchOpenAIModels_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: rewriteHostTransport{target: srv.URL, inner: http.DefaultTransport},
+	}
+	defer func() { http.DefaultClient = origClient }()
+
+	_, err := FetchOpenAIModels(context.Background(), "key")
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestCopilotModels(t *testing.T) {
+	models := CopilotModels()
+	if len(models) == 0 {
+		t.Fatal("expected non-empty copilot model list")
+	}
+	// spot-check known models
+	found := map[string]bool{}
+	for _, m := range models {
+		found[m] = true
+	}
+	for _, want := range []string{"claude-sonnet-4.6", "gpt-4.1", "gemini-2.5-pro"} {
+		if !found[want] {
+			t.Errorf("expected %q in copilot model list", want)
+		}
+	}
+}
+
+// rewriteHostTransport redirects all requests to the given target server URL.
+type rewriteHostTransport struct {
+	target string
+	inner  http.RoundTripper
+}
+
+func (t rewriteHostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.URL.Scheme = "http"
+	req.URL.Host = req.URL.Host // keep host for path matching but swap scheme+host
+	// Replace host with test server
+	u := *req.URL
+	u.Scheme = "http"
+	// extract host from target
+	targetURL := t.target
+	if len(targetURL) > 7 {
+		u.Host = targetURL[7:] // strip "http://"
+	}
+	req.URL = &u
+	return t.inner.RoundTrip(req)
+}

--- a/internal/providers/models_test.go
+++ b/internal/providers/models_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -21,12 +22,13 @@ func TestFetchAnthropicModels_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Patch default client base URL by injecting a test transport.
-	origClient := http.DefaultClient
-	http.DefaultClient = &http.Client{
+	// Inject test client instead of mutating global DefaultClient.
+	testClient := &http.Client{
 		Transport: rewriteHostTransport{target: srv.URL, inner: http.DefaultTransport},
 	}
-	defer func() { http.DefaultClient = origClient }()
+	origClient := httpClient
+	httpClient = testClient
+	defer func() { httpClient = origClient }()
 
 	ids, err := FetchAnthropicModels(context.Background(), "test-key")
 	if err != nil {
@@ -57,11 +59,12 @@ func TestFetchAnthropicModels_Paginated(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origClient := http.DefaultClient
-	http.DefaultClient = &http.Client{
+	testClient := &http.Client{
 		Transport: rewriteHostTransport{target: srv.URL, inner: http.DefaultTransport},
 	}
-	defer func() { http.DefaultClient = origClient }()
+	origClient := httpClient
+	httpClient = testClient
+	defer func() { httpClient = origClient }()
 
 	ids, err := FetchAnthropicModels(context.Background(), "key")
 	if err != nil {
@@ -78,11 +81,12 @@ func TestFetchAnthropicModels_Error(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origClient := http.DefaultClient
-	http.DefaultClient = &http.Client{
+	testClient := &http.Client{
 		Transport: rewriteHostTransport{target: srv.URL, inner: http.DefaultTransport},
 	}
-	defer func() { http.DefaultClient = origClient }()
+	origClient := httpClient
+	httpClient = testClient
+	defer func() { httpClient = origClient }()
 
 	_, err := FetchAnthropicModels(context.Background(), "bad-key")
 	if err == nil {
@@ -103,11 +107,12 @@ func TestFetchOpenAIModels_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origClient := http.DefaultClient
-	http.DefaultClient = &http.Client{
+	testClient := &http.Client{
 		Transport: rewriteHostTransport{target: srv.URL, inner: http.DefaultTransport},
 	}
-	defer func() { http.DefaultClient = origClient }()
+	origClient := httpClient
+	httpClient = testClient
+	defer func() { httpClient = origClient }()
 
 	ids, err := FetchOpenAIModels(context.Background(), "test-key")
 	if err != nil {
@@ -129,11 +134,12 @@ func TestFetchOpenAIModels_Error(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origClient := http.DefaultClient
-	http.DefaultClient = &http.Client{
+	testClient := &http.Client{
 		Transport: rewriteHostTransport{target: srv.URL, inner: http.DefaultTransport},
 	}
-	defer func() { http.DefaultClient = origClient }()
+	origClient := httpClient
+	httpClient = testClient
+	defer func() { httpClient = origClient }()
 
 	_, err := FetchOpenAIModels(context.Background(), "key")
 	if err == nil {
@@ -166,16 +172,17 @@ type rewriteHostTransport struct {
 
 func (t rewriteHostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
-	req.URL.Scheme = "http"
-	req.URL.Host = req.URL.Host // keep host for path matching but swap scheme+host
-	// Replace host with test server
-	u := *req.URL
-	u.Scheme = "http"
-	// extract host from target
-	targetURL := t.target
-	if len(targetURL) > 7 {
-		u.Host = targetURL[7:] // strip "http://"
+
+	// Parse target URL to get scheme and host
+	targetURL, err := url.Parse(t.target)
+	if err != nil {
+		return nil, err
 	}
-	req.URL = &u
+
+	// Rewrite request to point to test server while preserving path and query
+	req.URL.Scheme = targetURL.Scheme
+	req.URL.Host = targetURL.Host
+	req.Host = targetURL.Host
+
 	return t.inner.RoundTrip(req)
 }


### PR DESCRIPTION
## VC-59 — Dynamic model list for provider selection in setup wizard

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-59

### Description

h2. Problem

Model lists in the setup wizard ({{claudeModels}}, {{codexModels}}, {{copilotModels}}) are hardcoded in {{cmd/nightshift/commands/setup.go}}. When providers release new models or deprecate old ones, the binary must be recompiled to reflect changes. Users with outdated binaries see stale model lists.

h2. Acceptance Criteria

* Claude and OpenAI model lists are fetched at runtime from their respective APIs when the API key is set
* Copilot model list remains hardcoded (no API exists) but is kept up-to-date
* Fallback to hardcoded list when API is unreachable or key is absent
* Fetched lists are cached for the wizard session (no repeated calls)
* Setup wizard phase model selector reflects the live list
* Existing unit tests for model selection still pass (fallback path exercised)
* No CGO dependencies introduced
* Static fallback lists in {{setup.go}} are updated to reflect current models before shipping

h2. Technical Notes

h3. Claude (Anthropic)

* *Endpoint*: {{GET https://api.anthropic.com/v1/models}}
* *Headers*: {{X-Api-Key: $ANTHROPIC_API_KEY}}, {{anthropic-version: 2023-06-01}}
* *Pagination*: cursor-based via {{after_id}} query param; follow until {{has_more: false}}
* *Response*: {{data[].id}} contains model IDs (e.g. {{claude-opus-4-1-20250805}})
* *Auth gate*: only call when {{ANTHROPIC_API_KEY}} is set
* *Go*: can use {{github.com/anthropics/anthropic-sdk-go}} (official) or raw {{net/http}}

h3. OpenAI / Codex

* *Endpoint*: {{GET https://api.openai.com/v1/models}}
* *Headers*: {{Authorization: Bearer $OPENAI_API_KEY}}
* *Pagination*: none — single response returns all ~150 models
* *Response*: {{data[].id}}; filter client-side for {{gpt-}} and {{codex-}} prefixes
* *Auth gate*: only call when {{OPENAI_API_KEY}} is set
* *Go*: can use {{github.com/openai/openai-go}} (official) or raw {{net/http}}

h3. GitHub Copilot

* *No programmatic API exists* — no REST endpoint, no CLI command for model listing
* {{copilot models list}} does NOT exist; {{copilot --help}} does not emit a machine-readable model list
* GitHub Models Catalog API ({{models.github.ai/catalog/models}}) is a separate hosted-inference service — NOT the Copilot CLI model list
* *Strategy*: hardcode the list; update it as part of this ticket and on each Nightshift release
* Reference for current models: https://docs.github.com/en/copilot/reference/ai-models/supported-models

*Current Copilot model list to hardcode* (as of 2026-05-10):

{noformat}claude-haiku-4.5
claude-opus-4.5 / 4.6 / 4.7
claude-sonnet-4.5 / 4.6
gpt-4.1
gpt-5-mini
gpt-5.2 / gpt-5.2-codex
gpt-5.3-codex
gpt-5.4 / gpt-5.4-mini / gpt-5.4-nano / gpt-5.5
gemini-2.5-pro
gemini-3-flash / gemini-3.1-pro
grok-code-fast-1{noformat}

h2. Implementation Notes

* Fetch should run non-blocking during wizard init (show spinner; fall back to hardcoded immediately if slow)
* Create {{internal/providers/models.go}} with:
** {{FetchAnthropicModels(ctx, apiKey string) ([]string, error)}} — HTTP with pagination
** {{FetchOpenAIModels(ctx, apiKey string) ([]string, error)}} — single HTTP call
** {{CopilotModels() []string}} — returns hardcoded list
* Wire into {{newSetupModel()}}: fire fetches in goroutines, merge results into model vars before wizard renders first frame

h2. Static List Update (do as part of this ticket)

Audit and update the three static lists in {{cmd/nightshift/commands/setup.go}} using the sources above:

* {{claudeModels}} — sync with Anthropic {{/v1/models}} response or https://platform.claude.com/docs/en/about-claude/models/overview
* {{codexModels}} — sync with OpenAI {{/v1/models}} response filtered to gpt/codex models
* {{copilotModels}} — update to the hardcoded list above (dot notation e.g. {{claude-sonnet-4.6}})

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
