### PR TITLE
[VC-33] Active Budget Manager (API-first + fallback)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           go-version: '1.23'
 
+      - name: Download dependencies
+        run: go mod download
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/cmd/nightshift/commands/helpers.go
+++ b/cmd/nightshift/commands/helpers.go
@@ -119,6 +119,6 @@ func newBudgetManager(cfg *config.Config, database *db.DB) *budget.Manager {
 	copilotProvider := providers.NewCopilotWithPath(cfg.ExpandedProviderPath("copilot"))
 	cal := calibrator.New(database, cfg)
 	trend := trends.NewAnalyzer(database, cfg.Budget.SnapshotRetentionDays)
-	return budget.NewManagerFromProviders(cfg, claudeProvider, codexProvider, copilotProvider,
+	return budget.NewManagerWithTrackingFromProviders(cfg, claudeProvider, codexProvider, copilotProvider,
 		budget.WithBudgetSource(cal), budget.WithTrendAnalyzer(trend))
 }

--- a/cmd/nightshift/commands/root.go
+++ b/cmd/nightshift/commands/root.go
@@ -4,6 +4,7 @@ package commands
 import (
 	"os"
 
+	"github.com/marcus/nightshift/internal/usage"
 	"github.com/spf13/cobra"
 )
 
@@ -30,6 +31,9 @@ func Execute() {
 }
 
 func init() {
+	// Initialize usage.Version for API clients (User-Agent headers).
+	usage.Version = Version
+
 	// Global flags can be added here
 	rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose output")
 }

--- a/internal/budget/active.go
+++ b/internal/budget/active.go
@@ -283,13 +283,12 @@ func NewManagerWithTracking(
 		return NewManager(cfg, passiveClaude, passiveCodex, passiveCopilot, opts...)
 	}
 
-	var claudeP ClaudeUsageProvider = passiveClaude
 	var codexP CodexUsageProvider = passiveCodex
 	var copilotP CopilotUsageProvider = passiveCopilot
 
 	// Anthropic client — never fails at construction; credentials read at call time.
 	anthropicClient := usage.NewAnthropicClient()
-	claudeP = &anthropicActiveProvider{
+	claudeP := &anthropicActiveProvider{
 		client:  anthropicClient,
 		passive: passiveClaude,
 		hybrid:  mode == "hybrid", // suppress warnings for expected fallback in hybrid mode

--- a/internal/budget/active.go
+++ b/internal/budget/active.go
@@ -1,0 +1,381 @@
+package budget
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/marcus/nightshift/internal/config"
+	"github.com/marcus/nightshift/internal/providers"
+	"github.com/marcus/nightshift/internal/usage"
+	"github.com/rs/zerolog/log"
+)
+
+// Quota represents utilization for a single time window.
+type Quota struct {
+	Window      string
+	Utilization float64 // 0.0–1.0
+	ResetsAt    time.Time
+}
+
+// ProviderUsage is unified usage data from any provider.
+type ProviderUsage struct {
+	Provider  string
+	Quotas    []Quota
+	Credits   *float64
+	ResetTime *time.Time
+	Source    string // "api", "file", "tmux"
+	FetchedAt time.Time
+}
+
+// anthropicActiveProvider wraps AnthropicClient and falls back to a passive provider.
+type anthropicActiveProvider struct {
+	client  *usage.AnthropicClient
+	passive ClaudeUsageProvider
+	mu      sync.Mutex
+	src     string
+}
+
+func (p *anthropicActiveProvider) Name() string { return "claude" }
+
+func (p *anthropicActiveProvider) GetUsedPercent(mode string, weeklyBudget int64) (float64, error) {
+	if p.client != nil {
+		resp, err := p.client.FetchQuotas(context.Background())
+		if err == nil {
+			if entry, ok := resp["seven_day"]; ok {
+				pct := entry.Utilization * 100
+				p.setSource("api")
+				log.Debug().Str("provider", "claude").Str("source", "api").Float64("used_pct", pct).Msg("budget: usage from api")
+				return pct, nil
+			}
+			// seven_day key absent — fall through to passive
+		} else {
+			log.Warn().Err(err).Str("provider", "claude").Msg("budget: api fetch failed, falling back to file")
+		}
+	}
+	if p.passive != nil {
+		pct, err := p.passive.GetUsedPercent(mode, weeklyBudget)
+		if err == nil {
+			p.setSource("file")
+			log.Debug().Str("provider", "claude").Str("source", "file").Float64("used_pct", pct).Msg("budget: usage from file")
+		}
+		return pct, err
+	}
+	p.setSource("file")
+	return 0, nil
+}
+
+func (p *anthropicActiveProvider) LastUsedPercentSource() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.src
+}
+
+func (p *anthropicActiveProvider) setSource(s string) {
+	p.mu.Lock()
+	p.src = s
+	p.mu.Unlock()
+}
+
+// codexActiveProvider wraps CodexClient and falls back to a passive provider.
+type codexActiveProvider struct {
+	client  *usage.CodexClient
+	passive CodexUsageProvider
+	mu      sync.Mutex
+	src     string
+}
+
+func (p *codexActiveProvider) Name() string { return "codex" }
+
+func (p *codexActiveProvider) GetUsedPercent(mode string, weeklyBudget int64) (float64, error) {
+	if p.client != nil {
+		resp, err := p.client.FetchUsage(context.Background())
+		if err == nil && resp != nil && resp.RateLimit != nil && resp.RateLimit.SecondaryWindow != nil {
+			pct := resp.RateLimit.SecondaryWindow.UsedPercent
+			p.setSource("api")
+			log.Debug().Str("provider", "codex").Str("source", "api").Float64("used_pct", pct).Msg("budget: usage from api")
+			return pct, nil
+		}
+		if err != nil {
+			log.Warn().Err(err).Str("provider", "codex").Msg("budget: api fetch failed, falling back to file")
+		}
+	}
+	if p.passive != nil {
+		pct, err := p.passive.GetUsedPercent(mode, weeklyBudget)
+		if err == nil {
+			p.setSource("file")
+			log.Debug().Str("provider", "codex").Str("source", "file").Float64("used_pct", pct).Msg("budget: usage from file")
+		}
+		return pct, err
+	}
+	p.setSource("file")
+	return 0, nil
+}
+
+func (p *codexActiveProvider) GetResetTime(mode string) (time.Time, error) {
+	if p.client != nil {
+		resp, err := p.client.FetchUsage(context.Background())
+		if err == nil && resp != nil && resp.RateLimit != nil && resp.RateLimit.SecondaryWindow != nil {
+			return resp.RateLimit.SecondaryWindow.ResetAt.Time, nil
+		}
+	}
+	if p.passive != nil {
+		return p.passive.GetResetTime(mode)
+	}
+	return time.Time{}, nil
+}
+
+func (p *codexActiveProvider) LastUsedPercentSource() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.src
+}
+
+func (p *codexActiveProvider) setSource(s string) {
+	p.mu.Lock()
+	p.src = s
+	p.mu.Unlock()
+}
+
+// copilotActiveProvider wraps CopilotClient and falls back to a passive provider.
+type copilotActiveProvider struct {
+	client  *usage.CopilotClient
+	passive CopilotUsageProvider
+	mu      sync.Mutex
+	src     string
+}
+
+func (p *copilotActiveProvider) Name() string { return "copilot" }
+
+func (p *copilotActiveProvider) GetUsedPercent(mode string, monthlyLimit int64) (float64, error) {
+	if p.client != nil {
+		resp, err := p.client.FetchQuotas(context.Background())
+		if err == nil && resp != nil {
+			if snap, ok := resp.Quotas["premium_interactions"]; ok {
+				// PercentRemaining is 0–100; convert to used %.
+				pct := 100 - snap.PercentRemaining
+				if snap.Unlimited {
+					pct = 0
+				}
+				p.setSource("api")
+				log.Debug().Str("provider", "copilot").Str("source", "api").Float64("used_pct", pct).Msg("budget: usage from api")
+				return pct, nil
+			}
+		}
+		if err != nil {
+			log.Warn().Err(err).Str("provider", "copilot").Msg("budget: api fetch failed, falling back to file")
+		}
+	}
+	if p.passive != nil {
+		pct, err := p.passive.GetUsedPercent(mode, monthlyLimit)
+		if err == nil {
+			p.setSource("file")
+			log.Debug().Str("provider", "copilot").Str("source", "file").Float64("used_pct", pct).Msg("budget: usage from file")
+		}
+		return pct, err
+	}
+	p.setSource("file")
+	return 0, nil
+}
+
+func (p *copilotActiveProvider) GetResetTime(mode string) (time.Time, error) {
+	if p.client != nil {
+		resp, err := p.client.FetchQuotas(context.Background())
+		if err == nil && resp != nil && resp.QuotaResetDate != "" {
+			t, parseErr := time.Parse("2006-01-02", resp.QuotaResetDate)
+			if parseErr == nil {
+				return t, nil
+			}
+			log.Warn().Str("raw", resp.QuotaResetDate).Err(parseErr).Msg("budget: copilot reset date parse failed")
+		}
+	}
+	if p.passive != nil {
+		return p.passive.GetResetTime(mode)
+	}
+	return time.Time{}, nil
+}
+
+func (p *copilotActiveProvider) LastUsedPercentSource() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.src
+}
+
+func (p *copilotActiveProvider) setSource(s string) {
+	p.mu.Lock()
+	p.src = s
+	p.mu.Unlock()
+}
+
+// NewManagerWithTracking builds a Manager respecting cfg.Budget.Tracking.
+// For "passive" mode it delegates to NewManagerFromProviders with no change.
+// For "active" and "hybrid" modes it wraps each provider with an API client
+// that falls back to the passive provider on error.
+// Returns the same *Manager type so call sites require no changes.
+func NewManagerWithTracking(
+	cfg *config.Config,
+	passiveClaude ClaudeUsageProvider,
+	passiveCodex CodexUsageProvider,
+	passiveCopilot CopilotUsageProvider,
+	opts ...Option,
+) *Manager {
+	mode := cfg.Budget.Tracking
+	if mode == "" || mode == "passive" {
+		return NewManager(cfg, passiveClaude, passiveCodex, passiveCopilot, opts...)
+	}
+
+	var claudeP ClaudeUsageProvider = passiveClaude
+	var codexP CodexUsageProvider = passiveCodex
+	var copilotP CopilotUsageProvider = passiveCopilot
+
+	// Anthropic client — never fails at construction; credentials read at call time.
+	anthropicClient := usage.NewAnthropicClient()
+	claudeP = &anthropicActiveProvider{
+		client:  anthropicClient,
+		passive: passiveClaude,
+	}
+
+	// Codex client — fails at construction if no credentials.
+	codexClient, err := usage.NewCodexClient("")
+	if err != nil {
+		if mode == "active" {
+			log.Warn().Err(err).Msg("budget: codex api client unavailable, using passive fallback")
+		}
+		// hybrid: passiveCodex already set; active: also fall back gracefully.
+	} else {
+		codexP = &codexActiveProvider{
+			client:  codexClient,
+			passive: passiveCodex,
+		}
+	}
+
+	// Copilot client — fails at construction if no GitHub token.
+	copilotClient, err := usage.NewCopilotClient()
+	if err != nil {
+		if mode == "active" {
+			log.Warn().Err(err).Msg("budget: copilot api client unavailable, using passive fallback")
+		}
+	} else {
+		copilotP = &copilotActiveProvider{
+			client:  copilotClient,
+			passive: passiveCopilot,
+		}
+	}
+
+	return NewManager(cfg, claudeP, codexP, copilotP, opts...)
+}
+
+// NewManagerWithTrackingFromProviders is a convenience wrapper accepting concrete provider types.
+func NewManagerWithTrackingFromProviders(
+	cfg *config.Config,
+	claude *providers.Claude,
+	codex *providers.Codex,
+	copilot *providers.Copilot,
+	opts ...Option,
+) *Manager {
+	var claudeP ClaudeUsageProvider
+	var codexP CodexUsageProvider
+	var copilotP CopilotUsageProvider
+	if claude != nil {
+		claudeP = claude
+	}
+	if codex != nil {
+		codexP = codex
+	}
+	if copilot != nil {
+		copilotP = copilot
+	}
+	return NewManagerWithTracking(cfg, claudeP, codexP, copilotP, opts...)
+}
+
+// FetchProviderUsage fetches unified usage data for a named provider using API clients.
+// This is a best-effort convenience method; returns zero ProviderUsage on any error.
+func FetchProviderUsage(ctx context.Context, provider string) ProviderUsage {
+	now := time.Now()
+	switch provider {
+	case "claude":
+		client := usage.NewAnthropicClient()
+		resp, err := client.FetchQuotas(ctx)
+		if err != nil {
+			return ProviderUsage{Provider: provider, Source: "none", FetchedAt: now}
+		}
+		pu := ProviderUsage{Provider: provider, Source: "api", FetchedAt: now}
+		for key, entry := range resp {
+			q := Quota{
+				Window:      key,
+				Utilization: entry.Utilization,
+				ResetsAt:    entry.ResetsAt,
+			}
+			pu.Quotas = append(pu.Quotas, q)
+			if entry.UsedCredits != nil && pu.Credits == nil {
+				c := *entry.UsedCredits
+				pu.Credits = &c
+			}
+			if !entry.ResetsAt.IsZero() && (pu.ResetTime == nil || entry.ResetsAt.Before(*pu.ResetTime)) {
+				t := entry.ResetsAt
+				pu.ResetTime = &t
+			}
+		}
+		return pu
+
+	case "codex":
+		client, err := usage.NewCodexClient("")
+		if err != nil {
+			return ProviderUsage{Provider: provider, Source: "none", FetchedAt: now}
+		}
+		resp, err := client.FetchUsage(ctx)
+		if err != nil || resp == nil {
+			return ProviderUsage{Provider: provider, Source: "none", FetchedAt: now}
+		}
+		pu := ProviderUsage{Provider: provider, Source: "api", FetchedAt: now}
+		if resp.RateLimit != nil {
+			if sw := resp.RateLimit.SecondaryWindow; sw != nil {
+				pu.Quotas = append(pu.Quotas, Quota{
+					Window:      fmt.Sprintf("%ds", sw.LimitWindowSeconds),
+					Utilization: sw.UsedPercent / 100,
+					ResetsAt:    sw.ResetAt.Time,
+				})
+				t := sw.ResetAt.Time
+				pu.ResetTime = &t
+			}
+			if pw := resp.RateLimit.PrimaryWindow; pw != nil {
+				pu.Quotas = append(pu.Quotas, Quota{
+					Window:      fmt.Sprintf("%ds-primary", pw.LimitWindowSeconds),
+					Utilization: pw.UsedPercent / 100,
+					ResetsAt:    pw.ResetAt.Time,
+				})
+			}
+		}
+		if resp.Credits != nil {
+			c := resp.Credits.Balance
+			pu.Credits = &c
+		}
+		return pu
+
+	case "copilot":
+		client, err := usage.NewCopilotClient()
+		if err != nil {
+			return ProviderUsage{Provider: provider, Source: "none", FetchedAt: now}
+		}
+		resp, err := client.FetchQuotas(ctx)
+		if err != nil || resp == nil {
+			return ProviderUsage{Provider: provider, Source: "none", FetchedAt: now}
+		}
+		pu := ProviderUsage{Provider: provider, Source: "api", FetchedAt: now}
+		for key, snap := range resp.Quotas {
+			util := (100 - snap.PercentRemaining) / 100
+			if snap.Unlimited {
+				util = 0
+			}
+			pu.Quotas = append(pu.Quotas, Quota{Window: key, Utilization: util})
+		}
+		if resp.QuotaResetDate != "" {
+			if t, parseErr := time.Parse("2006-01-02", resp.QuotaResetDate); parseErr == nil {
+				pu.ResetTime = &t
+			}
+		}
+		return pu
+	}
+	return ProviderUsage{Provider: provider, Source: "none", FetchedAt: now}
+}

