### PR TITLE
[VC-62] Integrate GitHub status checks into fix-review workflow

### DIFF
--- a/internal/jira/e2e_test.go
+++ b/internal/jira/e2e_test.go
@@ -689,6 +689,91 @@ func TestE2E_VC8_NewOrchestrator_Defaults(t *testing.T) {
 	}
 }
 
+// ── VC-62: GitHub status checks in fix-review workflow ──────────────────────
+
+func TestE2E_VC62_FetchPRCheckRuns(t *testing.T) {
+	e2eGHAvailable(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Fetch review state for the test PR — this also populates FailingChecks.
+	rs, err := FetchPRReviewComments(ctx, ".", e2eTestPRURL())
+	if err != nil {
+		t.Skipf("FetchPRReviewComments: %v (gh CLI may not be authenticated)", err)
+	}
+
+	t.Logf("PR %s: failingChecks=%d", e2eTestPRURL(), len(rs.FailingChecks))
+	for _, cr := range rs.FailingChecks {
+		t.Logf("  failing check: name=%q conclusion=%q url=%s", cr.Name, cr.Conclusion, cr.LogsURL)
+	}
+
+	// Directly call FetchPRCheckRuns to verify it works standalone.
+	checks, err := FetchPRCheckRuns(ctx, ".", rs.Number)
+	if err != nil {
+		t.Logf("FetchPRCheckRuns: %v (may have no check-runs)", err)
+	} else {
+		t.Logf("FetchPRCheckRuns returned %d failing check-run(s)", len(checks))
+		for _, cr := range checks {
+			if cr.Name == "" {
+				t.Error("check-run has empty Name")
+			}
+			if cr.Status != "completed" {
+				t.Errorf("check-run %q: Status = %q, want 'completed'", cr.Name, cr.Status)
+			}
+		}
+	}
+}
+
+func TestE2E_VC62_ProcessFeedback_ChecksInPrompt(t *testing.T) {
+	client := e2eClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	failingCheck := CheckRun{Name: "go-test", Status: "completed", Conclusion: "failure", LogsURL: "https://github.com/runs/1"}
+
+	ra := &stubAgent{name: "e2e-fix", output: "done"}
+	o := &Orchestrator{
+		client:          &noMutationJiraClient{real: client},
+		cfg:             client.cfg,
+		reviewFixAgent:  ra,
+		implAgent:       ra,
+		validationAgent: ra,
+		fnHasChanges:    func(_ context.Context, _ string) (bool, error) { return false, nil },
+		fnCommitAndPush: func(_ context.Context, _, _ string) error { return nil },
+		fnFindPR: func(_ context.Context, _, _ string) (*PRInfo, error) {
+			return &PRInfo{URL: "https://github.com/org/repo/pull/1", Number: 1}, nil
+		},
+		fnFetchReviews: func(_ context.Context, _, _ string) (*PRReviewState, error) {
+			return &PRReviewState{
+				URL:           "https://github.com/org/repo/pull/1",
+				FailingChecks: []CheckRun{failingCheck},
+			}, nil
+		},
+		fnPostPRComment: func(_ context.Context, _, _, _ string) error { return nil },
+	}
+
+	ws := &Workspace{
+		TicketKey: "VC-62",
+		Repos:     []RepoWorkspace{{Name: "nightshift", Path: ".", Branch: "feature/VC-62"}},
+	}
+	_, err := o.ProcessFeedback(ctx, Ticket{Key: "VC-62", Summary: "status checks"}, ws)
+	if err != nil {
+		t.Fatalf("ProcessFeedback: %v", err)
+	}
+
+	// Agent must have been called — failing checks alone trigger rework.
+	if ra.capturedOpts.Prompt == "" {
+		t.Error("expected rework agent to be called for failing CI checks, but prompt was empty")
+	}
+	if !strings.Contains(ra.capturedOpts.Prompt, "go-test") {
+		t.Error("rework prompt missing failing check name 'go-test'")
+	}
+	if !strings.Contains(ra.capturedOpts.Prompt, "failure") {
+		t.Error("rework prompt missing failing check conclusion 'failure'")
+	}
+}
+
 func statusNames(ss []Status) []string {
 	names := make([]string, len(ss))
 	for i, s := range ss {

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -291,7 +291,7 @@ func buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace)
 	}
 	if len(review.FailingChecks) > 0 {
 		b.WriteString("### Failing CI Checks\n\n")
-		b.WriteString("The following GitHub status checks are failing on this PR:\n\n")
+		b.WriteString("Status checks failing on PR:\n\n")
 		for _, cr := range review.FailingChecks {
 			if cr.LogsURL != "" {
 				fmt.Fprintf(&b, "- **%s** (`%s`) — %s\n", cr.Name, cr.Conclusion, cr.LogsURL)
@@ -299,7 +299,7 @@ func buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace)
 				fmt.Fprintf(&b, "- **%s** (`%s`)\n", cr.Name, cr.Conclusion)
 			}
 		}
-		b.WriteString("\nFix all CI failures before pushing.\n\n")
+		b.WriteString("\nFix all CI failures before push.\n\n")
 	}
 	b.WriteString("### Instructions\n")
 	b.WriteString("Address ALL reviewer feedback. For each comment:\n")

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -146,21 +146,21 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			// After filtering by lastReworkAt, if nothing remains → skip regardless
 			// of ReviewDecision (it stays CHANGES_REQUESTED until a re-review).
 			// On first run (lastReworkAt zero), fall back to the original heuristic.
