### PR TITLE
[VC-34] Copilot Usage API Client

### DIFF
--- a/internal/providers/models.go
+++ b/internal/providers/models.go
@@ -41,7 +41,7 @@ func FetchAnthropicModels(ctx context.Context, apiKey string) ([]string, error) 
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil, fmt.Errorf("anthropic models API status %d", resp.StatusCode)
 		}
 
@@ -51,10 +51,10 @@ func FetchAnthropicModels(ctx context.Context, apiKey string) ([]string, error) 
 			LastID  string                            `json:"last_id"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil, fmt.Errorf("decode anthropic models: %w", err)
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		for _, m := range page.Data {
 			if m.ID != "" {
@@ -86,7 +86,7 @@ func FetchOpenAIModels(ctx context.Context, apiKey string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetch openai models: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("openai models API status %d", resp.StatusCode)

--- a/internal/usage/copilot_client.go
+++ b/internal/usage/copilot_client.go
@@ -11,11 +11,14 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/marcus/nightshift/cmd/nightshift/commands"
 )
 
 const (
-	copilotAPIURL  = "https://api.github.com/copilot_internal/user"
-	copilotTimeout = 30 * time.Second
+	defaultCopilotAPIURL = "https://api.github.com/copilot_internal/user"
+	copilotTimeout       = 30 * time.Second
+	tokenDiscoveryTimeout = 5 * time.Second
 )
 
 // Sentinel errors for Copilot API responses.
@@ -29,6 +32,7 @@ var (
 type CopilotClient struct {
 	token      string
 	httpClient *http.Client
+	baseURL    string
 	userAgent  string
 	// ghExec runs gh with the given args and returns stdout. Injectable for tests.
 	ghExec func(args ...string) ([]byte, error)
@@ -41,10 +45,11 @@ type CopilotClient struct {
 func NewCopilotClient() (*CopilotClient, error) {
 	c := &CopilotClient{
 		httpClient: &http.Client{Timeout: copilotTimeout},
-		userAgent:  "nightshift/0.3.4",
+		baseURL:    defaultCopilotAPIURL,
+		userAgent:  "nightshift/" + commands.Version,
 		ghExec:     defaultGHExec,
 	}
-	token, err := c.discoverToken()
+	token, err := c.discoverToken(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -52,14 +57,31 @@ func NewCopilotClient() (*CopilotClient, error) {
 	return c, nil
 }
 
-// newCopilotClientWithExec is used in tests to inject a fake ghExec.
+// newCopilotClientWithExec is used in tests to inject a fake ghExec and custom baseURL.
 func newCopilotClientWithExec(ghExec func(args ...string) ([]byte, error)) (*CopilotClient, error) {
 	c := &CopilotClient{
 		httpClient: &http.Client{Timeout: copilotTimeout},
-		userAgent:  "nightshift/0.3.4",
+		baseURL:    defaultCopilotAPIURL,
+		userAgent:  "nightshift/" + commands.Version,
 		ghExec:     ghExec,
 	}
-	token, err := c.discoverToken()
+	token, err := c.discoverToken(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	c.token = token
+	return c, nil
+}
+
+// NewCopilotClientWithBaseURL constructs a client with a custom API base URL (useful for GitHub Enterprise or tests).
+func NewCopilotClientWithBaseURL(baseURL string) (*CopilotClient, error) {
+	c := &CopilotClient{
+		httpClient: &http.Client{Timeout: copilotTimeout},
+		baseURL:    baseURL,
+		userAgent:  "nightshift/" + commands.Version,
+		ghExec:     defaultGHExec,
+	}
+	token, err := c.discoverToken(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -68,12 +90,15 @@ func newCopilotClientWithExec(ghExec func(args ...string) ([]byte, error)) (*Cop
 }
 
 func defaultGHExec(args ...string) ([]byte, error) {
-	return exec.Command("gh", args...).Output()
+	ctx, cancel := context.WithTimeout(context.Background(), tokenDiscoveryTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, "gh", args...).Output()
 }
 
-func (c *CopilotClient) discoverToken() (string, error) {
-	// 1. gh auth token
-	if out, err := c.ghExec("auth", "token"); err == nil {
+func (c *CopilotClient) discoverToken(ctx context.Context) (string, error) {
+	// 1. gh auth token (defaultGHExec handles timeout internally)
+	out, err := c.ghExec("auth", "token")
+	if err == nil {
 		if tok := strings.TrimSpace(string(out)); tok != "" {
 			return tok, nil
 		}
@@ -94,12 +119,11 @@ func (c *CopilotClient) discoverToken() (string, error) {
 
 // FetchQuotas calls the Copilot internal user API and returns normalized quota data.
 func (c *CopilotClient) FetchQuotas(ctx context.Context) (*CopilotUserResponse, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, copilotAPIURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("copilot: building request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer [REDACTED]") // placeholder; real token set below
-	req.Header["Authorization"] = []string{"Bearer " + c.token}
+	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", c.userAgent)
 

--- a/internal/usage/copilot_client.go
+++ b/internal/usage/copilot_client.go
@@ -1,0 +1,132 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	copilotAPIURL  = "https://api.github.com/copilot_internal/user"
+	copilotTimeout = 30 * time.Second
+)
+
+// Sentinel errors for Copilot API responses.
+var (
+	ErrCopilotUnauthorized = errors.New("copilot: unauthorized (invalid or missing token)")
+	ErrCopilotNotFound     = errors.New("copilot: resource not found")
+	ErrCopilotUnavailable  = errors.New("copilot: service unavailable")
+)
+
+// CopilotClient fetches Copilot quota data from the GitHub internal API.
+type CopilotClient struct {
+	token      string
+	httpClient *http.Client
+	userAgent  string
+	// ghExec runs gh with the given args and returns stdout. Injectable for tests.
+	ghExec func(args ...string) ([]byte, error)
+}
+
+// NewCopilotClient constructs a CopilotClient, discovering the GitHub token via:
+//  1. gh auth token
+//  2. $GITHUB_TOKEN
+//  3. $GH_TOKEN
+func NewCopilotClient() (*CopilotClient, error) {
+	c := &CopilotClient{
+		httpClient: &http.Client{Timeout: copilotTimeout},
+		userAgent:  "nightshift/0.3.4",
+		ghExec:     defaultGHExec,
+	}
+	token, err := c.discoverToken()
+	if err != nil {
+		return nil, err
+	}
+	c.token = token
+	return c, nil
+}
+
+// newCopilotClientWithExec is used in tests to inject a fake ghExec.
+func newCopilotClientWithExec(ghExec func(args ...string) ([]byte, error)) (*CopilotClient, error) {
+	c := &CopilotClient{
+		httpClient: &http.Client{Timeout: copilotTimeout},
+		userAgent:  "nightshift/0.3.4",
+		ghExec:     ghExec,
+	}
+	token, err := c.discoverToken()
+	if err != nil {
+		return nil, err
+	}
+	c.token = token
+	return c, nil
+}
+
+func defaultGHExec(args ...string) ([]byte, error) {
+	return exec.Command("gh", args...).Output()
+}
+
+func (c *CopilotClient) discoverToken() (string, error) {
+	// 1. gh auth token
+	if out, err := c.ghExec("auth", "token"); err == nil {
+		if tok := strings.TrimSpace(string(out)); tok != "" {
+			return tok, nil
+		}
+	}
+
+	// 2. $GITHUB_TOKEN
+	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
+		return tok, nil
+	}
+
+	// 3. $GH_TOKEN
+	if tok := os.Getenv("GH_TOKEN"); tok != "" {
+		return tok, nil
+	}
+
+	return "", fmt.Errorf("copilot: no GitHub token found (tried gh auth token, $GITHUB_TOKEN, $GH_TOKEN)")
+}
+
+// FetchQuotas calls the Copilot internal user API and returns normalized quota data.
+func (c *CopilotClient) FetchQuotas(ctx context.Context) (*CopilotUserResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, copilotAPIURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("copilot: building request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer [REDACTED]") // placeholder; real token set below
+	req.Header["Authorization"] = []string{"Bearer " + c.token}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("copilot: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return nil, ErrCopilotUnauthorized
+	case http.StatusNotFound:
+		return nil, ErrCopilotNotFound
+	}
+	if resp.StatusCode >= 500 {
+		return nil, fmt.Errorf("%w: HTTP %d", ErrCopilotUnavailable, resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("copilot: unexpected status %d: %s", resp.StatusCode, body)
+	}
+
+	var raw copilotAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("copilot: decoding response: %w", err)
+	}
+
+	return normalize(raw), nil
+}

--- a/internal/usage/copilot_client.go
+++ b/internal/usage/copilot_client.go
@@ -107,7 +107,7 @@ func (c *CopilotClient) FetchQuotas(ctx context.Context) (*CopilotUserResponse, 
 	if err != nil {
 		return nil, fmt.Errorf("copilot: request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusUnauthorized:

--- a/internal/usage/copilot_client_test.go
+++ b/internal/usage/copilot_client_test.go
@@ -235,22 +235,3 @@ func clientWithServer(t *testing.T, srv *httptest.Server) *CopilotClient {
 	c.baseURL = srv.URL + "/copilot_internal/user"
 	return c
 }
-
-// rewriteTransport rewrites scheme and host while preserving path and query.
-type rewriteTransport struct {
-	base   http.RoundTripper
-	target string
-}
-
-func (rt rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req = req.Clone(req.Context())
-	// Parse target to extract scheme and host
-	parsed, err := http.NewRequest(req.Method, rt.target, req.Body)
-	if err != nil {
-		return nil, err
-	}
-	// Rewrite only scheme and host; preserve path and query
-	req.URL.Scheme = parsed.URL.Scheme
-	req.URL.Host = parsed.URL.Host
-	return rt.base.RoundTrip(req)
-}

--- a/internal/usage/copilot_client_test.go
+++ b/internal/usage/copilot_client_test.go
@@ -1,0 +1,258 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchQuotas_PremiumPlan(t *testing.T) {
+	raw := copilotAPIResponse{
+		Login:          "octocat",
+		CopilotPlan:    "pro",
+		AccessTypeSKU:  "copilot_pro",
+		QuotaResetDate: "2026-06-01",
+		QuotaSnapshots: map[string]premiumQuota{
+			"premium_interactions": {
+				Entitlement:      300,
+				Remaining:        250,
+				PercentRemaining: 83.33,
+				OveragePermitted: true,
+				Unlimited:        false,
+			},
+			"chat": {
+				Entitlement: 0,
+				Unlimited:   true,
+			},
+		},
+	}
+	srv := jsonServer(t, raw, http.StatusOK)
+	defer srv.Close()
+
+	c := clientWithServer(t, srv)
+	resp, err := c.FetchQuotas(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Login != "octocat" {
+		t.Errorf("login = %q, want %q", resp.Login, "octocat")
+	}
+	prem, ok := resp.Quotas["premium_interactions"]
+	if !ok {
+		t.Fatal("missing premium_interactions quota")
+	}
+	if prem.Remaining != 250 {
+		t.Errorf("remaining = %d, want 250", prem.Remaining)
+	}
+	if prem.PercentRemaining != 83.33 {
+		t.Errorf("percent_remaining = %v, want 83.33", prem.PercentRemaining)
+	}
+	chat := resp.Quotas["chat"]
+	if !chat.Unlimited {
+		t.Error("chat quota should be unlimited")
+	}
+}
+
+func TestFetchQuotas_FreePlan(t *testing.T) {
+	raw := copilotAPIResponse{
+		Login:       "freeuser",
+		CopilotPlan: "free",
+		LimitedUserQuotas: map[string]int{
+			"completions": 150,
+			"chat":        40,
+		},
+		MonthlyQuotas: map[string]int{
+			"completions": 2000,
+			"chat":        50,
+		},
+	}
+	srv := jsonServer(t, raw, http.StatusOK)
+	defer srv.Close()
+
+	c := clientWithServer(t, srv)
+	resp, err := c.FetchQuotas(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	comp := resp.Quotas["completions"]
+	if comp.Remaining != 150 {
+		t.Errorf("completions remaining = %d, want 150", comp.Remaining)
+	}
+	if comp.Entitlement != 2000 {
+		t.Errorf("completions entitlement = %d, want 2000", comp.Entitlement)
+	}
+	wantPct := float64(150) / float64(2000) * 100
+	if comp.PercentRemaining != wantPct {
+		t.Errorf("percent_remaining = %v, want %v", comp.PercentRemaining, wantPct)
+	}
+}
+
+func TestFetchQuotas_Unauthorized(t *testing.T) {
+	srv := statusServer(http.StatusUnauthorized)
+	defer srv.Close()
+
+	c := clientWithServer(t, srv)
+	_, err := c.FetchQuotas(context.Background())
+	if !errors.Is(err, ErrCopilotUnauthorized) {
+		t.Errorf("err = %v, want ErrCopilotUnauthorized", err)
+	}
+}
+
+func TestFetchQuotas_NotFound(t *testing.T) {
+	srv := statusServer(http.StatusNotFound)
+	defer srv.Close()
+
+	c := clientWithServer(t, srv)
+	_, err := c.FetchQuotas(context.Background())
+	if !errors.Is(err, ErrCopilotNotFound) {
+		t.Errorf("err = %v, want ErrCopilotNotFound", err)
+	}
+}
+
+func TestFetchQuotas_ServerError(t *testing.T) {
+	srv := statusServer(http.StatusInternalServerError)
+	defer srv.Close()
+
+	c := clientWithServer(t, srv)
+	_, err := c.FetchQuotas(context.Background())
+	if !errors.Is(err, ErrCopilotUnavailable) {
+		t.Errorf("err = %v, want ErrCopilotUnavailable", err)
+	}
+}
+
+func TestTokenDiscovery_GHExecFirst(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+
+	called := false
+	c, err := newCopilotClientWithExec(func(args ...string) ([]byte, error) {
+		called = true
+		return []byte("gh-token\n"), nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("ghExec not called")
+	}
+	if c.token != "gh-token" {
+		t.Errorf("token = %q, want %q", c.token, "gh-token")
+	}
+}
+
+func TestTokenDiscovery_FallsBackToGITHUB_TOKEN(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "env-token")
+	t.Setenv("GH_TOKEN", "")
+
+	c, err := newCopilotClientWithExec(func(args ...string) ([]byte, error) {
+		return nil, errors.New("gh not found")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.token != "env-token" {
+		t.Errorf("token = %q, want env-token", c.token)
+	}
+}
+
+func TestTokenDiscovery_FallsBackToGH_TOKEN(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "gh-env-token")
+
+	c, err := newCopilotClientWithExec(func(args ...string) ([]byte, error) {
+		return nil, errors.New("gh not found")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.token != "gh-env-token" {
+		t.Errorf("token = %q, want gh-env-token", c.token)
+	}
+}
+
+func TestTokenDiscovery_NoTokenError(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+
+	_, err := newCopilotClientWithExec(func(args ...string) ([]byte, error) {
+		return nil, errors.New("gh not found")
+	})
+	if err == nil {
+		t.Error("expected error when no token available")
+	}
+}
+
+func TestDisplayName(t *testing.T) {
+	cases := []struct{ key, want string }{
+		{"premium_interactions", "Premium Requests"},
+		{"chat", "Chat"},
+		{"completions", "Completions"},
+		{"code_review", "Code Review"},
+		{"unknown_key", "Unknown Key"},
+	}
+	for _, tc := range cases {
+		if got := DisplayName(tc.key); got != tc.want {
+			t.Errorf("DisplayName(%q) = %q, want %q", tc.key, got, tc.want)
+		}
+	}
+}
+
+// --- helpers ---
+
+func jsonServer(t *testing.T, v interface{}, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if err := json.NewEncoder(w).Encode(v); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	}))
+}
+
+func statusServer(status int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+	}))
+}
+
+// clientWithServer builds a CopilotClient that hits srv instead of the real API.
+func clientWithServer(t *testing.T, srv *httptest.Server) *CopilotClient {
+	t.Helper()
+	c, err := newCopilotClientWithExec(func(args ...string) ([]byte, error) {
+		return []byte("test-token\n"), nil
+	})
+	if err != nil {
+		t.Fatalf("building client: %v", err)
+	}
+	// Override HTTP client to target test server.
+	c.httpClient = &http.Client{}
+	// Patch the URL by replacing the transport.
+	c.httpClient.Transport = rewriteTransport{base: http.DefaultTransport, target: srv.URL}
+	return c
+}
+
+// rewriteTransport rewrites all requests to target.
+type rewriteTransport struct {
+	base   http.RoundTripper
+	target string
+}
+
+func (rt rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.URL.Scheme = "http"
+	req.URL.Host = req.URL.Hostname() // strip port from original
+	// Replace host entirely with test server host.
+	parsed, err := http.NewRequest(req.Method, rt.target+req.URL.Path, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	parsed.Header = req.Header
+	parsed = parsed.WithContext(req.Context())
+	return rt.base.RoundTrip(parsed)
+}

--- a/internal/usage/copilot_client_test.go
+++ b/internal/usage/copilot_client_test.go
@@ -15,7 +15,7 @@ func TestFetchQuotas_PremiumPlan(t *testing.T) {
 		CopilotPlan:    "pro",
 		AccessTypeSKU:  "copilot_pro",
 		QuotaResetDate: "2026-06-01",
-		QuotaSnapshots: map[string]premiumQuota{
+		QuotaSnapshots: map[string]CopilotQuotaSnapshot{
 			"premium_interactions": {
 				Entitlement:      300,
 				Remaining:        250,

--- a/internal/usage/copilot_client_test.go
+++ b/internal/usage/copilot_client_test.go
@@ -232,12 +232,11 @@ func clientWithServer(t *testing.T, srv *httptest.Server) *CopilotClient {
 	}
 	// Override HTTP client to target test server.
 	c.httpClient = &http.Client{}
-	// Patch the URL by replacing the transport.
-	c.httpClient.Transport = rewriteTransport{base: http.DefaultTransport, target: srv.URL}
+	c.baseURL = srv.URL + "/copilot_internal/user"
 	return c
 }
 
-// rewriteTransport rewrites all requests to target.
+// rewriteTransport rewrites scheme and host while preserving path and query.
 type rewriteTransport struct {
 	base   http.RoundTripper
 	target string
@@ -245,14 +244,13 @@ type rewriteTransport struct {
 
 func (rt rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
-	req.URL.Scheme = "http"
-	req.URL.Host = req.URL.Hostname() // strip port from original
-	// Replace host entirely with test server host.
-	parsed, err := http.NewRequest(req.Method, rt.target+req.URL.Path, req.Body)
+	// Parse target to extract scheme and host
+	parsed, err := http.NewRequest(req.Method, rt.target, req.Body)
 	if err != nil {
 		return nil, err
 	}
-	parsed.Header = req.Header
-	parsed = parsed.WithContext(req.Context())
-	return rt.base.RoundTrip(parsed)
+	// Rewrite only scheme and host; preserve path and query
+	req.URL.Scheme = parsed.URL.Scheme
+	req.URL.Host = parsed.URL.Host
+	return rt.base.RoundTrip(req)
 }

--- a/internal/usage/copilot_types.go
+++ b/internal/usage/copilot_types.go
@@ -7,6 +7,7 @@ import "strings"
 type CopilotQuotaSnapshot struct {
 	Entitlement      int     `json:"entitlement"`
 	Remaining        int     `json:"remaining"`
+	QuotaRemaining   float64 `json:"quota_remaining"`
 	PercentRemaining float64 `json:"percent_remaining"`
 	OverageCount     int     `json:"overage_count"`
 	OveragePermitted bool    `json:"overage_permitted"`

--- a/internal/usage/copilot_types.go
+++ b/internal/usage/copilot_types.go
@@ -1,0 +1,113 @@
+// Package usage provides API-based usage fetching for AI providers.
+package usage
+
+import "strings"
+
+// CopilotQuotaSnapshot holds usage quota data for a single Copilot feature.
+type CopilotQuotaSnapshot struct {
+	Entitlement      int     `json:"entitlement"`
+	Remaining        int     `json:"remaining"`
+	PercentRemaining float64 `json:"percent_remaining"`
+	OverageCount     int     `json:"overage_count"`
+	OveragePermitted bool    `json:"overage_permitted"`
+	Unlimited        bool    `json:"unlimited"`
+}
+
+// CopilotQuotaMap is a normalized map of quota name → snapshot.
+type CopilotQuotaMap map[string]CopilotQuotaSnapshot
+
+// copilotAPIResponse is the raw JSON from api.github.com/copilot_internal/user.
+// Both premium and free plan fields are present; normalize() unifies them.
+type copilotAPIResponse struct {
+	Login          string                     `json:"login"`
+	CopilotPlan    string                     `json:"copilot_plan"`
+	AccessTypeSKU  string                     `json:"access_type_sku"`
+	QuotaResetDate string                     `json:"quota_reset_date"`
+	// Premium plan
+	QuotaSnapshots map[string]premiumQuota    `json:"quota_snapshots"`
+	// Free plan
+	LimitedUserQuotas map[string]int          `json:"limited_user_quotas"`
+	MonthlyQuotas     map[string]int          `json:"monthly_quotas"`
+}
+
+type premiumQuota struct {
+	Entitlement      int     `json:"entitlement"`
+	Remaining        int     `json:"remaining"`
+	PercentRemaining float64 `json:"percent_remaining"`
+	OverageCount     int     `json:"overage_count"`
+	OveragePermitted bool    `json:"overage_permitted"`
+	Unlimited        bool    `json:"unlimited"`
+}
+
+// CopilotUserResponse is the normalized, caller-facing response.
+type CopilotUserResponse struct {
+	Login          string
+	CopilotPlan    string
+	AccessTypeSKU  string
+	QuotaResetDate string
+	Quotas         CopilotQuotaMap
+}
+
+// normalize converts raw API response into CopilotUserResponse.
+func normalize(raw copilotAPIResponse) *CopilotUserResponse {
+	resp := &CopilotUserResponse{
+		Login:          raw.Login,
+		CopilotPlan:    raw.CopilotPlan,
+		AccessTypeSKU:  raw.AccessTypeSKU,
+		QuotaResetDate: raw.QuotaResetDate,
+		Quotas:         make(CopilotQuotaMap),
+	}
+
+	// Premium plan: quota_snapshots
+	for k, v := range raw.QuotaSnapshots {
+		resp.Quotas[k] = CopilotQuotaSnapshot{
+			Entitlement:      v.Entitlement,
+			Remaining:        v.Remaining,
+			PercentRemaining: v.PercentRemaining,
+			OverageCount:     v.OverageCount,
+			OveragePermitted: v.OveragePermitted,
+			Unlimited:        v.Unlimited,
+		}
+	}
+
+	// Free plan: limited_user_quotas (per-feature remaining counts)
+	for k, remaining := range raw.LimitedUserQuotas {
+		snap := resp.Quotas[k] // may already exist from quota_snapshots
+		snap.Remaining = remaining
+		resp.Quotas[k] = snap
+	}
+
+	// Free plan: monthly_quotas (total entitlements)
+	for k, entitlement := range raw.MonthlyQuotas {
+		snap := resp.Quotas[k]
+		snap.Entitlement = entitlement
+		if entitlement > 0 {
+			snap.PercentRemaining = float64(snap.Remaining) / float64(entitlement) * 100
+		}
+		resp.Quotas[k] = snap
+	}
+
+	return resp
+}
+
+var quotaDisplayNames = map[string]string{
+	"premium_interactions": "Premium Requests",
+	"chat":                 "Chat",
+	"completions":          "Completions",
+	"code_review":          "Code Review",
+}
+
+// DisplayName maps an API quota key to a human-readable label.
+func DisplayName(key string) string {
+	if name, ok := quotaDisplayNames[key]; ok {
+		return name
+	}
+	// Fallback: replace underscores with spaces and title-case.
+	words := strings.Split(key, "_")
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}

--- a/internal/usage/copilot_types.go
+++ b/internal/usage/copilot_types.go
@@ -24,19 +24,10 @@ type copilotAPIResponse struct {
 	AccessTypeSKU  string                     `json:"access_type_sku"`
 	QuotaResetDate string                     `json:"quota_reset_date"`
 	// Premium plan
-	QuotaSnapshots map[string]premiumQuota    `json:"quota_snapshots"`
+	QuotaSnapshots map[string]CopilotQuotaSnapshot `json:"quota_snapshots"`
 	// Free plan
 	LimitedUserQuotas map[string]int          `json:"limited_user_quotas"`
 	MonthlyQuotas     map[string]int          `json:"monthly_quotas"`
-}
-
-type premiumQuota struct {
-	Entitlement      int     `json:"entitlement"`
-	Remaining        int     `json:"remaining"`
-	PercentRemaining float64 `json:"percent_remaining"`
-	OverageCount     int     `json:"overage_count"`
-	OveragePermitted bool    `json:"overage_permitted"`
-	Unlimited        bool    `json:"unlimited"`
 }
 
 // CopilotUserResponse is the normalized, caller-facing response.
@@ -60,14 +51,7 @@ func normalize(raw copilotAPIResponse) *CopilotUserResponse {
 
 	// Premium plan: quota_snapshots
 	for k, v := range raw.QuotaSnapshots {
-		resp.Quotas[k] = CopilotQuotaSnapshot{
-			Entitlement:      v.Entitlement,
-			Remaining:        v.Remaining,
-			PercentRemaining: v.PercentRemaining,
-			OverageCount:     v.OverageCount,
-			OveragePermitted: v.OveragePermitted,
-			Unlimited:        v.Unlimited,
-		}
+		resp.Quotas[k] = v
 	}
 
 	// Free plan: limited_user_quotas (per-feature remaining counts)

--- a/run/run.go
+++ b/run/run.go
@@ -1,0 +1,2 @@
+// Package run is intentionally empty.
+package run

--- a/run/run.go
+++ b/run/run.go
@@ -1,2 +1,0 @@
-// Package run is intentionally empty.
-package run


### PR DESCRIPTION
## VC-34 — Copilot Usage API Client

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-34

### Description

Summary
Create an HTTP client for the GitHub Copilot internal user-level API at api.github.com/copilot_internal/user. This fetches premium request quotas and entitlements at the individual user level.
API Details
Endpoint: GET https://api.github.com/copilot_internal/user
Auth: Authorization: Bearer <github_token> (from gh auth token)
Headers: Accept: application/json, User-Agent: nightshift/x.y.z
Response: JSON with login, copilot_plan, access_type_sku, quota_reset_date, and quota_snapshots map
Quota Snapshots
Each quota entry (e.g., premium_interactions, chat, completions) contains:
entitlement — total monthly allowance
remaining — requests remaining
percent_remaining — 0–100
overage_count — overages used
overage_permitted — whether overages allowed
unlimited — whether unlimited quota
Free Plan Format
Free plans use different fields: limited_user_quotas and monthly_quotas maps with integer counts. Client must normalize both formats into unified quota_snapshots.
Token Discovery
Run gh auth token to get GitHub token
Falls back to $GITHUB_TOKEN env var
Falls back to $GH_TOKEN env var
No OAuth refresh needed — GitHub tokens don't expire (or are managed by gh itself).
Reference
onWatch copilot_client.go
onWatch copilot_types.go
Implementation
In internal/usage/:
copilot_client.go — HTTP client, FetchQuotas()
copilot_types.go — response structs, normalize(), snapshot conversion
copilot_client_test.go — table-driven tests
Acceptance Criteria
[ ] CopilotClient.FetchQuotas(ctx) returns typed CopilotUserResponse
[ ] Both premium plan and free plan response formats handled (normalize)
[ ] Token discovered via gh auth token → $GITHUB_TOKEN → $GH_TOKEN
[ ] HTTP errors mapped to sentinel errors
[ ] 30s timeout with context support
[ ] Quota names mapped to display names (premium_interactions → "Premium Requests")
[ ] Token redacted in logs
[ ] Tests use httptest, no real API calls
[ ] make test passes, make build succeeds
Agent Workflow
Branch from main → feat/copilot-usage-client
Implement in internal/usage/
Write tests
Run make test && make build
Create PR targeting main

### Acceptance Criteria

[ ] CopilotClient.FetchQuotas(ctx) returns typed CopilotUserResponse
[ ] Both premium plan and free plan response formats handled (normalize)
[ ] Token discovered via gh auth token → $GITHUB_TOKEN → $GH_TOKEN
[ ] HTTP errors mapped to sentinel errors
[ ] 30s timeout with context support
[ ] Quota names mapped to display names (premium_interactions → "Premium Requests")
[ ] Token redacted in logs
[ ] Tests use httptest, no real API calls
[ ] make test passes, make build succeeds
Agent Workflow
Branch from main → feat/copilot-usage-client
Implement in internal/usage/
Write tests
Run make test && make build
Create PR targeting main

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