--- a/internal/budget/active.go
+++ b/internal/budget/active.go
@@ -35,6 +35,7 @@ type anthropicActiveProvider struct {
 	passive ClaudeUsageProvider
 	mu      sync.Mutex
 	src     string
+	hybrid  bool // if true, only warn at debug level on API errors (expected fallback)
 }
 
 func (p *anthropicActiveProvider) Name() string { return "claude" }
@@ -51,7 +52,13 @@ func (p *anthropicActiveProvider) GetUsedPercent(mode string, weeklyBudget int64
 			}
 			// seven_day key absent — fall through to passive
 		} else {
-			log.Warn().Err(err).Str("provider", "claude").Msg("budget: api fetch failed, falling back to file")
+			// In hybrid mode, API errors are expected (missing credentials); log at debug.
+			// In active mode, warn so user knows the fallback is happening.
+			if p.hybrid {
+				log.Debug().Err(err).Str("provider", "claude").Msg("budget: anthropic api unavailable, using passive fallback")
+			} else {
+				log.Warn().Err(err).Str("provider", "claude").Msg("budget: api fetch failed, falling back to file")
+			}
 		}
 	}
 	if p.passive != nil {
@@ -84,6 +91,11 @@ type codexActiveProvider struct {
 	passive CodexUsageProvider
 	mu      sync.Mutex
 	src     string
+	// Cache last FetchUsage response to avoid duplicate API calls
+	// when both GetUsedPercent and GetResetTime are called for the same check.
+	cachedResp  *usage.CodexUsageResponse
+	cachedTime  time.Time
+	cacheTTL    time.Duration // default 1 minute
 }
 
 func (p *codexActiveProvider) Name() string { return "codex" }
@@ -92,6 +104,14 @@ func (p *codexActiveProvider) GetUsedPercent(mode string, weeklyBudget int64) (f
 	if p.client != nil {
 		resp, err := p.client.FetchUsage(context.Background())
 		if err == nil && resp != nil && resp.RateLimit != nil && resp.RateLimit.SecondaryWindow != nil {
+			// Cache response for reuse by GetResetTime (1-minute TTL).
+			p.mu.Lock()
+			p.cachedResp = resp
+			p.cachedTime = time.Now()
+			if p.cacheTTL == 0 {
+				p.cacheTTL = 1 * time.Minute
+			}
+			p.mu.Unlock()
 			pct := resp.RateLimit.SecondaryWindow.UsedPercent
 			p.setSource("api")
 			log.Debug().Str("provider", "codex").Str("source", "api").Float64("used_pct", pct).Msg("budget: usage from api")
@@ -114,6 +134,16 @@ func (p *codexActiveProvider) GetUsedPercent(mode string, weeklyBudget int64) (f
 }
 
 func (p *codexActiveProvider) GetResetTime(mode string) (time.Time, error) {
+	// Check cache first to avoid duplicate API calls.
+	p.mu.Lock()
+	if p.cachedResp != nil && time.Since(p.cachedTime) < p.cacheTTL {
+		defer p.mu.Unlock()
+		if p.cachedResp.RateLimit != nil && p.cachedResp.RateLimit.SecondaryWindow != nil {
+			return p.cachedResp.RateLimit.SecondaryWindow.ResetAt.Time, nil
+		}
+	}
+	p.mu.Unlock()
+
 	if p.client != nil {
 		resp, err := p.client.FetchUsage(context.Background())
 		if err == nil && resp != nil && resp.RateLimit != nil && resp.RateLimit.SecondaryWindow != nil {
@@ -144,6 +174,11 @@ type copilotActiveProvider struct {
 	passive CopilotUsageProvider
 	mu      sync.Mutex
 	src     string
+	// Cache last FetchQuotas response to avoid duplicate API calls
+	// when both GetUsedPercent and GetResetTime are called for the same check.
+	cachedResp  *usage.CopilotUserResponse
+	cachedTime  time.Time
+	cacheTTL    time.Duration // default 1 minute
 }
 
 func (p *copilotActiveProvider) Name() string { return "copilot" }
@@ -152,6 +187,15 @@ func (p *copilotActiveProvider) GetUsedPercent(mode string, monthlyLimit int64) 
 	if p.client != nil {
 		resp, err := p.client.FetchQuotas(context.Background())
 		if err == nil && resp != nil {
+			// Cache response for reuse by GetResetTime (1-minute TTL).
+			p.mu.Lock()
+			p.cachedResp = resp
+			p.cachedTime = time.Now()
+			if p.cacheTTL == 0 {
+				p.cacheTTL = 1 * time.Minute
+			}
+			p.mu.Unlock()
+
 			if snap, ok := resp.Quotas["premium_interactions"]; ok {
 				// PercentRemaining is 0–100; convert to used %.
 				pct := 100 - snap.PercentRemaining
@@ -180,6 +224,20 @@ func (p *copilotActiveProvider) GetUsedPercent(mode string, monthlyLimit int64) 
 }
 
 func (p *copilotActiveProvider) GetResetTime(mode string) (time.Time, error) {
+	// Check cache first to avoid duplicate API calls.
+	p.mu.Lock()
+	if p.cachedResp != nil && time.Since(p.cachedTime) < p.cacheTTL {
+		defer p.mu.Unlock()
+		if p.cachedResp.QuotaResetDate != "" {
+			t, parseErr := time.Parse("2006-01-02", p.cachedResp.QuotaResetDate)
+			if parseErr == nil {
+				return t, nil
+			}
+			log.Warn().Str("raw", p.cachedResp.QuotaResetDate).Err(parseErr).Msg("budget: copilot reset date parse failed")
+		}
+	}
+	p.mu.Unlock()
+
 	if p.client != nil {
 		resp, err := p.client.FetchQuotas(context.Background())
 		if err == nil && resp != nil && resp.QuotaResetDate != "" {
@@ -209,7 +267,7 @@ func (p *copilotActiveProvider) setSource(s string) {
 }
 
 // NewManagerWithTracking builds a Manager respecting cfg.Budget.Tracking.
-// For "passive" mode it delegates to NewManagerFromProviders with no change.
+// For "passive" mode it delegates to NewManager with no change.
 // For "active" and "hybrid" modes it wraps each provider with an API client
 // that falls back to the passive provider on error.
 // Returns the same *Manager type so call sites require no changes.
@@ -234,9 +292,11 @@ func NewManagerWithTracking(
 	claudeP = &anthropicActiveProvider{
 		client:  anthropicClient,
 		passive: passiveClaude,
+		hybrid:  mode == "hybrid", // suppress warnings for expected fallback in hybrid mode
 	}
 
 	// Codex client — fails at construction if no credentials.
+	// In hybrid mode, construction failure is expected and safe; active mode logs and falls back.
 	codexClient, err := usage.NewCodexClient("")
 	if err != nil {
 		if mode == "active" {

--- a/internal/budget/active_test.go
+++ b/internal/budget/active_test.go
@@ -89,13 +89,6 @@ func anthropicErrorServer() *httptest.Server {
 // --- passive mode ---
 
 func TestPassiveMode_NeverCallsAPI(t *testing.T) {
-	apiCalled := false
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		apiCalled = true
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer srv.Close()
-
 	passive := &fakeClaudeProvider{pct: 42.0}
 	cfg := makeConfig("passive")
 	mgr := NewManagerWithTracking(cfg, passive, nil, nil)
@@ -107,8 +100,10 @@ func TestPassiveMode_NeverCallsAPI(t *testing.T) {
 	if pct != 42.0 {
 		t.Errorf("want 42.0, got %f", pct)
 	}
-	if apiCalled {
-		t.Error("API should not be called in passive mode")
+	// In passive mode, the returned manager should use the exact passive provider passed in,
+	// not wrapped. Verify the provider is not an active wrapper.
+	if _, isActive := mgr.claude.(*anthropicActiveProvider); isActive {
+		t.Error("passive mode should not wrap provider in active adapter")
 	}
 }
 
@@ -263,7 +258,34 @@ func TestCopilotActiveProvider_APIError_FallsBackToPassive(t *testing.T) {
 	}
 }
 
-// --- hybrid mode ---
+// --- hybrid mode via NewManagerWithTracking ---
+
+func TestHybridMode_ConstructsActiveWrappersViaNewManagerWithTracking(t *testing.T) {
+	// Test that NewManagerWithTracking with tracking="hybrid" creates active wrappers.
+	// This verifies the constructor properly detects the tracking mode and wraps providers.
+	passiveClaude := &fakeClaudeProvider{pct: 42.0}
+	passiveCodex := &fakeCodexProvider{pct: 50.0}
+	passiveCopilot := &fakeCopilotProvider{pct: 30.0}
+
+	cfg := makeConfig("hybrid")
+	// NewManagerWithTracking creates AnthropicClient and wraps all providers.
+	// Construction succeeds even without real credentials (errors occur at API call time).
+	mgr := NewManagerWithTracking(cfg, passiveClaude, passiveCodex, passiveCopilot)
+
+	// Verify the manager was created (no panic, no error).
+	if mgr == nil {
+		t.Fatal("NewManagerWithTracking returned nil manager")
+	}
+	// In hybrid mode, the manager should be populated with wrapped providers.
+	// We can't directly inspect mgr.claude without exposing it, but we can verify
+	// GetUsedPercent doesn't panic and returns a valid percentage.
+	_, err := mgr.GetUsedPercent("claude")
+	if err != nil {
+		t.Fatalf("GetUsedPercent failed: %v", err)
+	}
+}
+
+// --- hybrid mode manual construction (for detailed testing) ---
 
 func TestHybridMode_MixedCredentials(t *testing.T) {
 	// Anthropic API succeeds; codex/copilot no credentials → passive used.
@@ -278,7 +300,7 @@ func TestHybridMode_MixedCredentials(t *testing.T) {
 		usage.WithHTTPClient(srv.Client()),
 		usage.WithCredentialStore(&staticCred{token: "test-token"}),
 	)
-	claudeP := &anthropicActiveProvider{client: apiClient, passive: passiveClaude}
+	claudeP := &anthropicActiveProvider{client: apiClient, passive: passiveClaude, hybrid: true}
 	codexP := &codexActiveProvider{client: nil, passive: passiveCodex}
 
 	cfg := makeConfig("hybrid")

--- a/internal/budget/active_test.go
+++ b/internal/budget/active_test.go
@@ -1,0 +1,346 @@
+package budget
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marcus/nightshift/internal/config"
+	"github.com/marcus/nightshift/internal/usage"
+)
+
+// --- fake passive providers ---
+
+type fakeClaudeProvider struct {
+	pct float64
+	err error
+	src string
+}
+
+func (f *fakeClaudeProvider) Name() string { return "claude" }
+func (f *fakeClaudeProvider) GetUsedPercent(_ string, _ int64) (float64, error) {
+	return f.pct, f.err
+}
+func (f *fakeClaudeProvider) LastUsedPercentSource() string { return f.src }
+
+type fakeCodexProvider struct {
+	pct   float64
+	err   error
+	reset time.Time
+}
+
+func (f *fakeCodexProvider) Name() string { return "codex" }
+func (f *fakeCodexProvider) GetUsedPercent(_ string, _ int64) (float64, error) {
+	return f.pct, f.err
+}
+func (f *fakeCodexProvider) GetResetTime(_ string) (time.Time, error) { return f.reset, nil }
+
+type fakeCopilotProvider struct {
+	pct   float64
+	err   error
+	reset time.Time
+}
+
+func (f *fakeCopilotProvider) Name() string { return "copilot" }
+func (f *fakeCopilotProvider) GetUsedPercent(_ string, _ int64) (float64, error) {
+	return f.pct, f.err
+}
+func (f *fakeCopilotProvider) GetResetTime(_ string) (time.Time, error) { return f.reset, nil }
+
+// --- helpers ---
+
+func makeConfig(tracking string) *config.Config {
+	return &config.Config{
+		Budget: config.BudgetConfig{
+			Mode:         "weekly",
+			MaxPercent:   80,
+			WeeklyTokens: 1_000_000,
+			Tracking:     tracking,
+		},
+	}
+}
+
+// anthropicTestServer returns a server that serves a minimal AnthropicQuotaResponse.
+func anthropicTestServer(utilization float64) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		type entry struct {
+			Utilization float64 `json:"utilization"`
+			ResetsAt    string  `json:"resets_at"`
+			IsEnabled   bool    `json:"is_enabled"`
+		}
+		payload := map[string]entry{
+			"seven_day": {Utilization: utilization, IsEnabled: true, ResetsAt: "2099-01-01T00:00:00Z"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+}
+
+func anthropicErrorServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+}
+
+// --- passive mode ---
+
+func TestPassiveMode_NeverCallsAPI(t *testing.T) {
+	apiCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalled = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	passive := &fakeClaudeProvider{pct: 42.0}
+	cfg := makeConfig("passive")
+	mgr := NewManagerWithTracking(cfg, passive, nil, nil)
+
+	pct, err := mgr.GetUsedPercent("claude")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pct != 42.0 {
+		t.Errorf("want 42.0, got %f", pct)
+	}
+	if apiCalled {
+		t.Error("API should not be called in passive mode")
+	}
+}
+
+func TestEmptyTrackingMode_BehavesLikePassive(t *testing.T) {
+	passive := &fakeClaudeProvider{pct: 55.0}
+	cfg := makeConfig("")
+	mgr := NewManagerWithTracking(cfg, passive, nil, nil)
+
+	pct, err := mgr.GetUsedPercent("claude")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pct != 55.0 {
+		t.Errorf("want 55.0, got %f", pct)
+	}
+}
+
+// --- active mode: anthropic adapter ---
+
+func TestAnthropicActiveProvider_APISuccess(t *testing.T) {
+	srv := anthropicTestServer(0.6) // 60% utilization
+	defer srv.Close()
+
+	passive := &fakeClaudeProvider{pct: 99.0}
+	apiClient := usage.NewAnthropicClient(
+		usage.WithBaseURL(srv.URL),
+		usage.WithHTTPClient(srv.Client()),
+		// Use a static credential store so no real credentials are needed.
+		usage.WithCredentialStore(&staticCred{token: "test-token"}),
+	)
+	p := &anthropicActiveProvider{client: apiClient, passive: passive}
+
+	pct, err := p.GetUsedPercent("weekly", 1_000_000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pct != 60.0 {
+		t.Errorf("want 60.0, got %f", pct)
+	}
+	if p.LastUsedPercentSource() != "api" {
+		t.Errorf("want source=api, got %s", p.LastUsedPercentSource())
+	}
+}
+
+func TestAnthropicActiveProvider_APIError_FallsBackToPassive(t *testing.T) {
+	srv := anthropicErrorServer()
+	defer srv.Close()
+
+	passive := &fakeClaudeProvider{pct: 33.0}
+	apiClient := usage.NewAnthropicClient(
+		usage.WithBaseURL(srv.URL),
+		usage.WithHTTPClient(srv.Client()),
+		usage.WithCredentialStore(&staticCred{token: "test-token"}),
+	)
+	p := &anthropicActiveProvider{client: apiClient, passive: passive}
+
+	pct, err := p.GetUsedPercent("weekly", 1_000_000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pct != 33.0 {
+		t.Errorf("want 33.0 (passive fallback), got %f", pct)
+	}
+	if p.LastUsedPercentSource() != "file" {
+		t.Errorf("want source=file, got %s", p.LastUsedPercentSource())
+	}
+}
+
+func TestAnthropicActiveProvider_NilClient_FallsBackToPassive(t *testing.T) {
+	passive := &fakeClaudeProvider{pct: 20.0}
+	p := &anthropicActiveProvider{client: nil, passive: passive}
+
+	pct, err := p.GetUsedPercent("weekly", 1_000_000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pct != 20.0 {
+		t.Errorf("want 20.0, got %f", pct)
+	}
+}
+
+// --- copilot adapter ---
+
+func copilotTestServer(percentRemaining float64) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]interface{}{
+			"login":            "testuser",
+			"copilot_plan":     "copilot_enterprise",
+			"quota_reset_date": "2099-06-01",
+			"quota_snapshots": map[string]interface{}{
+				"premium_interactions": map[string]interface{}{
+					"entitlement":       300,
+					"remaining":         150,
+					"quota_remaining":   150.0,
+					"percent_remaining": percentRemaining,
+					"overage_count":     0,
+					"overage_permitted": false,
+					"unlimited":         false,
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+}
+
+func TestCopilotActiveProvider_APISuccess(t *testing.T) {
+	srv := copilotTestServer(40.0) // 40% remaining → 60% used
+	defer srv.Close()
+
+	passive := &fakeCopilotProvider{pct: 99.0}
+	ghExec := func(args ...string) ([]byte, error) {
+		return []byte("fake-gh-token\n"), nil
+	}
+	apiClient := newCopilotClientForTest(t, srv.URL, ghExec)
+	p := &copilotActiveProvider{client: apiClient, passive: passive}
+
+	pct, err := p.GetUsedPercent("weekly", 300)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pct != 60.0 {
+		t.Errorf("want 60.0, got %f", pct)
+	}
+	if p.LastUsedPercentSource() != "api" {
+		t.Errorf("want source=api, got %s", p.LastUsedPercentSource())
+	}
+}
+
+func TestCopilotActiveProvider_APIError_FallsBackToPassive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	passive := &fakeCopilotProvider{pct: 10.0}
+	ghExec := func(args ...string) ([]byte, error) {
+		return []byte("fake-gh-token\n"), nil
+	}
+	apiClient := newCopilotClientForTest(t, srv.URL, ghExec)
+	p := &copilotActiveProvider{client: apiClient, passive: passive}
+
+	pct, err := p.GetUsedPercent("weekly", 300)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pct != 10.0 {
+		t.Errorf("want 10.0 (passive fallback), got %f", pct)
+	}
+	if p.LastUsedPercentSource() != "file" {
+		t.Errorf("want source=file, got %s", p.LastUsedPercentSource())
+	}
+}
+
+// --- hybrid mode ---
+
+func TestHybridMode_MixedCredentials(t *testing.T) {
+	// Anthropic API succeeds; codex/copilot no credentials → passive used.
+	srv := anthropicTestServer(0.25)
+	defer srv.Close()
+
+	passiveClaude := &fakeClaudeProvider{pct: 99.0}
+	passiveCodex := &fakeCodexProvider{pct: 50.0}
+
+	apiClient := usage.NewAnthropicClient(
+		usage.WithBaseURL(srv.URL),
+		usage.WithHTTPClient(srv.Client()),
+		usage.WithCredentialStore(&staticCred{token: "test-token"}),
+	)
+	claudeP := &anthropicActiveProvider{client: apiClient, passive: passiveClaude}
+	codexP := &codexActiveProvider{client: nil, passive: passiveCodex}
+
+	cfg := makeConfig("hybrid")
+	mgr := NewManager(cfg, claudeP, codexP, nil)
+
+	pct, err := mgr.GetUsedPercent("claude")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pct != 25.0 {
+		t.Errorf("want 25.0 (api), got %f", pct)
+	}
+
+	pct, err = mgr.GetUsedPercent("codex")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pct != 50.0 {
+		t.Errorf("want 50.0 (passive), got %f", pct)
+	}
+}
+
+// --- thread safety ---
+
+func TestAnthropicActiveProvider_Concurrent(t *testing.T) {
+	srv := anthropicTestServer(0.5)
+	defer srv.Close()
+
+	passive := &fakeClaudeProvider{pct: 99.0}
+	apiClient := usage.NewAnthropicClient(
+		usage.WithBaseURL(srv.URL),
+		usage.WithHTTPClient(srv.Client()),
+		usage.WithCredentialStore(&staticCred{token: "test-token"}),
+	)
+	p := &anthropicActiveProvider{client: apiClient, passive: passive}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = p.GetUsedPercent("weekly", 1_000_000)
+			_ = p.LastUsedPercentSource()
+		}()
+	}
+	wg.Wait()
+}
+
+// --- helpers for tests ---
+
+// staticCred is a CredentialStore that always returns a fixed token.
+type staticCred struct{ token string }
+
+func (s *staticCred) ReadToken(_ context.Context) (string, error) { return s.token, nil }
+
+// newCopilotClientForTest creates a CopilotClient with a custom baseURL and ghExec.
+// Uses package-internal constructor via test helper exposed below.
+func newCopilotClientForTest(t *testing.T, baseURL string, ghExec func(...string) ([]byte, error)) *usage.CopilotClient {
+	t.Helper()
+	c, err := usage.NewCopilotClientWithBaseURL(baseURL, usage.WithCopilotGHExec(ghExec))
+	if err != nil {
+		t.Fatalf("NewCopilotClientWithBaseURL: %v", err)
+	}
+	return c
+}

--- a/internal/usage/copilot_client.go
+++ b/internal/usage/copilot_client.go
@@ -12,8 +12,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/marcus/nightshift/cmd/nightshift/commands"
 )
+
+// Version is injected by the caller at startup to populate User-Agent headers.
+// Defaults to "unknown" if not set.
+var Version = "unknown"
 
 const (
 	defaultCopilotAPIURL = "https://api.github.com/copilot_internal/user"
@@ -46,7 +49,7 @@ func NewCopilotClient() (*CopilotClient, error) {
 	c := &CopilotClient{
 		httpClient: &http.Client{Timeout: copilotTimeout},
 		baseURL:    defaultCopilotAPIURL,
-		userAgent:  "nightshift/" + commands.Version,
+		userAgent:  "nightshift/" + Version,
 		ghExec:     defaultGHExec,
 	}
 	token, err := c.discoverToken(context.Background())
@@ -62,7 +65,7 @@ func newCopilotClientWithExec(ghExec func(args ...string) ([]byte, error)) (*Cop
 	c := &CopilotClient{
 		httpClient: &http.Client{Timeout: copilotTimeout},
 		baseURL:    defaultCopilotAPIURL,
-		userAgent:  "nightshift/" + commands.Version,
+		userAgent:  "nightshift/" + Version,
 		ghExec:     ghExec,
 	}
 	token, err := c.discoverToken(context.Background())
@@ -73,13 +76,24 @@ func newCopilotClientWithExec(ghExec func(args ...string) ([]byte, error)) (*Cop
 	return c, nil
 }
 
+// CopilotOption configures a CopilotClient.
+type CopilotOption func(*CopilotClient)
+
+// WithCopilotGHExec overrides the gh executor (useful for tests).
+func WithCopilotGHExec(fn func(args ...string) ([]byte, error)) CopilotOption {
+	return func(c *CopilotClient) { c.ghExec = fn }
+}
+
 // NewCopilotClientWithBaseURL constructs a client with a custom API base URL (useful for GitHub Enterprise or tests).
-func NewCopilotClientWithBaseURL(baseURL string) (*CopilotClient, error) {
+func NewCopilotClientWithBaseURL(baseURL string, opts ...CopilotOption) (*CopilotClient, error) {
 	c := &CopilotClient{
 		httpClient: &http.Client{Timeout: copilotTimeout},
 		baseURL:    baseURL,
-		userAgent:  "nightshift/" + commands.Version,
+		userAgent:  "nightshift/" + Version,
 		ghExec:     defaultGHExec,
+	}
+	for _, opt := range opts {
+		opt(c)
 	}
 	token, err := c.discoverToken(context.Background())
 	if err != nil {


### PR DESCRIPTION
## VC-33 — Active Budget Manager (API-first + fallback)

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-33

### Description

Summary
Create a new budget manager that wraps the existing passive budget system and optionally routes through the active API clients. Respects the tracking config: passive uses existing code, active uses API clients, hybrid uses API where credentials exist and falls back to file parsing.
Reference
Epic: VC-29 (Active Token Budget Tracking)
onWatch — reference implementation; see how their polling loop calls FetchQuotas/FetchUsage per provider and normalizes into snapshots
onWatch client.go — generic client pattern with FetchQuotas interface
Design
Interface
// UsageProvider abstracts usage fetching for a single provider.
type UsageProvider interface {
    Name() string
    FetchUsage(ctx context.Context) (*ProviderUsage, error)
    Available() bool  // whether credentials/config exist for this provider
}

// ProviderUsage is the unified usage data from any provider.
type ProviderUsage struct {
    Provider       string
    Quotas         []Quota           // utilization per window (5h, weekly, monthly)
    Credits        *float64          // cost/credits balance if available
    ResetTime      *time.Time
    Source         string            // "api", "file", "tmux"
    FetchedAt      time.Time
}
ActiveBudgetManager
type ActiveBudgetManager struct {
    config       *config.BudgetConfig
    anthropic    UsageProvider  // API client or nil
    codex        UsageProvider  // API client or nil
    copilot      UsageProvider  // API client or nil
    passive      *budget.Budget // existing passive fallback
}
Fallback Chain
For each provider:
If tracking=active|hybrid AND API credentials available → call API
If API fails or tracking=hybrid AND no API creds → fall back to file parsing
If file parsing fails → return zero usage (safe: allows runs, logs warning)
Integration Points
internal/orchestrator/orchestrator.go — uses budget check before spawning agents
cmd/nightshift/commands/run.go — pre-run budget verification
cmd/nightshift/commands/budget.go — display budget info
Implementation
New file: internal/budget/active.go
ActiveBudgetManager struct
Constructor that reads config and initializes providers
GetUsage(ctx, provider) → tries API, falls back to passive
CanRun(ctx, provider, estimatedTokens) → budget-aware run gating
Modify: internal/budget/budget.go
Add UsageProvider interface
Wrap existing passive functions to implement the interface
Acceptance Criteria
[ ] ActiveBudgetManager created and initialized from config
[ ] tracking=passive → all calls routed to existing budget.Budget (zero behavior change)
[ ] tracking=active → API calls made; file fallback on API error
[ ] tracking=hybrid → API for providers with creds, passive for others
[ ] Graceful degradation: API timeout/error → fallback → zero (never crash)
[ ] ProviderUsage struct captures both quota utilization AND cost data
[ ] Thread-safe (budget checked from multiple goroutines during parallel runs)
[ ] Logging: which source was used for each provider (api/file/tmux)
[ ] Tests cover all 3 modes + fallback scenarios
[ ] make test passes, make build succeeds
Agent Workflow
Branch from main → feat/active-budget-manager
Implement internal/budget/active.go
Wire into existing budget flow
Write tests
Run make test && make build
Create PR targeting main

### Acceptance Criteria

[ ] ActiveBudgetManager created and initialized from config
[ ] tracking=passive → all calls routed to existing budget.Budget (zero behavior change)
[ ] tracking=active → API calls made; file fallback on API error
[ ] tracking=hybrid → API for providers with creds, passive for others
[ ] Graceful degradation: API timeout/error → fallback → zero (never crash)
[ ] ProviderUsage struct captures both quota utilization AND cost data
[ ] Thread-safe (budget checked from multiple goroutines during parallel runs)
[ ] Logging: which source was used for each provider (api/file/tmux)
[ ] Tests cover all 3 modes + fallback scenarios
[ ] make test passes, make build succeeds
Agent Workflow
Branch from main → feat/active-budget-manager
Implement internal/budget/active.go
Wire into existing budget flow
Write tests
Run make test && make build
Create PR targeting main

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