+			// Failing CI checks are always current state and not filtered by lastReworkAt.
+			hasFailingChecks := len(reviewState.FailingChecks) > 0
 			if !lastReworkAt.IsZero() {
-				if len(reviewState.Reviews) == 0 && !hasActionableComments(reviewState) {
+				if len(reviewState.Reviews) == 0 && !hasActionableComments(reviewState) && !hasFailingChecks {
 					o.log.Infof("ticket %s: skipping rework — no new content since lastReworkAt=%s",
 						ticket.Key, lastReworkAt.Format(time.RFC3339))
-					o.emit("  ✓ no new review comments since last rework — skipping")
+					o.emit("  ✓ no new review comments or failing checks since last rework — skipping")
 					continue
 				}
 			} else {
-				// No previous rework: proceed only when changes are explicitly requested
-				// or there are actionable inline comments (Copilot posts COMMENTED reviews,
-				// not CHANGES_REQUESTED). Outdated comments are included — position=null
-				// means the diff moved after a push, not that the suggestion was resolved.
-				if reviewState.ReviewDecision != "CHANGES_REQUESTED" && !hasActionableComments(reviewState) {
-					o.log.Infof("ticket %s: skipping rework — no actionable comments", ticket.Key)
-					o.emit("  ✓ no actionable review comments — skipping")
+				// No previous rework: proceed only when changes are explicitly requested,
+				// there are actionable inline comments, or CI checks are failing.
+				if reviewState.ReviewDecision != "CHANGES_REQUESTED" && !hasActionableComments(reviewState) && !hasFailingChecks {
+					o.log.Infof("ticket %s: skipping rework — no actionable comments or failing checks", ticket.Key)
+					o.emit("  ✓ no actionable review comments or failing checks — skipping")
 					continue
 				}
 			}
@@ -288,6 +288,18 @@ func buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace)
 				fmt.Fprintf(&b, "**%s:%d** (%s):\n%s\n\n", c.Path, c.Line, c.Author, c.Body)
 			}
 		}
+	}
+	if len(review.FailingChecks) > 0 {
+		b.WriteString("### Failing CI Checks\n\n")
+		b.WriteString("The following GitHub status checks are failing on this PR:\n\n")
+		for _, cr := range review.FailingChecks {
+			if cr.LogsURL != "" {
+				fmt.Fprintf(&b, "- **%s** (`%s`) — %s\n", cr.Name, cr.Conclusion, cr.LogsURL)
+			} else {
+				fmt.Fprintf(&b, "- **%s** (`%s`)\n", cr.Name, cr.Conclusion)
+			}
+		}
+		b.WriteString("\nFix all CI failures before pushing.\n\n")
 	}
 	b.WriteString("### Instructions\n")
 	b.WriteString("Address ALL reviewer feedback above. For each comment:\n")

