### PR TITLE
[VC-37] OpenAI/Codex Usage API Client

### DIFF
--- a/internal/usage/codex_client.go
+++ b/internal/usage/codex_client.go
@@ -12,7 +12,6 @@ const (
 	codexPrimaryURL  = "https://chatgpt.com/backend-api/wham/usage"
 	codexFallbackURL = "https://chatgpt.com/api/codex/usage"
 	codexTimeout     = 10 * time.Second
-	nightshiftVersion = "0.3.4"
 )
 
 // CodexClient fetches real-time rate limit usage from the Codex/ChatGPT API.
@@ -27,24 +26,32 @@ type CodexClient struct {
 }
 
 // NewCodexClient creates a client by auto-discovering credentials.
-func NewCodexClient() (*CodexClient, error) {
+// userAgent defaults to "nightshift/unknown" if empty; callers should inject actual version.
+func NewCodexClient(userAgent string) (*CodexClient, error) {
 	creds, err := LoadCredentials()
 	if err != nil {
 		return nil, err
 	}
-	return NewCodexClientWithCreds(creds), nil
+	return NewCodexClientWithCreds(creds, userAgent)
 }
 
 // NewCodexClientWithCreds creates a client with pre-loaded credentials (useful in tests).
-func NewCodexClientWithCreds(creds *CodexCredentials) *CodexClient {
+// Returns error if creds is nil. userAgent defaults to "nightshift/unknown" if empty.
+func NewCodexClientWithCreds(creds *CodexCredentials, userAgent string) (*CodexClient, error) {
+	if creds == nil {
+		return nil, fmt.Errorf("codex: credentials required")
+	}
+	if userAgent == "" {
+		userAgent = "nightshift/unknown"
+	}
 	return &CodexClient{
 		httpClient:  &http.Client{Timeout: codexTimeout},
 		primaryURL:  codexPrimaryURL,
 		fallbackURL: codexFallbackURL,
 		creds:       creds,
-		userAgent:   "nightshift/" + nightshiftVersion,
+		userAgent:   userAgent,
 		oauthURL:    codexOAuthURL,
-	}
+	}, nil
 }
 
 // FetchUsage retrieves current rate limit utilization from the Codex usage API.

--- a/internal/usage/codex_client.go
+++ b/internal/usage/codex_client.go
@@ -1,0 +1,148 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	codexPrimaryURL  = "https://chatgpt.com/backend-api/wham/usage"
+	codexFallbackURL = "https://chatgpt.com/api/codex/usage"
+	codexTimeout     = 10 * time.Second
+	nightshiftVersion = "0.3.4"
+)
+
+// CodexClient fetches real-time rate limit usage from the Codex/ChatGPT API.
+type CodexClient struct {
+	httpClient  *http.Client
+	primaryURL  string
+	fallbackURL string
+	creds       *CodexCredentials
+	userAgent   string
+	// oauthURL allows tests to override the token refresh endpoint.
+	oauthURL string
+}
+
+// NewCodexClient creates a client by auto-discovering credentials.
+func NewCodexClient() (*CodexClient, error) {
+	creds, err := LoadCredentials()
+	if err != nil {
+		return nil, err
+	}
+	return NewCodexClientWithCreds(creds), nil
+}
+
+// NewCodexClientWithCreds creates a client with pre-loaded credentials (useful in tests).
+func NewCodexClientWithCreds(creds *CodexCredentials) *CodexClient {
+	return &CodexClient{
+		httpClient:  &http.Client{Timeout: codexTimeout},
+		primaryURL:  codexPrimaryURL,
+		fallbackURL: codexFallbackURL,
+		creds:       creds,
+		userAgent:   "nightshift/" + nightshiftVersion,
+		oauthURL:    codexOAuthURL,
+	}
+}
+
+// FetchUsage retrieves current rate limit utilization from the Codex usage API.
+// It auto-refreshes expired tokens and falls back to the alternate URL on 404.
+func (c *CodexClient) FetchUsage(ctx context.Context) (*CodexUsageResponse, error) {
+	if c.creds.IsExpired() {
+		if err := refreshTokenWithURL(ctx, c.creds, c.oauthURL); err != nil {
+			return nil, ErrTokenExpired
+		}
+	}
+
+	resp, err := c.fetchURL(ctx, c.primaryURL)
+	if err != nil {
+		return nil, err
+	}
+	if resp != nil {
+		return resp, nil
+	}
+
+	// Primary returned 404 — try fallback.
+	resp, err = c.fetchURL(ctx, c.fallbackURL)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, ErrUsageNotFound
+	}
+	return resp, nil
+}
+
+// fetchURL performs a single GET. Returns (nil, nil) on 404 so the caller can try the fallback.
+func (c *CodexClient) fetchURL(ctx context.Context, rawURL string) (*CodexUsageResponse, error) {
+	result, err := c.doRequest(ctx, rawURL)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// doRequest sends GET rawURL with auth headers. On 401 it attempts one refresh and retries.
+// Returns (nil, nil) on 404.
+func (c *CodexClient) doRequest(ctx context.Context, rawURL string) (*CodexUsageResponse, error) {
+	resp, err := c.get(ctx, rawURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var out CodexUsageResponse
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			return nil, fmt.Errorf("codex: decode response: %w", err)
+		}
+		return &out, nil
+
+	case http.StatusNotFound:
+		return nil, nil // caller tries fallback
+
+	case http.StatusUnauthorized:
+		// Drain and close current body before retry.
+		resp.Body.Close()
+		if err := refreshTokenWithURL(ctx, c.creds, c.oauthURL); err != nil {
+			return nil, ErrTokenExpired
+		}
+		retryResp, err := c.get(ctx, rawURL)
+		if err != nil {
+			return nil, err
+		}
+		defer retryResp.Body.Close()
+		if retryResp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("codex: usage API status %d after token refresh", retryResp.StatusCode)
+		}
+		var out CodexUsageResponse
+		if err := json.NewDecoder(retryResp.Body).Decode(&out); err != nil {
+			return nil, fmt.Errorf("codex: decode response after refresh: %w", err)
+		}
+		return &out, nil
+
+	default:
+		return nil, fmt.Errorf("codex: usage API status %d", resp.StatusCode)
+	}
+}
+
+func (c *CodexClient) get(ctx context.Context, rawURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("codex: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.creds.AccessToken)
+	req.Header.Set("User-Agent", c.userAgent)
+	if c.creds.UserID != "" {
+		req.Header.Set("X-Account-Id", c.creds.UserID)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("codex: request failed: %w", err)
+	}
+	return resp, nil
+}

--- a/internal/usage/codex_client_test.go
+++ b/internal/usage/codex_client_test.go
@@ -59,7 +59,7 @@ func newClient(primary, fallback, oauth string, creds *CodexCredentials) *CodexC
 func TestFetchUsage_success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(sampleUsageJSON(1234.56)))