--- a/internal/jira/feedback_test.go
+++ b/internal/jira/feedback_test.go
@@ -482,6 +482,123 @@ func TestProcessFeedback_FindPRError(t *testing.T) {
 	}
 }
 
+// TestProcessFeedback_StatusCheckTrigger verifies the 4 combinations of failing checks /
+// review comments that determine whether the rework agent is spawned.
+func TestProcessFeedback_StatusCheckTrigger(t *testing.T) {
+	failingCheck := CheckRun{Name: "go-test", Status: "completed", Conclusion: "failure", LogsURL: "https://github.com/runs/1"}
+
+	tests := []struct {
+		name          string
+		failingChecks []CheckRun
+		reviews       []Review
+		wantAgentRun  bool
+	}{
+		{
+			name:          "all-green and no comments — skip",
+			failingChecks: nil,
+			reviews:       nil,
+			wantAgentRun:  false,
+		},
+		{
+			name:          "failing checks and no comments — run",
+			failingChecks: []CheckRun{failingCheck},
+			reviews:       nil,
+			wantAgentRun:  true,
+		},
+		{
+			name:          "green and review comments — run",
+			failingChecks: nil,
+			reviews:       []Review{{Author: "alice", State: "CHANGES_REQUESTED", Body: "fix it"}},
+			wantAgentRun:  true,
+		},
+		{
+			name:          "failing checks and review comments — run",
+			failingChecks: []CheckRun{failingCheck},
+			reviews:       []Review{{Author: "alice", State: "CHANGES_REQUESTED", Body: "fix it"}},
+			wantAgentRun:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := &stubJiraClient{}
+			ra := &stubAgent{name: "fix", output: "done"}
+
+			reviewDecision := "APPROVED"
+			if len(tt.reviews) > 0 {
+				reviewDecision = "CHANGES_REQUESTED"
+			}
+			fnFindPR := func(_ context.Context, _, _ string) (*PRInfo, error) {
+				return &PRInfo{URL: "https://github.com/org/repo/pull/1", Number: 1}, nil
+			}
+			fnFetchReviews := func(_ context.Context, _, _ string) (*PRReviewState, error) {
+				return &PRReviewState{
+					URL:            "https://github.com/org/repo/pull/1",
+					ReviewDecision: reviewDecision,
+					Reviews:        tt.reviews,
+					FailingChecks:  tt.failingChecks,
+				}, nil
+			}
+
+			o := newFeedbackOrchestrator(sc, ra, fnFindPR, fnFetchReviews, noCommit, noPRComment)
+
+			ws := &Workspace{
+				TicketKey: "X-1",
+				Repos:     []RepoWorkspace{{Name: "repo", Path: "/tmp/repo", Branch: "feature/X-1"}},
+			}
+			_, err := o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, ws)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// capturedOpts.Prompt is non-empty only when the agent was actually called.
+			agentCalled := ra.capturedOpts.Prompt != ""
+			if agentCalled != tt.wantAgentRun {
+				t.Errorf("agentCalled = %v, want %v", agentCalled, tt.wantAgentRun)
+			}
+		})
+	}
+}
+
+// TestBuildReworkPrompt_FailingChecks verifies the failing checks section appears in the prompt.
+func TestBuildReworkPrompt_FailingChecks(t *testing.T) {
+	ticket := Ticket{Key: "VC-62", Summary: "status checks"}
+	review := &PRReviewState{
+		URL: "https://github.com/org/repo/pull/7",
+		FailingChecks: []CheckRun{
+			{Name: "go-lint", Conclusion: "failure", LogsURL: "https://github.com/runs/1"},
+			{Name: "go-test", Conclusion: "timed_out", LogsURL: ""},
+		},
+	}
+	repo := RepoWorkspace{Name: "nightshift", Branch: "feature/VC-62"}
+
+	prompt := buildReworkPrompt(ticket, review, repo)
+
+	for _, want := range []string{
+		"Failing CI Checks",
+		"go-lint",
+		"failure",
+		"https://github.com/runs/1",
+		"go-test",
+		"timed_out",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}
+
+func TestBuildReworkPrompt_NoFailingChecks(t *testing.T) {
+	ticket := Ticket{Key: "VC-62", Summary: "status checks"}
+	review := &PRReviewState{URL: "https://github.com/org/repo/pull/7"}
+	repo := RepoWorkspace{Name: "nightshift", Branch: "feature/VC-62"}
+
+	prompt := buildReworkPrompt(ticket, review, repo)
+
+	if strings.Contains(prompt, "Failing CI Checks") {
+		t.Error("prompt should not include Failing CI Checks section when no checks are failing")
+	}
+}
+
 // TestProcessFeedback_OnlyFnHasChangesSet_NoPanic reproduces VC-52: if fnHasChanges is
 // overridden but fnCommitAndPush is left nil, ProcessFeedback must not panic.
 func TestProcessFeedback_OnlyFnHasChangesSet_NoPanic(t *testing.T) {

--- a/internal/jira/pr.go
+++ b/internal/jira/pr.go
@@ -21,6 +21,14 @@ type PRInfo struct {
 	IsNew      bool
 }
 
+// CheckRun represents a single GitHub Actions / check-run result for a commit.
+type CheckRun struct {
+	Name       string
+	Status     string // "completed", "in_progress", "queued"
+	Conclusion string // "failure", "timed_out", "cancelled", "success", "neutral", "skipped", ""
+	LogsURL    string
+}
+
 // PRReviewState captures the current review state of a pull request.
 type PRReviewState struct {
 	URL            string
@@ -29,6 +37,7 @@ type PRReviewState struct {
 	ReviewDecision string
 	Reviews        []Review
 	Comments       []PRComment
+	FailingChecks  []CheckRun // check-runs with a failing conclusion (populated by FetchPRReviewComments)
 }
 
 // Review represents a single pull request review.
@@ -159,6 +168,7 @@ func buildPRBody(ticket Ticket, jiraSite string) string {
 
 // FetchPRReviewComments fetches the current review state for a PR using `gh pr view --json`
 // and appends inline review thread comments (with resolved status) via the GitHub GraphQL API.
+// It also populates FailingChecks with any failing GitHub status checks on the PR head commit.
 func FetchPRReviewComments(ctx context.Context, repoPath, prURL string) (*PRReviewState, error) {
 	out, err := ghExec(ctx, repoPath, "pr", "view", prURL,
 		"--json", "url,state,reviewDecision,reviews,comments,number")
@@ -178,7 +188,74 @@ func FetchPRReviewComments(ctx context.Context, repoPath, prURL string) (*PRRevi
 	if err == nil {
 		rs.Comments = append(rs.Comments, inline...)
 	}
+
+	// Fetch failing GitHub status checks — non-fatal; log and continue on error.
+	checks, err := FetchPRCheckRuns(ctx, repoPath, rs.Number)
+	if err != nil {
+		logging.Get().Warnf("jira: pr: fetch check-runs for PR #%d (%s) in repo %s: %v", rs.Number, prURL, repoPath, err)
+	} else {
+		rs.FailingChecks = checks
+	}
+
 	return rs, nil
+}
+
+// FetchPRCheckRuns fetches GitHub check-run results for the head commit of a PR and returns
+// only those that completed with a failing conclusion (failure, timed_out, or cancelled).
+func FetchPRCheckRuns(ctx context.Context, repoPath string, prNumber int) ([]CheckRun, error) {
+	if prNumber == 0 {
+		return nil, nil
+	}
+	// Resolve the head commit SHA for this PR.
+	shaOut, err := ghExec(ctx, repoPath, "pr", "view", fmt.Sprintf("%d", prNumber),
+		"--json", "headRefOid", "--jq", ".headRefOid")
+	if err != nil {
+		return nil, fmt.Errorf("gh pr view headRefOid: %w", err)
+	}
+	sha := strings.TrimSpace(shaOut)
+	if sha == "" {
+		return nil, fmt.Errorf("empty head SHA for PR #%d", prNumber)
+	}
+
+	out, err := ghExec(ctx, repoPath, "api",
+		fmt.Sprintf("repos/{owner}/{repo}/commits/%s/check-runs?per_page=100", sha))
+	if err != nil {
+		return nil, fmt.Errorf("gh api check-runs: %w", err)
+	}
+	return parseCheckRuns(out)
+}
+
+// parseCheckRuns decodes the GitHub check-runs API response and returns only entries
+// that completed with a failing conclusion.
+func parseCheckRuns(raw string) ([]CheckRun, error) {
+	var v struct {
+		CheckRuns []struct {
+			Name       string `json:"name"`
+			Status     string `json:"status"`
+			Conclusion string `json:"conclusion"`
+			DetailsURL string `json:"details_url"`
+		} `json:"check_runs"`
+	}
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return nil, fmt.Errorf("parse check-runs: %w", err)
+	}
+	failingConclusions := map[string]bool{
+		"failure":   true,
+		"timed_out": true,
+		"cancelled": true,
+	}
+	var runs []CheckRun
+	for _, cr := range v.CheckRuns {
+		if cr.Status == "completed" && failingConclusions[cr.Conclusion] {
+			runs = append(runs, CheckRun{
+				Name:       cr.Name,
+				Status:     cr.Status,
+				Conclusion: cr.Conclusion,
+				LogsURL:    cr.DetailsURL,
+			})
+		}
+	}
+	return runs, nil
 }
 
 // fetchReviewThreads fetches per-line review thread comments via the GitHub GraphQL API.

--- a/internal/jira/pr.go
+++ b/internal/jira/pr.go
@@ -38,6 +38,7 @@ type PRReviewState struct {
 	Reviews        []Review
 	Comments       []PRComment
 	FailingChecks  []CheckRun // check-runs with a failing conclusion (populated by FetchPRReviewComments)
+	HeadRefOid     string     // head commit SHA; included in FetchPRReviewComments to avoid duplicate gh pr view calls
 }
 
 // Review represents a single pull request review.
@@ -171,7 +172,7 @@ func buildPRBody(ticket Ticket, jiraSite string) string {
 // It also populates FailingChecks with any failing GitHub status checks on the PR head commit.
 func FetchPRReviewComments(ctx context.Context, repoPath, prURL string) (*PRReviewState, error) {
 	out, err := ghExec(ctx, repoPath, "pr", "view", prURL,
-		"--json", "url,state,reviewDecision,reviews,comments,number")
+		"--json", "url,state,reviewDecision,reviews,comments,number,headRefOid")
 	if err != nil {
 		return nil, fmt.Errorf("jira: pr: fetch review state: %w", err)
 	}
@@ -190,7 +191,8 @@ func FetchPRReviewComments(ctx context.Context, repoPath, prURL string) (*PRRevi
 	}
 
 	// Fetch failing GitHub status checks — non-fatal; log and continue on error.
-	checks, err := FetchPRCheckRuns(ctx, repoPath, rs.Number)
+	// Pass the head SHA from the initial query to avoid a duplicate gh pr view call.
+	checks, err := FetchPRCheckRuns(ctx, repoPath, rs.Number, rs.HeadRefOid)
 	if err != nil {
 		logging.Get().Warnf("jira: pr: fetch check-runs for PR #%d (%s) in repo %s: %v", rs.Number, prURL, repoPath, err)
 	} else {
@@ -201,24 +203,33 @@ func FetchPRReviewComments(ctx context.Context, repoPath, prURL string) (*PRRevi
 }
 
 // FetchPRCheckRuns fetches GitHub check-run results for the head commit of a PR and returns
-// only those that completed with a failing conclusion (failure, timed_out, or cancelled).
-func FetchPRCheckRuns(ctx context.Context, repoPath string, prNumber int) ([]CheckRun, error) {
+// only those that completed with a failing conclusion (failure, timed_out, cancelled, or action_required).
+// If sha is non-empty, it is used directly; otherwise, the head commit SHA is fetched via gh pr view.
+func FetchPRCheckRuns(ctx context.Context, repoPath string, prNumber int, sha ...string) ([]CheckRun, error) {
 	if prNumber == 0 {
 		return nil, nil
 	}
-	// Resolve the head commit SHA for this PR.
-	shaOut, err := ghExec(ctx, repoPath, "pr", "view", fmt.Sprintf("%d", prNumber),
-		"--json", "headRefOid", "--jq", ".headRefOid")
-	if err != nil {
-		return nil, fmt.Errorf("gh pr view headRefOid: %w", err)
+
+	// Use provided SHA if available; otherwise fetch from PR.
+	commitSha := ""
+	if len(sha) > 0 && sha[0] != "" {
+		commitSha = sha[0]
+	} else {
+		// Resolve the head commit SHA for this PR.
+		shaOut, err := ghExec(ctx, repoPath, "pr", "view", fmt.Sprintf("%d", prNumber),
+			"--json", "headRefOid", "--jq", ".headRefOid")
+		if err != nil {
+			return nil, fmt.Errorf("gh pr view headRefOid: %w", err)
+		}
+		commitSha = strings.TrimSpace(shaOut)
 	}
-	sha := strings.TrimSpace(shaOut)
-	if sha == "" {
+
+	if commitSha == "" {
 		return nil, fmt.Errorf("empty head SHA for PR #%d", prNumber)
 	}
 
 	out, err := ghExec(ctx, repoPath, "api",
-		fmt.Sprintf("repos/{owner}/{repo}/commits/%s/check-runs?per_page=100", sha))
+		fmt.Sprintf("repos/{owner}/{repo}/commits/%s/check-runs?per_page=100", commitSha))
 	if err != nil {
 		return nil, fmt.Errorf("gh api check-runs: %w", err)
 	}
@@ -226,7 +237,8 @@ func FetchPRCheckRuns(ctx context.Context, repoPath string, prNumber int) ([]Che
 }
 
 // parseCheckRuns decodes the GitHub check-runs API response and returns only entries
-// that completed with a failing conclusion.
+// that completed with a failing conclusion (failure, timed_out, cancelled, action_required).
+// These are the conclusions that block PR merges or require manual intervention.
 func parseCheckRuns(raw string) ([]CheckRun, error) {
 	var v struct {
 		CheckRuns []struct {
@@ -240,11 +252,12 @@ func parseCheckRuns(raw string) ([]CheckRun, error) {
 		return nil, fmt.Errorf("parse check-runs: %w", err)
 	}
 	failingConclusions := map[string]bool{
-		"failure":   true,
-		"timed_out": true,
-		"cancelled": true,
+		"failure":           true,
+		"timed_out":         true,
+		"cancelled":         true,
+		"action_required":   true,
 	}
-	var runs []CheckRun
+	runs := make([]CheckRun, 0)
 	for _, cr := range v.CheckRuns {
 		if cr.Status == "completed" && failingConclusions[cr.Conclusion] {
 			runs = append(runs, CheckRun{
@@ -334,6 +347,7 @@ func parsePRReviewState(raw string) (*PRReviewState, error) {
 		Number         int    `json:"number"`
 		State          string `json:"state"`
 		ReviewDecision string `json:"reviewDecision"`
+		HeadRefOid     string `json:"headRefOid"`
 		Reviews        []struct {
 			Author struct {
 				Login string `json:"login"`
@@ -358,6 +372,7 @@ func parsePRReviewState(raw string) (*PRReviewState, error) {
 		Number:         v.Number,
 		State:          v.State,
 		ReviewDecision: v.ReviewDecision,
+		HeadRefOid:     v.HeadRefOid,
 	}
 	for _, r := range v.Reviews {
 		rs.Reviews = append(rs.Reviews, Review{

--- a/internal/jira/pr_test.go
+++ b/internal/jira/pr_test.go
@@ -366,6 +366,7 @@ func TestFetchPRReviewComments_ReviewThreadsError(t *testing.T) {
 		"state": "OPEN",
 		"reviewDecision": "",
 		"number": 7,
+		"headRefOid": "abc123def456",
 		"reviews": [],
 		"comments": [
 			{"author": {"login": "alice"}, "body": "top-level comment", "createdAt": "2026-04-07T10:00:00Z"}
@@ -417,5 +418,149 @@ func TestFetchPRReviewComments_ReviewThreadsError(t *testing.T) {
 	}
 	if !strings.Contains(logOutput, "#7") {
 		t.Errorf("expected warning log containing PR number, got: %s", logOutput)
+	}
+}
+
+// ── parseCheckRuns ────────────────────────────────────────────────────────────
+
+func TestParseCheckRuns_ValidFailing(t *testing.T) {
+	raw := `{
+		"check_runs": [
+			{"name": "go-lint", "status": "completed", "conclusion": "failure", "details_url": "https://github.com/org/repo/runs/1"},
+			{"name": "go-test", "status": "completed", "conclusion": "timed_out", "details_url": "https://github.com/org/repo/runs/2"},
+			{"name": "security-scan", "status": "completed", "conclusion": "action_required", "details_url": "https://github.com/org/repo/runs/3"}
+		]
+	}`
+	runs, err := parseCheckRuns(raw)
+	if err != nil {
+		t.Fatalf("parseCheckRuns: %v", err)
+	}
+	if len(runs) != 3 {
+		t.Fatalf("len(runs) = %d, want 3", len(runs))
+	}
+	if runs[0].Name != "go-lint" || runs[0].Conclusion != "failure" {
+		t.Errorf("runs[0] = {%q, %q}, want {go-lint, failure}", runs[0].Name, runs[0].Conclusion)
+	}
+	if runs[1].Conclusion != "timed_out" {
+		t.Errorf("runs[1].Conclusion = %q, want timed_out", runs[1].Conclusion)
+	}
+	if runs[2].Conclusion != "action_required" {
+		t.Errorf("runs[2].Conclusion = %q, want action_required", runs[2].Conclusion)
+	}
+}
+
+func TestParseCheckRuns_SkipNonFailing(t *testing.T) {
+	raw := `{
+		"check_runs": [
+			{"name": "lint", "status": "completed", "conclusion": "success", "details_url": "https://github.com/org/repo/runs/1"},
+			{"name": "test", "status": "completed", "conclusion": "neutral", "details_url": "https://github.com/org/repo/runs/2"},
+			{"name": "skip", "status": "completed", "conclusion": "skipped", "details_url": "https://github.com/org/repo/runs/3"}
+		]
+	}`
+	runs, err := parseCheckRuns(raw)
+	if err != nil {
+		t.Fatalf("parseCheckRuns: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("len(runs) = %d, want 0 (success/neutral/skipped should be filtered)", len(runs))
+	}
+}
+
+func TestParseCheckRuns_SkipIncompleted(t *testing.T) {
+	raw := `{
+		"check_runs": [
+			{"name": "pending", "status": "in_progress", "conclusion": "failure", "details_url": "https://github.com/org/repo/runs/1"},
+			{"name": "queued", "status": "queued", "conclusion": "", "details_url": "https://github.com/org/repo/runs/2"},
+			{"name": "completed-fail", "status": "completed", "conclusion": "failure", "details_url": "https://github.com/org/repo/runs/3"}
+		]
+	}`
+	runs, err := parseCheckRuns(raw)
+	if err != nil {
+		t.Fatalf("parseCheckRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Errorf("len(runs) = %d, want 1 (only completed+failing counted)", len(runs))
+	}
+	if runs[0].Name != "completed-fail" {
+		t.Errorf("runs[0].Name = %q, want completed-fail", runs[0].Name)
+	}
+}
+
+func TestParseCheckRuns_MixedResults(t *testing.T) {
+	raw := `{
+		"check_runs": [
+			{"name": "success", "status": "completed", "conclusion": "success", "details_url": "https://github.com/org/repo/runs/1"},
+			{"name": "fail", "status": "completed", "conclusion": "failure", "details_url": "https://github.com/org/repo/runs/2"},
+			{"name": "timeout", "status": "completed", "conclusion": "timed_out", "details_url": "https://github.com/org/repo/runs/3"},
+			{"name": "pending", "status": "in_progress", "conclusion": "failure", "details_url": "https://github.com/org/repo/runs/4"},
+			{"name": "cancel", "status": "completed", "conclusion": "cancelled", "details_url": "https://github.com/org/repo/runs/5"}
+		]
+	}`
+	runs, err := parseCheckRuns(raw)
+	if err != nil {
+		t.Fatalf("parseCheckRuns: %v", err)
+	}
+	if len(runs) != 3 {
+		t.Errorf("len(runs) = %d, want 3 (fail, timeout, cancel)", len(runs))
+	}
+	conclusions := make([]string, len(runs))
+	for i, r := range runs {
+		conclusions[i] = r.Conclusion
+	}
+	expected := []string{"failure", "timed_out", "cancelled"}
+	for i, exp := range expected {
+		if i >= len(conclusions) || conclusions[i] != exp {
+			t.Errorf("conclusions[%d] = %q, want %q", i, conclusions[i], exp)
+		}
+	}
+}
+
+func TestParseCheckRuns_Empty(t *testing.T) {
+	raw := `{"check_runs": []}`
+	runs, err := parseCheckRuns(raw)
+	if err != nil {
+		t.Fatalf("parseCheckRuns: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("len(runs) = %d, want 0", len(runs))
+	}
+	if runs == nil {
+		t.Error("expected empty slice, got nil")
+	}
+}
+
+func TestParseCheckRuns_InvalidJSON(t *testing.T) {
+	raw := `not json`
+	_, err := parseCheckRuns(raw)
+	if err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestParseCheckRuns_MissingFields(t *testing.T) {
+	// Minimal valid JSON — missing optional fields should not error.
+	raw := `{"check_runs": [{"name": "test"}]}`
+	runs, err := parseCheckRuns(raw)
+	if err != nil {
+		t.Fatalf("parseCheckRuns with minimal JSON: %v", err)
+	}
+	// Missing conclusion and status means it won't be included (status not "completed")
+	if len(runs) != 0 {
+		t.Errorf("len(runs) = %d, want 0 (missing status/conclusion)", len(runs))
+	}
+}
+
+func TestParseCheckRuns_PreservesURLs(t *testing.T) {
+	raw := `{
+		"check_runs": [
+			{"name": "ci", "status": "completed", "conclusion": "failure", "details_url": "https://example.com/run/123"}
+		]
+	}`
+	runs, err := parseCheckRuns(raw)
+	if err != nil {
+		t.Fatalf("parseCheckRuns: %v", err)
+	}
+	if runs[0].LogsURL != "https://example.com/run/123" {
+		t.Errorf("LogsURL = %q, want https://example.com/run/123", runs[0].LogsURL)
 	}
 }


### PR DESCRIPTION
## VC-62 — Integrate GitHub status checks into fix-review workflow

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-62

### Description

h2. Context

The current fix-review pipeline ({{feedback.go}} / {{orchestrator.go}}) only triggers rework agents when PR review comments are present. It ignores failing GitHub status checks (CI, lint, tests), which means broken PRs can sit unaddressed if reviewers haven't left text comments.

h2. Goal

Extend the fix-review trigger logic to also consider GitHub status checks on the PR branch. The agent should be invoked when *either* condition is true:

* There are new review comments to process (existing behaviour)
* One or more required status checks are failing

The agent should be *skipped* when both conditions are false:

* No new review comments
* All status checks are green (or no checks exist)

h2. Acceptance Criteria

* {{pr.go}} fetches GitHub status checks for the PR head commit (via {{gh}} CLI or GitHub API)
* A new helper {{PRReviewState}} field (or equivalent) exposes failing check names + logs URLs
* {{ProcessFeedback}} (or the orchestrator phase that calls it) evaluates both signals before deciding to run the rework agent
* Failing checks are included in the rework prompt so the agent knows what to fix
* If checks are green and no comments → rework agent is not spawned (no wasted tokens)
* Unit tests cover: all-green+no-comments (skip), failing checks+no-comments (run), green+comments (run), failing+comments (run)
* e2e test in {{internal/jira/e2e_test.go}} exercises the status-check path (skips when {{NIGHTSHIFT_JIRA_TOKEN}} absent)

h2. Implementation Notes

* Status checks: use {{gh api repos/{owner}/{repo}/commits/{sha}/check-runs}} or {{gh pr checks <PR-number>}}
* {{ghExec}} package-level var already exists for test substitution — reuse it
* Keep SQL out of this layer; no schema changes expected
* Failing check info should be formatted as a section in {{buildReworkPrompt}}

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