+		_, _ = w.Write([]byte(sampleUsageJSON(1234.56)))
 	}))
 	defer srv.Close()
 
@@ -92,7 +92,7 @@ func TestFetchUsage_fallback404(t *testing.T) {
 	fallbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fallbackCalled.Store(true)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(sampleUsageJSON(0)))
+		_, _ = w.Write([]byte(sampleUsageJSON(0)))
 	}))
 	defer fallbackSrv.Close()
 
@@ -135,7 +135,7 @@ func TestFetchUsage_tokenRefreshOn401(t *testing.T) {
 	var refreshed atomic.Bool
 	oauthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		refreshed.Store(true)
-		json.NewEncoder(w).Encode(oauthTokenResponse{
+		_ = json.NewEncoder(w).Encode(oauthTokenResponse{
 			AccessToken:  "newtoken",
 			RefreshToken: "newrefresh",
 			ExpiresIn:    3600,
@@ -151,7 +151,7 @@ func TestFetchUsage_tokenRefreshOn401(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(sampleUsageJSON(0)))
+		_, _ = w.Write([]byte(sampleUsageJSON(0)))
 	}))
 	defer apiSrv.Close()
 
@@ -238,7 +238,9 @@ func TestLoadCredentials_authJson(t *testing.T) {
 	af.Tokens.RefreshToken = "file-refresh"
 	af.Tokens.IDToken = jwt
 	data, _ := json.Marshal(af)
-	os.WriteFile(filepath.Join(dir, "auth.json"), data, 0600)
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), data, 0600); err != nil {
+		t.Fatalf("writing auth.json: %v", err)
+	}
 
 	t.Setenv("CODEX_HOME", dir)
 	t.Setenv("CODEX_TOKEN", "") // ensure env var path not taken
@@ -278,15 +280,20 @@ func TestRefreshToken_rotation(t *testing.T) {
 	initial.Tokens.AccessToken = "old-access"
 	initial.Tokens.RefreshToken = "old-refresh"
 	data, _ := json.Marshal(initial)
-	os.WriteFile(authPath, data, 0600)
+	if err := os.WriteFile(authPath, data, 0600); err != nil {
+		t.Fatalf("writing auth.json: %v", err)
+	}
 
 	oauthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 		if r.FormValue("refresh_token") != "old-refresh" {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		json.NewEncoder(w).Encode(oauthTokenResponse{
+		_ = json.NewEncoder(w).Encode(oauthTokenResponse{
 			AccessToken:  "new-access",
 			RefreshToken: "new-refresh",
 			ExpiresIn:    3600,
@@ -314,7 +321,7 @@ func TestRefreshToken_rotation(t *testing.T) {
 	// Verify file written.
 	written, _ := os.ReadFile(authPath)
 	var af authFileShape
-	json.Unmarshal(written, &af)
+	_ = json.Unmarshal(written, &af)
 	if af.Tokens.AccessToken != "new-access" {
 		t.Errorf("file access_token = %q, want new-access", af.Tokens.AccessToken)
 	}

--- a/internal/usage/codex_client_test.go
+++ b/internal/usage/codex_client_test.go
@@ -26,14 +26,14 @@ func sampleUsageJSON(creditsBalance interface{}) string {
 		"plan_type": "pro",
 		"rate_limit": map[string]interface{}{
 			"primary_window": map[string]interface{}{
-				"used_percent":          42.5,
-				"reset_at":              time.Now().Add(time.Hour).Format(time.RFC3339),
-				"limit_window_seconds":  18000,
+				"used_percent":         42.5,
+				"reset_at":             time.Now().Add(time.Hour).Unix(),
+				"limit_window_seconds": 18000,
 			},
 			"secondary_window": map[string]interface{}{
-				"used_percent":          10.0,
-				"reset_at":              time.Now().Add(7 * 24 * time.Hour).Format(time.RFC3339),
-				"limit_window_seconds":  604800,
+				"used_percent":         10.0,
+				"reset_at":             time.Now().Add(7 * 24 * time.Hour).Unix(),
+				"limit_window_seconds": 604800,
 			},
 		},
 		"credits": map[string]interface{}{

--- a/internal/usage/codex_client_test.go
+++ b/internal/usage/codex_client_test.go
@@ -1,0 +1,356 @@
+package usage
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// makeJWT builds a minimal unsigned JWT with the given claims.
+func makeJWT(claims map[string]interface{}) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload, _ := json.Marshal(claims)
+	body := base64.RawURLEncoding.EncodeToString(payload)
+	return header + "." + body + ".fakesig"
+}
+
+func sampleUsageJSON(creditsBalance interface{}) string {
+	b, _ := json.Marshal(map[string]interface{}{
+		"plan_type": "pro",
+		"rate_limit": map[string]interface{}{
+			"primary_window": map[string]interface{}{
+				"used_percent":          42.5,
+				"reset_at":              time.Now().Add(time.Hour).Format(time.RFC3339),
+				"limit_window_seconds":  18000,
+			},
+			"secondary_window": map[string]interface{}{
+				"used_percent":          10.0,
+				"reset_at":              time.Now().Add(7 * 24 * time.Hour).Format(time.RFC3339),
+				"limit_window_seconds":  604800,
+			},
+		},
+		"credits": map[string]interface{}{
+			"balance": creditsBalance,
+		},
+	})
+	return string(b)
+}
+
+func newClient(primary, fallback, oauth string, creds *CodexCredentials) *CodexClient {
+	c := NewCodexClientWithCreds(creds)
+	c.primaryURL = primary
+	c.fallbackURL = fallback
+	c.oauthURL = oauth
+	return c
+}
+
+// ---- FetchUsage tests ----
+
+func TestFetchUsage_success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleUsageJSON(1234.56)))
+	}))
+	defer srv.Close()
+
+	creds := &CodexCredentials{AccessToken: "tok"}
+	c := newClient(srv.URL, srv.URL+"/fallback", "", creds)
+
+	resp, err := c.FetchUsage(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.PlanType != "pro" {
+		t.Errorf("plan_type = %q, want pro", resp.PlanType)
+	}
+	if resp.RateLimit == nil || resp.RateLimit.PrimaryWindow == nil {
+		t.Fatal("expected primary window")
+	}
+	if resp.RateLimit.PrimaryWindow.UsedPercent != 42.5 {
+		t.Errorf("used_percent = %v, want 42.5", resp.RateLimit.PrimaryWindow.UsedPercent)
+	}
+	if resp.Credits == nil {
+		t.Fatal("expected credits")
+	}
+	if resp.Credits.Balance != 1234.56 {
+		t.Errorf("credits.balance = %v, want 1234.56", resp.Credits.Balance)
+	}
+}
+
+func TestFetchUsage_fallback404(t *testing.T) {
+	fallbackCalled := false
+	fallbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCalled = true
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleUsageJSON(0)))
+	}))
+	defer fallbackSrv.Close()
+
+	primarySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer primarySrv.Close()
+
+	creds := &CodexCredentials{AccessToken: "tok"}
+	c := newClient(primarySrv.URL, fallbackSrv.URL, "", creds)
+
+	resp, err := c.FetchUsage(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fallbackCalled {
+		t.Error("fallback URL not called")
+	}
+	if resp == nil {
+		t.Fatal("expected response from fallback")
+	}
+}
+
+func TestFetchUsage_fallbackAlsoFails(t *testing.T) {
+	srv404 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv404.Close()
+
+	creds := &CodexCredentials{AccessToken: "tok"}
+	c := newClient(srv404.URL, srv404.URL, "", creds)
+
+	_, err := c.FetchUsage(context.Background())
+	if err != ErrUsageNotFound {
+		t.Errorf("want ErrUsageNotFound, got %v", err)
+	}
+}
+
+func TestFetchUsage_tokenRefreshOn401(t *testing.T) {
+	refreshed := false
+	oauthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshed = true
+		json.NewEncoder(w).Encode(oauthTokenResponse{
+			AccessToken:  "newtoken",
+			RefreshToken: "newrefresh",
+			ExpiresIn:    3600,
+		})
+	}))
+	defer oauthSrv.Close()
+
+	calls := 0
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleUsageJSON(0)))
+	}))
+	defer apiSrv.Close()
+
+	creds := &CodexCredentials{AccessToken: "oldtok", RefreshToken: "oldrefresh"}
+	c := newClient(apiSrv.URL, apiSrv.URL+"/fallback", oauthSrv.URL, creds)
+
+	resp, err := c.FetchUsage(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !refreshed {
+		t.Error("token refresh not called")
+	}
+	if resp == nil {
+		t.Fatal("expected response after refresh")
+	}
+}
+
+func TestFetchUsage_creditsStringFloat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// balance as quoted string
+		w.Write([]byte(sampleUsageJSON("999.99")))
+	}))
+	defer srv.Close()
+
+	creds := &CodexCredentials{AccessToken: "tok"}
+	c := newClient(srv.URL, srv.URL, "", creds)
+
+	resp, err := c.FetchUsage(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Credits == nil {
+		t.Fatal("expected credits")
+	}
+	if resp.Credits.Balance != 999.99 {
+		t.Errorf("balance = %v, want 999.99", resp.Credits.Balance)
+	}
+}
+
+func TestFetchUsage_creditsNumericFloat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleUsageJSON(500.0)))
+	}))
+	defer srv.Close()
+
+	creds := &CodexCredentials{AccessToken: "tok"}
+	c := newClient(srv.URL, srv.URL, "", creds)
+
+	resp, err := c.FetchUsage(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Credits.Balance != 500.0 {
+		t.Errorf("balance = %v, want 500.0", resp.Credits.Balance)
+	}
+}
+
+// ---- Credential tests ----
+
+func TestLoadCredentials_envVar(t *testing.T) {
+	t.Setenv("CODEX_TOKEN", "env-token")
+	creds, err := LoadCredentials()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.AccessToken != "env-token" {
+		t.Errorf("access_token = %q, want env-token", creds.AccessToken)
+	}
+}
+
+func TestLoadCredentials_authJson(t *testing.T) {
+	dir := t.TempDir()
+	exp := time.Now().Add(time.Hour).Unix()
+	jwt := makeJWT(map[string]interface{}{
+		"exp":             exp,
+		"chatgpt_user_id": "usr_abc123",
+	})
+
+	af := authFileShape{}
+	af.Tokens.AccessToken = "file-token"
+	af.Tokens.RefreshToken = "file-refresh"
+	af.Tokens.IDToken = jwt
+	data, _ := json.Marshal(af)
+	os.WriteFile(filepath.Join(dir, "auth.json"), data, 0600)
+
+	t.Setenv("CODEX_HOME", dir)
+	t.Setenv("CODEX_TOKEN", "") // ensure env var path not taken
+
+	creds, err := LoadCredentials()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.AccessToken != "file-token" {
+		t.Errorf("access_token = %q", creds.AccessToken)
+	}
+	if creds.UserID != "usr_abc123" {
+		t.Errorf("user_id = %q, want usr_abc123", creds.UserID)
+	}
+	if creds.ExpiresAt.Unix() != exp {
+		t.Errorf("expires_at = %v, want %v", creds.ExpiresAt.Unix(), exp)
+	}
+}
+
+func TestLoadCredentials_notFound(t *testing.T) {
+	t.Setenv("CODEX_TOKEN", "")
+	t.Setenv("CODEX_HOME", "/nonexistent/path/that/cannot/exist/xyz")
+
+	_, err := LoadCredentials()
+	if err != ErrNoCredentials {
+		t.Errorf("want ErrNoCredentials, got %v", err)
+	}
+}
+
+// ---- Refresh token tests ----
+
+func TestRefreshToken_rotation(t *testing.T) {
+	dir := t.TempDir()
+	authPath := filepath.Join(dir, "auth.json")
+
+	initial := authFileShape{}
+	initial.Tokens.AccessToken = "old-access"
+	initial.Tokens.RefreshToken = "old-refresh"
+	data, _ := json.Marshal(initial)
+	os.WriteFile(authPath, data, 0600)
+
+	oauthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		if r.FormValue("refresh_token") != "old-refresh" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(oauthTokenResponse{
+			AccessToken:  "new-access",
+			RefreshToken: "new-refresh",
+			ExpiresIn:    3600,
+		})
+	}))
+	defer oauthSrv.Close()
+
+	creds := &CodexCredentials{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		AuthFilePath: authPath,
+	}
+
+	if err := refreshTokenWithURL(context.Background(), creds, oauthSrv.URL); err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+
+	if creds.AccessToken != "new-access" {
+		t.Errorf("in-memory access_token = %q, want new-access", creds.AccessToken)
+	}
+	if creds.RefreshToken != "new-refresh" {
+		t.Errorf("in-memory refresh_token = %q, want new-refresh", creds.RefreshToken)
+	}
+
+	// Verify file written.
+	written, _ := os.ReadFile(authPath)
+	var af authFileShape
+	json.Unmarshal(written, &af)
+	if af.Tokens.AccessToken != "new-access" {
+		t.Errorf("file access_token = %q, want new-access", af.Tokens.AccessToken)
+	}
+	if af.Tokens.RefreshToken != "new-refresh" {
+		t.Errorf("file refresh_token = %q, want new-refresh", af.Tokens.RefreshToken)
+	}
+}
+
+// ---- JWT parsing tests ----
+
+func TestJWTParsing_expiry(t *testing.T) {
+	exp := time.Now().Add(2 * time.Hour).Unix()
+	jwt := makeJWT(map[string]interface{}{
+		"exp":             exp,
+		"chatgpt_user_id": "user_xyz",
+	})
+
+	userID, expTime, err := parseIDToken(jwt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if userID != "user_xyz" {
+		t.Errorf("userID = %q, want user_xyz", userID)
+	}
+	if expTime.Unix() != exp {
+		t.Errorf("exp = %v, want %v", expTime.Unix(), exp)
+	}
+}
+
+func TestJWTParsing_subFallback(t *testing.T) {
+	jwt := makeJWT(map[string]interface{}{
+		"sub": "sub_fallback",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	userID, _, err := parseIDToken(jwt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if userID != "sub_fallback" {
+		t.Errorf("userID = %q, want sub_fallback", userID)
+	}
+}

--- a/internal/usage/codex_client_test.go
+++ b/internal/usage/codex_client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -43,7 +44,10 @@ func sampleUsageJSON(creditsBalance interface{}) string {
 }
 
 func newClient(primary, fallback, oauth string, creds *CodexCredentials) *CodexClient {
-	c := NewCodexClientWithCreds(creds)
+	c, err := NewCodexClientWithCreds(creds, "test/1.0")
+	if err != nil {
+		panic(err)
+	}
 	c.primaryURL = primary
 	c.fallbackURL = fallback
 	c.oauthURL = oauth
@@ -84,9 +88,9 @@ func TestFetchUsage_success(t *testing.T) {
 }
 
 func TestFetchUsage_fallback404(t *testing.T) {
-	fallbackCalled := false
+	var fallbackCalled atomic.Bool
 	fallbackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fallbackCalled = true
+		fallbackCalled.Store(true)
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(sampleUsageJSON(0)))
 	}))
@@ -104,7 +108,7 @@ func TestFetchUsage_fallback404(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !fallbackCalled {
+	if !fallbackCalled.Load() {
 		t.Error("fallback URL not called")
 	}
 	if resp == nil {
@@ -128,9 +132,9 @@ func TestFetchUsage_fallbackAlsoFails(t *testing.T) {
 }
 
 func TestFetchUsage_tokenRefreshOn401(t *testing.T) {
-	refreshed := false
+	var refreshed atomic.Bool
 	oauthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		refreshed = true
+		refreshed.Store(true)
 		json.NewEncoder(w).Encode(oauthTokenResponse{
 			AccessToken:  "newtoken",
 			RefreshToken: "newrefresh",
@@ -139,10 +143,10 @@ func TestFetchUsage_tokenRefreshOn401(t *testing.T) {
 	}))
 	defer oauthSrv.Close()
 
-	calls := 0
+	var calls atomic.Int32
 	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
-		if calls == 1 {
+		callNum := calls.Add(1)
+		if callNum == 1 {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
@@ -158,7 +162,7 @@ func TestFetchUsage_tokenRefreshOn401(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !refreshed {
+	if !refreshed.Load() {
 		t.Error("token refresh not called")
 	}
 	if resp == nil {

--- a/internal/usage/codex_client_test.go
+++ b/internal/usage/codex_client_test.go
@@ -174,7 +174,7 @@ func TestFetchUsage_creditsStringFloat(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		// balance as quoted string
-		w.Write([]byte(sampleUsageJSON("999.99")))
+		_, _ = w.Write([]byte(sampleUsageJSON("999.99")))
 	}))
 	defer srv.Close()
 
@@ -196,7 +196,7 @@ func TestFetchUsage_creditsStringFloat(t *testing.T) {
 func TestFetchUsage_creditsNumericFloat(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(sampleUsageJSON(500.0)))
+		_, _ = w.Write([]byte(sampleUsageJSON(500.0)))
 	}))
 	defer srv.Close()
 

--- a/internal/usage/codex_credentials.go
+++ b/internal/usage/codex_credentials.go
@@ -1,0 +1,137 @@
+package usage
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CodexCredentials holds OAuth tokens for the Codex/ChatGPT API.
+type CodexCredentials struct {
+	AccessToken  string
+	RefreshToken string
+	IDToken      string
+	UserID       string
+	ExpiresAt    time.Time
+	AuthFilePath string
+}
+
+// IsExpired reports whether the access token is expired or expiring within 30s.
+func (c *CodexCredentials) IsExpired() bool {
+	return !c.ExpiresAt.IsZero() && time.Now().After(c.ExpiresAt.Add(-30*time.Second))
+}
+
+// authFileShape mirrors the structure of ~/.codex/auth.json.
+type authFileShape struct {
+	Tokens struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
+	} `json:"tokens"`
+}
+
+// LoadCredentials discovers Codex OAuth credentials in order:
+//  1. CODEX_TOKEN env var
+//  2. $CODEX_HOME/auth.json
+//  3. ~/.codex/auth.json
+func LoadCredentials() (*CodexCredentials, error) {
+	if tok := os.Getenv("CODEX_TOKEN"); tok != "" {
+		return &CodexCredentials{AccessToken: tok}, nil
+	}
+
+	path, err := authFilePath()
+	if err != nil {
+		return nil, ErrNoCredentials
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, ErrNoCredentials
+	}
+
+	var af authFileShape
+	if err := json.Unmarshal(data, &af); err != nil {
+		return nil, fmt.Errorf("codex: parse auth.json: %w", err)
+	}
+
+	if af.Tokens.AccessToken == "" {
+		return nil, ErrNoCredentials
+	}
+
+	creds := &CodexCredentials{
+		AccessToken:  af.Tokens.AccessToken,
+		RefreshToken: af.Tokens.RefreshToken,
+		IDToken:      af.Tokens.IDToken,
+		AuthFilePath: path,
+	}
+
+	if af.Tokens.IDToken != "" {
+		if userID, exp, err := parseIDToken(af.Tokens.IDToken); err == nil {
+			creds.UserID = userID
+			creds.ExpiresAt = exp
+		}
+	}
+
+	return creds, nil
+}
+
+func authFilePath() (string, error) {
+	if home := os.Getenv("CODEX_HOME"); home != "" {
+		return filepath.Join(home, "auth.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".codex", "auth.json"), nil
+}
+
+// parseIDToken decodes the JWT middle segment and extracts exp + chatgpt_user_id.
+// Signature is NOT verified — we only need the claims.
+func parseIDToken(token string) (userID string, exp time.Time, err error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", time.Time{}, fmt.Errorf("codex: malformed id_token")
+	}
+
+	// Base64url decode without padding
+	payload := parts[1]
+	switch len(payload) % 4 {
+	case 2:
+		payload += "=="
+	case 3:
+		payload += "="
+	}
+	decoded, err := base64.URLEncoding.DecodeString(payload)
+	if err != nil {
+		// Try RawURLEncoding
+		decoded, err = base64.RawURLEncoding.DecodeString(parts[1])
+		if err != nil {
+			return "", time.Time{}, fmt.Errorf("codex: decode id_token payload: %w", err)
+		}
+	}
+
+	var claims struct {
+		Exp            int64  `json:"exp"`
+		ChatGPTUserID  string `json:"chatgpt_user_id"`
+		Sub            string `json:"sub"`
+	}
+	if err := json.Unmarshal(decoded, &claims); err != nil {
+		return "", time.Time{}, fmt.Errorf("codex: parse id_token claims: %w", err)
+	}
+
+	if claims.Exp > 0 {
+		exp = time.Unix(claims.Exp, 0)
+	}
+
+	userID = claims.ChatGPTUserID
+	if userID == "" {
+		userID = claims.Sub
+	}
+
+	return userID, exp, nil
+}

--- a/internal/usage/codex_oauth.go
+++ b/internal/usage/codex_oauth.go
@@ -50,7 +50,9 @@ func refreshTokenWithURL(ctx context.Context, creds *CodexCredentials, oauthURL 
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	// Use timeout-bounded client for refresh requests (avoid indefinite hang).
+	httpClient := &http.Client{Timeout: codexTimeout}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("codex: refresh token request: %w", err)
 	}
@@ -83,8 +85,7 @@ func refreshTokenWithURL(ctx context.Context, creds *CodexCredentials, oauthURL 
 
 	if creds.AuthFilePath != "" {
 		if err := writeCredentials(creds.AuthFilePath, creds); err != nil {
-			// Non-fatal: log but continue — creds in memory are valid.
-			_ = err
+			return fmt.Errorf("codex: failed to write rotated token to %s: %w (credentials in memory updated but not persisted; next refresh will fail)", creds.AuthFilePath, err)
 		}
 	}
 

--- a/internal/usage/codex_oauth.go
+++ b/internal/usage/codex_oauth.go
@@ -113,16 +113,16 @@ func writeCredentials(path string, creds *CodexCredentials) error {
 
 	if _, err := tmp.Write(data); err != nil {
 		tmp.Close()
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("codex: write temp auth file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("codex: close temp auth file: %w", err)
 	}
 
 	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("codex: rename auth file: %w", err)
 	}
 

--- a/internal/usage/codex_oauth.go
+++ b/internal/usage/codex_oauth.go
@@ -1,0 +1,129 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	codexOAuthURL  = "https://auth.openai.com/oauth/token"
+	codexClientID  = "app_EMoamEEZ73f0CkXaXp7hrann"
+	codexOAuthScope = "openid profile email offline_access"
+)
+
+// oauthTokenResponse is the response from the token refresh endpoint.
+type oauthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+}
+
+// RefreshToken refreshes the OAuth access token using the stored refresh token.
+// OpenAI uses one-time-use refresh tokens (rotation) — the new refresh token is
+// written back to auth.json atomically before returning.
+func RefreshToken(ctx context.Context, creds *CodexCredentials) error {
+	return refreshTokenWithURL(ctx, creds, codexOAuthURL)
+}
+
+func refreshTokenWithURL(ctx context.Context, creds *CodexCredentials, oauthURL string) error {
+	if creds.RefreshToken == "" {
+		return fmt.Errorf("codex: no refresh token available")
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", creds.RefreshToken)
+	form.Set("client_id", codexClientID)
+	form.Set("scope", codexOAuthScope)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauthURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("codex: build refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("codex: refresh token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("codex: refresh token status %d", resp.StatusCode)
+	}
+
+	var tok oauthTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tok); err != nil {
+		return fmt.Errorf("codex: decode refresh response: %w", err)
+	}
+
+	creds.AccessToken = tok.AccessToken
+	creds.RefreshToken = tok.RefreshToken
+	creds.IDToken = tok.IDToken
+	if tok.ExpiresIn > 0 {
+		creds.ExpiresAt = time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second)
+	}
+
+	if tok.IDToken != "" {
+		if userID, exp, err := parseIDToken(tok.IDToken); err == nil {
+			creds.UserID = userID
+			if !exp.IsZero() {
+				creds.ExpiresAt = exp
+			}
+		}
+	}
+
+	if creds.AuthFilePath != "" {
+		if err := writeCredentials(creds.AuthFilePath, creds); err != nil {
+			// Non-fatal: log but continue — creds in memory are valid.
+			_ = err
+		}
+	}
+
+	return nil
+}
+
+// writeCredentials atomically writes updated tokens to auth.json.
+func writeCredentials(path string, creds *CodexCredentials) error {
+	af := authFileShape{}
+	af.Tokens.AccessToken = creds.AccessToken
+	af.Tokens.RefreshToken = creds.RefreshToken
+	af.Tokens.IDToken = creds.IDToken
+
+	data, err := json.MarshalIndent(af, "", "  ")
+	if err != nil {
+		return fmt.Errorf("codex: marshal auth.json: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".auth_tmp_*")
+	if err != nil {
+		return fmt.Errorf("codex: create temp auth file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("codex: write temp auth file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("codex: close temp auth file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("codex: rename auth file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/usage/codex_types.go
+++ b/internal/usage/codex_types.go
@@ -31,8 +31,20 @@ type CodexAPIRateLimit struct {
 // CodexWindow represents a single rate limit window.
 type CodexWindow struct {
 	UsedPercent        float64   `json:"used_percent"`
-	ResetAt            time.Time `json:"reset_at"`
+	ResetAt            UnixTime  `json:"reset_at"`
 	LimitWindowSeconds int64     `json:"limit_window_seconds"`
+}
+
+// UnixTime unmarshals a Unix timestamp integer as time.Time.
+type UnixTime struct{ time.Time }
+
+func (u *UnixTime) UnmarshalJSON(data []byte) error {
+	var ts int64
+	if err := json.Unmarshal(data, &ts); err != nil {
+		return fmt.Errorf("codex reset_at: %w", err)
+	}
+	u.Time = time.Unix(ts, 0)
+	return nil
 }
 
 // CodexCredits holds the credits balance, which the API may encode as float or string.

--- a/internal/usage/codex_types.go
+++ b/internal/usage/codex_types.go
@@ -1,0 +1,74 @@
+package usage
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+var (
+	ErrNoCredentials = errors.New("codex: no credentials found")
+	ErrTokenExpired  = errors.New("codex: token expired and refresh failed")
+	ErrUsageNotFound = errors.New("codex: usage endpoint not found")
+)
+
+// CodexUsageResponse is the top-level API response from the usage endpoint.
+type CodexUsageResponse struct {
+	PlanType            string             `json:"plan_type"`
+	RateLimit           *CodexAPIRateLimit `json:"rate_limit"`
+	CodeReviewRateLimit *CodexAPIRateLimit `json:"code_review_rate_limit"`
+	Credits             *CodexCredits      `json:"credits,omitempty"`
+}
+
+// CodexAPIRateLimit holds primary and secondary rate limit windows.
+type CodexAPIRateLimit struct {
+	PrimaryWindow   *CodexWindow `json:"primary_window"`
+	SecondaryWindow *CodexWindow `json:"secondary_window"`
+}
+
+// CodexWindow represents a single rate limit window.
+type CodexWindow struct {
+	UsedPercent        float64   `json:"used_percent"`
+	ResetAt            time.Time `json:"reset_at"`
+	LimitWindowSeconds int64     `json:"limit_window_seconds"`
+}
+
+// CodexCredits holds the credits balance, which the API may encode as float or string.
+type CodexCredits struct {
+	Balance float64
+}
+
+func (c *CodexCredits) UnmarshalJSON(data []byte) error {
+	// Try object with balance field first
+	var raw struct {
+		Balance json.RawMessage `json:"balance"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("codex credits: %w", err)
+	}
+	if raw.Balance == nil {
+		return nil
+	}
+
+	// Try numeric
+	var f float64
+	if err := json.Unmarshal(raw.Balance, &f); err == nil {
+		c.Balance = f
+		return nil
+	}
+
+	// Try string-encoded float
+	var s string
+	if err := json.Unmarshal(raw.Balance, &s); err == nil {
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return fmt.Errorf("codex credits balance string: %w", err)
+		}
+		c.Balance = f
+		return nil
+	}
+
+	return fmt.Errorf("codex credits: cannot parse balance from %s", string(raw.Balance))
+}


### PR DESCRIPTION
## VC-37 — OpenAI/Codex Usage API Client

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-37

### Description

Summary
Create an HTTP client for the OpenAI/Codex user-level usage API at chatgpt.com/backend-api/wham/usage. This fetches real-time rate limit utilization using OAuth tokens that the Codex CLI stores locally.
API Details
Endpoint: GET https://chatgpt.com/backend-api/wham/usage
Fallback: GET https://chatgpt.com/api/codex/usage (auto-switch on 404)
Auth: Authorization: Bearer <oauth_access_token>
Headers: User-Agent: nightshift/x.y.z, optional X-Account-Id
Response: plan_type, rate_limit (primary_window + secondary_window with used_percent, reset_at, limit_window_seconds), code_review_rate_limit, optional credits with balance
Rate Limit Windows
WindowMeaningPrimary (5h)5-hour rolling usage limitSecondary (7d)Weekly all-model limitCode ReviewReview request limitToken Discovery
Read OAuth access token from:
$CODEX_HOME/auth.json (if CODEX_HOME set)
~/.codex/auth.json → tokens.access_token
$CODEX_TOKEN env var fallback
Parse id_token JWT for expiry (exp claim) and chatgpt_user_id.
OAuth Token Refresh
When token expired, refresh via POST https://auth.openai.com/oauth/token (form-encoded):
grant_type=refresh_token
refresh_token=<from auth.json>
client_id=app_EMoamEEZ73f0CkXaXp7hrann
scope=openid profile email offline_access
IMPORTANT: OpenAI uses one-time-use refresh tokens (rotation). Must save new refresh token immediately after refresh.
Reference
onWatch codex_client.go
onWatch codex_oauth.go
onWatch codex_types.go
onWatch codex_credentials.go
Implementation
In internal/usage/:
codex_client.go — HTTP client, FetchUsage(), URL fallback logic
codex_types.go — response structs (rate limits, windows, credits)
codex_credentials.go — credential discovery, JWT parsing
codex_oauth.go — token refresh with rotation
codex_client_test.go — table-driven tests with httptest
Acceptance Criteria
[ ] CodexClient.FetchUsage(ctx) returns typed CodexUsageResponse
[ ] Token auto-discovered from ~/.codex/auth.json or $CODEX_TOKEN
[ ] Auto-fallback between primary and alternate usage URLs on 404
[ ] Expired tokens auto-refreshed; new refresh token written back atomically
[ ] JWT id_token parsed for expiry and user ID
[ ] HTTP errors mapped to sentinel errors
[ ] 10s timeout (Codex API is faster)
[ ] Credits balance parsed (supports both float and string-encoded floats)
[ ] Tests use httptest, no real API calls
[ ] make test passes, make build succeeds
Agent Workflow
Branch from main → feat/codex-usage-client
Implement in internal/usage/
Write comprehensive tests
Run make test && make build
Create PR targeting main

### Acceptance Criteria

[ ] CodexClient.FetchUsage(ctx) returns typed CodexUsageResponse
[ ] Token auto-discovered from ~/.codex/auth.json or $CODEX_TOKEN
[ ] Auto-fallback between primary and alternate usage URLs on 404
[ ] Expired tokens auto-refreshed; new refresh token written back atomically
[ ] JWT id_token parsed for expiry and user ID
[ ] HTTP errors mapped to sentinel errors
[ ] 10s timeout (Codex API is faster)
[ ] Credits balance parsed (supports both float and string-encoded floats)
[ ] Tests use httptest, no real API calls
[ ] make test passes, make build succeeds
Agent Workflow
Branch from main → feat/codex-usage-client
Implement in internal/usage/
Write comprehensive tests
Run make test && make build
Create PR targeting main

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
