### PR TITLE
[VC-35] Cost Tracking & Reporting

### DIFF
--- a/cmd/nightshift/commands/run_reporting.go
+++ b/cmd/nightshift/commands/run_reporting.go
@@ -1,12 +1,14 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"time"
 
 	"github.com/marcus/nightshift/internal/budget"
 	"github.com/marcus/nightshift/internal/config"
+	"github.com/marcus/nightshift/internal/db"
 	"github.com/marcus/nightshift/internal/logging"
 	"github.com/marcus/nightshift/internal/reporting"
 )
@@ -35,6 +37,10 @@ func (r *runReport) addTask(task reporting.TaskResult) {
 }
 
 func (r *runReport) finalize(cfg *config.Config, log *logging.Logger) {
+	r.finalizeWithDB(cfg, log, nil)
+}
+
+func (r *runReport) finalizeWithDB(cfg *config.Config, log *logging.Logger, database *db.DB) {
 	if r == nil || r.results == nil || cfg == nil {
 		return
 	}
@@ -52,8 +58,26 @@ func (r *runReport) finalize(cfg *config.Config, log *logging.Logger) {
 	}
 	r.results.LogPath = logPath
 
+	// Fetch cost snapshots for active/hybrid tracking modes.
+	if cfg.Budget.Tracking != "" && cfg.Budget.Tracking != "passive" {
+		ctx := context.Background()
+		snapshots := budget.FetchAllCostSnapshots(ctx)
+		r.results.CostSnapshots = snapshots
+		// Persist for yesterday-delta in future summaries.
+		if database != nil {
+			for i := range snapshots {
+				if err := database.SaveCostSnapshot(ctx, &snapshots[i]); err != nil {
+					log.Warnf("cost snapshot save (%s): %v", snapshots[i].Provider, err)
+				}
+			}
+		}
+	}
+
 	if cfg.Reporting.MorningSummary {
 		gen := reporting.NewGenerator(cfg)
+		if database != nil {
+			gen = gen.WithCostHistory(database)
+		}
 		summary, err := gen.Generate(r.results)
 		if err != nil {
 			log.Warnf("summary generate: %v", err)

--- a/internal/budget/active.go
+++ b/internal/budget/active.go
@@ -438,3 +438,44 @@ func FetchProviderUsage(ctx context.Context, provider string) ProviderUsage {
 	}
 	return ProviderUsage{Provider: provider, Source: "none", FetchedAt: now}
 }
+
+// FetchAllCostSnapshots fetches cost snapshots from all three providers.
+// Results for providers that fail or have no cost data are silently omitted.
+// Never returns an error — failures are degraded gracefully.
+func FetchAllCostSnapshots(ctx context.Context) []usage.CostSnapshot {
+	var out []usage.CostSnapshot
+
+	// Anthropic
+	anthropicClient := usage.NewAnthropicClient()
+	if resp, err := anthropicClient.FetchQuotas(ctx); err == nil {
+		if snap := usage.ExtractAnthropicCost(resp); snap != nil {
+			out = append(out, *snap)
+		}
+	} else {
+		log.Debug().Err(err).Str("provider", "anthropic").Msg("cost: fetch failed")
+	}
+
+	// Codex
+	if codexClient, err := usage.NewCodexClient(""); err == nil {
+		if resp, err := codexClient.FetchUsage(ctx); err == nil {
+			if snap := usage.ExtractCodexCost(resp); snap != nil {
+				out = append(out, *snap)
+			}
+		} else {
+			log.Debug().Err(err).Str("provider", "codex").Msg("cost: fetch failed")
+		}
+	}
+
+	// Copilot
+	if copilotClient, err := usage.NewCopilotClient(); err == nil {
+		if resp, err := copilotClient.FetchQuotas(ctx); err == nil {
+			if snap := usage.ExtractCopilotCost(resp); snap != nil {
+				out = append(out, *snap)
+			}
+		} else {
+			log.Debug().Err(err).Str("provider", "copilot").Msg("cost: fetch failed")
+		}
+	}
+
+	return out
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/marcus/nightshift/internal/usage"
 	_ "modernc.org/sqlite"
 )
 
@@ -326,6 +327,97 @@ func (d *DB) GetJiraRun(ctx context.Context, runID string) (*JiraRun, error) {
 		}
 	}
 	return &r, nil
+}
+
+// --- Cost snapshots ---
+
+// SaveCostSnapshot inserts a cost_snapshots row.
+func (d *DB) SaveCostSnapshot(ctx context.Context, s *usage.CostSnapshot) error {
+	if d == nil || d.sql == nil {
+		return fmt.Errorf("db not open")
+	}
+	if s == nil {
+		return fmt.Errorf("snapshot is nil")
+	}
+	_, err := d.sql.ExecContext(ctx,
+		`INSERT INTO cost_snapshots (provider, total_budget, used, remaining, overage, currency, period, captured_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.Provider,
+		nullableFloat64(s.TotalBudget),
+		nullableFloat64(s.Used),
+		nullableFloat64(s.Remaining),
+		s.OverageCount,
+		s.Currency,
+		s.Period,
+		s.CapturedAt.UTC().Format(time.RFC3339),
+	)
+	return err
+}
+
+// GetLatestCostSnapshot returns the most recent cost_snapshots row for the given provider.
+// Returns (nil, nil) when no rows exist.
+func (d *DB) GetLatestCostSnapshot(ctx context.Context, provider string) (*usage.CostSnapshot, error) {
+	if d == nil || d.sql == nil {
+		return nil, fmt.Errorf("db not open")
+	}
+	row := d.sql.QueryRowContext(ctx,
+		`SELECT provider, total_budget, used, remaining, overage, currency, period, captured_at
+		 FROM cost_snapshots WHERE provider=? ORDER BY captured_at DESC LIMIT 1`,
+		provider,
+	)
+	return scanCostSnapshot(row)
+}
+
+// GetYesterdayCostSnapshot returns the most recent cost_snapshots row for the given provider
+// that was captured before today (UTC midnight).
+func (d *DB) GetYesterdayCostSnapshot(ctx context.Context, provider string) (*usage.CostSnapshot, error) {
+	if d == nil || d.sql == nil {
+		return nil, fmt.Errorf("db not open")
+	}
+	today := time.Now().UTC().Format("2006-01-02")
+	row := d.sql.QueryRowContext(ctx,
+		`SELECT provider, total_budget, used, remaining, overage, currency, period, captured_at
+		 FROM cost_snapshots WHERE provider=? AND date(captured_at) < ? ORDER BY captured_at DESC LIMIT 1`,
+		provider, today,
+	)
+	return scanCostSnapshot(row)
+}
+
+func scanCostSnapshot(row *sql.Row) (*usage.CostSnapshot, error) {
+	var s usage.CostSnapshot
+	var totalBudget, used, remaining sql.NullFloat64
+	var capturedAtStr string
+	err := row.Scan(&s.Provider, &totalBudget, &used, &remaining,
+		&s.OverageCount, &s.Currency, &s.Period, &capturedAtStr)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if totalBudget.Valid {
+		v := totalBudget.Float64
+		s.TotalBudget = &v
+	}
+	if used.Valid {
+		v := used.Float64
+		s.Used = &v
+	}
+	if remaining.Valid {
+		v := remaining.Float64
+		s.Remaining = &v
+	}
+	if t, err := time.Parse(time.RFC3339, capturedAtStr); err == nil {
+		s.CapturedAt = t
+	}
+	return &s, nil
+}
+
+func nullableFloat64(v *float64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
 }
 
 // nullableString returns nil for empty strings so they become SQL NULL.

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -45,6 +45,11 @@ var migrations = []Migration{
 		Description: "add jira run history tables: jira_runs, jira_ticket_results, jira_phase_logs",
 		SQL:         migration006SQL,
 	},
+	{
+		Version:     7,
+		Description: "add cost_snapshots table for monetary cost tracking",
+		SQL:         migration007SQL,
+	},
 }
 
 const migration002SQL = `
@@ -164,6 +169,22 @@ CREATE TABLE IF NOT EXISTS jira_phase_logs (
 
 CREATE INDEX IF NOT EXISTS idx_jira_phase_logs_run_ticket ON jira_phase_logs(run_id, ticket_key);
 CREATE INDEX IF NOT EXISTS idx_jira_ticket_results_run ON jira_ticket_results(run_id);
+`
+
+const migration007SQL = `
+CREATE TABLE IF NOT EXISTS cost_snapshots (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider     TEXT    NOT NULL,
+    total_budget REAL,
+    used         REAL,
+    remaining    REAL,
+    overage      INTEGER NOT NULL DEFAULT 0,
+    currency     TEXT    NOT NULL DEFAULT 'USD',
+    period       TEXT    NOT NULL DEFAULT 'monthly',
+    captured_at  DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cost_snapshots_provider_time
+    ON cost_snapshots(provider, captured_at DESC);
 `
 
 // Migrate runs all pending migrations inside transactions.

--- a/internal/reporting/run_report.go
+++ b/internal/reporting/run_report.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/marcus/nightshift/internal/usage"
 )
 
 // DefaultRunReportPath returns the default path for a run report file.
@@ -53,6 +55,10 @@ func RenderRunReport(results *RunResults, logPath string) (string, error) {
 	}
 	buf.WriteString("\n")
 
+	if len(results.CostSnapshots) > 0 {
+		renderCostSection(&buf, results.CostSnapshots)
+	}
+
 	writeTaskSection(&buf, "Tasks Completed", completed, "")
 	writeTaskSection(&buf, "Tasks Failed", failed, "")
 	writeTaskSection(&buf, "Tasks Skipped", skipped, "Skip reason: ")
@@ -73,6 +79,47 @@ func SaveRunReport(results *RunResults, path string, logPath string) error {
 		return fmt.Errorf("writing report: %w", err)
 	}
 	return nil
+}
+
+// renderCostSection writes a markdown Cost Summary table to buf.
+func renderCostSection(buf *bytes.Buffer, snapshots []usage.CostSnapshot) {
+	buf.WriteString("## Cost Summary\n")
+	buf.WriteString("| Provider | Used | Remaining | Budget |\n")
+	buf.WriteString("|----------|------|-----------|--------|\n")
+	for _, s := range snapshots {
+		usedStr, remStr, budgetStr := "-", "-", "-"
+		switch s.Provider {
+		case "anthropic":
+			if s.Used != nil {
+				usedStr = fmt.Sprintf("$%.2f", *s.Used)
+			}
+			if s.Remaining != nil {
+				remStr = fmt.Sprintf("$%.2f", *s.Remaining)
+			}
+			if s.TotalBudget != nil {
+				budgetStr = fmt.Sprintf("$%.2f/mo", *s.TotalBudget)
+			}
+		case "codex":
+			if s.Remaining != nil {
+				remStr = fmt.Sprintf("$%.2f", *s.Remaining)
+			}
+			budgetStr = "credits"
+		case "copilot":
+			if s.OverageCount > 0 {
+				usedStr = fmt.Sprintf("%d overage", s.OverageCount)
+			} else {
+				usedStr = "0 overage"
+			}
+			if s.Remaining != nil {
+				remStr = fmt.Sprintf("%.0f left", *s.Remaining)
+			}
+			if s.TotalBudget != nil {
+				budgetStr = fmt.Sprintf("%.0f/mo", *s.TotalBudget)
+			}
+		}
+		fmt.Fprintf(buf, "| %s | %s | %s | %s |\n", s.Provider, usedStr, remStr, budgetStr)
+	}
+	buf.WriteString("\n")
 }
 
 func writeTaskSection(buf *bytes.Buffer, title string, tasks []TaskResult, reasonPrefix string) {

--- a/internal/reporting/summary.go
+++ b/internal/reporting/summary.go
@@ -4,6 +4,7 @@ package reporting
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/marcus/nightshift/internal/config"
 	"github.com/marcus/nightshift/internal/logging"
+	"github.com/marcus/nightshift/internal/usage"
 )
 
 // TaskResult represents a completed or skipped task in the run.
@@ -33,14 +35,15 @@ type TaskResult struct {
 
 // RunResults holds all results from a nightshift run.
 type RunResults struct {
-	Date            time.Time    `json:"date"`
-	StartBudget     int          `json:"start_budget"`
-	UsedBudget      int          `json:"used_budget"`
-	RemainingBudget int          `json:"remaining_budget"`
-	Tasks           []TaskResult `json:"tasks"`
-	StartTime       time.Time    `json:"start_time"`
-	EndTime         time.Time    `json:"end_time"`
-	LogPath         string       `json:"log_path,omitempty"`
+	Date            time.Time             `json:"date"`
+	StartBudget     int                   `json:"start_budget"`
+	UsedBudget      int                   `json:"used_budget"`
+	RemainingBudget int                   `json:"remaining_budget"`
+	Tasks           []TaskResult          `json:"tasks"`
+	StartTime       time.Time             `json:"start_time"`
+	EndTime         time.Time             `json:"end_time"`
+	LogPath         string                `json:"log_path,omitempty"`
+	CostSnapshots   []usage.CostSnapshot  `json:"cost_snapshots,omitempty"`
 }
 
 // Summary represents a generated morning summary.
@@ -54,12 +57,19 @@ type Summary struct {
 	BudgetStart     int
 	BudgetUsed      int
 	BudgetRemaining int
+	CostSnapshots   []usage.CostSnapshot
+}
+
+// CostSnapshotProvider retrieves cost snapshots from persistent storage for delta calculations.
+type CostSnapshotProvider interface {
+	GetYesterdayCostSnapshot(ctx context.Context, provider string) (*usage.CostSnapshot, error)
 }
 
 // Generator creates morning summary reports.
 type Generator struct {
-	cfg    *config.Config
-	logger *logging.Logger
+	cfg         *config.Config
+	logger      *logging.Logger
+	costHistory CostSnapshotProvider // optional; enables yesterday deltas in cost section
 }
 
 // NewGenerator creates a summary generator with the given configuration.
@@ -68,6 +78,12 @@ func NewGenerator(cfg *config.Config) *Generator {
 		cfg:    cfg,
 		logger: logging.Component("reporting"),
 	}
+}
+
+// WithCostHistory attaches a CostSnapshotProvider for yesterday-delta calculations.
+func (g *Generator) WithCostHistory(p CostSnapshotProvider) *Generator {
+	g.costHistory = p
+	return g
 }
 
 // Generate creates a summary from run results.
@@ -85,6 +101,7 @@ func (g *Generator) Generate(results *RunResults) (*Summary, error) {
 		CompletedTasks:  make([]TaskResult, 0),
 		SkippedTasks:    make([]TaskResult, 0),
 		FailedTasks:     make([]TaskResult, 0),
+		CostSnapshots:   results.CostSnapshots,
 	}
 
 	// Categorize tasks and count by project
@@ -122,6 +139,11 @@ func (g *Generator) renderMarkdown(summary *Summary, results *RunResults) string
 	fmt.Fprintf(&buf, "- Started with: %s tokens\n", formatTokens(summary.BudgetStart))
 	fmt.Fprintf(&buf, "- Used: %s tokens (%d%%)\n", formatTokens(summary.BudgetUsed), usedPercent)
 	fmt.Fprintf(&buf, "- Remaining: %s tokens\n\n", formatTokens(summary.BudgetRemaining))
+
+	// Cost section — only rendered when snapshots present
+	if len(summary.CostSnapshots) > 0 {
+		g.renderCostSection(&buf, summary.CostSnapshots)
+	}
 
 	// Projects processed section
 	if len(summary.ProjectCounts) > 0 {
@@ -198,6 +220,61 @@ func (g *Generator) renderMarkdown(summary *Summary, results *RunResults) string
 	}
 
 	return buf.String()
+}
+
+// renderCostSection writes a markdown Cost Summary table to buf.
+func (g *Generator) renderCostSection(buf *bytes.Buffer, snapshots []usage.CostSnapshot) {
+	buf.WriteString("## Cost Summary\n")
+	buf.WriteString("| Provider | Used | Remaining | Budget |\n")
+	buf.WriteString("|----------|------|-----------|--------|\n")
+
+	for _, s := range snapshots {
+		usedStr := "-"
+		remStr := "-"
+		budgetStr := "-"
+
+		switch s.Provider {
+		case "anthropic":
+			if s.Used != nil {
+				usedStr = fmt.Sprintf("$%.2f", *s.Used)
+			}
+			if s.Remaining != nil {
+				remStr = fmt.Sprintf("$%.2f", *s.Remaining)
+			}
+			if s.TotalBudget != nil {
+				budgetStr = fmt.Sprintf("$%.2f/mo", *s.TotalBudget)
+			}
+			// fetch yesterday delta when history provider available
+			if g.costHistory != nil && s.Used != nil {
+				if prev, err := g.costHistory.GetYesterdayCostSnapshot(context.Background(), s.Provider); err == nil && prev != nil && prev.Used != nil {
+					delta := *s.Used - *prev.Used
+					if delta >= 0 {
+						usedStr = fmt.Sprintf("$%.2f (+$%.2f today)", *s.Used, delta)
+					}
+				}
+			}
+		case "codex":
+			if s.Remaining != nil {
+				remStr = fmt.Sprintf("$%.2f", *s.Remaining)
+			}
+			budgetStr = "credits"
+		case "copilot":
+			if s.OverageCount > 0 {
+				usedStr = fmt.Sprintf("%d overage", s.OverageCount)
+			} else {
+				usedStr = "0 overage"
+			}
+			if s.Remaining != nil {
+				remStr = fmt.Sprintf("%.0f left", *s.Remaining)
+			}
+			if s.TotalBudget != nil {
+				budgetStr = fmt.Sprintf("%.0f/mo", *s.TotalBudget)
+			}
+		}
+
+		fmt.Fprintf(buf, "| %s | %s | %s | %s |\n", s.Provider, usedStr, remStr, budgetStr)
+	}
+	buf.WriteString("\n")
 }
 
 // formatTaskLine formats a single completed task as a markdown line.

--- a/internal/usage/costs.go
+++ b/internal/usage/costs.go
@@ -1,0 +1,88 @@
+package usage
+
+import "time"
+
+// CostSnapshot holds monetary cost data captured from a provider API at a point in time.
+type CostSnapshot struct {
+	Provider     string
+	TotalBudget  *float64  // monthly limit (Anthropic) or nil
+	Used         *float64  // credits consumed (Anthropic used_credits)
+	Remaining    *float64  // credits remaining (Codex credits.balance)
+	OverageCount int       // Copilot overage_count
+	Currency     string    // "USD" or "credits"
+	Period       string    // "monthly", "balance"
+	CapturedAt   time.Time
+}
+
+// ExtractAnthropicCost pulls cost data from an Anthropic quota response.
+// Returns nil if no monthly_limit entry or no credit data is present.
+func ExtractAnthropicCost(resp AnthropicQuotaResponse) *CostSnapshot {
+	entry, ok := resp["monthly_limit"]
+	if !ok {
+		return nil
+	}
+	if entry.MonthlyLimit == nil && entry.UsedCredits == nil {
+		return nil
+	}
+
+	snap := &CostSnapshot{
+		Provider:   "anthropic",
+		Currency:   "USD",
+		Period:     "monthly",
+		CapturedAt: time.Now(),
+	}
+	if entry.MonthlyLimit != nil {
+		v := float64(*entry.MonthlyLimit) / 100 // cents → dollars
+		snap.TotalBudget = &v
+	}
+	if entry.UsedCredits != nil {
+		snap.Used = entry.UsedCredits
+		if snap.TotalBudget != nil {
+			rem := *snap.TotalBudget - *snap.Used
+			snap.Remaining = &rem
+		}
+	}
+	return snap
+}
+
+// ExtractCodexCost pulls cost data from a Codex usage response.
+// Returns nil if resp is nil or Credits is nil.
+func ExtractCodexCost(resp *CodexUsageResponse) *CostSnapshot {
+	if resp == nil || resp.Credits == nil {
+		return nil
+	}
+	bal := resp.Credits.Balance
+	return &CostSnapshot{
+		Provider:   "codex",
+		Remaining:  &bal,
+		Currency:   "credits",
+		Period:     "balance",
+		CapturedAt: time.Now(),
+	}
+}
+
+// ExtractCopilotCost pulls cost data from a Copilot user response.
+// Returns nil if resp is nil or no premium_interactions quota exists.
+func ExtractCopilotCost(resp *CopilotUserResponse) *CostSnapshot {
+	if resp == nil {
+		return nil
+	}
+	snap, ok := resp.Quotas["premium_interactions"]
+	if !ok {
+		return nil
+	}
+	entitlement := snap.Entitlement
+	remaining := snap.Remaining
+	entF := float64(entitlement)
+	remF := float64(remaining)
+	s := &CostSnapshot{
+		Provider:     "copilot",
+		TotalBudget:  &entF,
+		Remaining:    &remF,
+		OverageCount: snap.OverageCount,
+		Currency:     "requests",
+		Period:       "monthly",
+		CapturedAt:   time.Now(),
+	}
+	return s
+}

--- a/internal/usage/costs_test.go
+++ b/internal/usage/costs_test.go
@@ -1,0 +1,221 @@
+package usage
+
+import (
+	"testing"
+	"time"
+)
+
+func ptr64(v float64) *float64 { return &v }
+func ptrI64(v int64) *int64    { return &v }
+
+func TestExtractAnthropicCost(t *testing.T) {
+	tests := []struct {
+		name         string
+		resp         AnthropicQuotaResponse
+		wantNil      bool
+		wantTotal    *float64
+		wantUsed     *float64
+		wantRem      *float64
+	}{
+		{
+			name:    "empty response",
+			resp:    AnthropicQuotaResponse{},
+			wantNil: true,
+		},
+		{
+			name: "no monthly_limit key",
+			resp: AnthropicQuotaResponse{
+				"five_hour": {Utilization: 0.5, ResetsAt: time.Now()},
+			},
+			wantNil: true,
+		},
+		{
+			name: "monthly_limit present but nil fields",
+			resp: AnthropicQuotaResponse{
+				"monthly_limit": {IsEnabled: true},
+			},
+			wantNil: true,
+		},
+		{
+			name: "monthly_limit with used_credits only",
+			resp: AnthropicQuotaResponse{
+				"monthly_limit": {
+					IsEnabled:   true,
+					UsedCredits: ptr64(12.40),
+				},
+			},
+			wantNil:  false,
+			wantUsed: ptr64(12.40),
+		},
+		{
+			name: "monthly_limit with both fields",
+			resp: AnthropicQuotaResponse{
+				"monthly_limit": {
+					IsEnabled:    true,
+					MonthlyLimit: ptrI64(5000), // 5000 cents = $50.00
+					UsedCredits:  ptr64(12.40),
+				},
+			},
+			wantNil:   false,
+			wantTotal: ptr64(50.00),
+			wantUsed:  ptr64(12.40),
+			wantRem:   ptr64(37.60),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractAnthropicCost(tt.resp)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil")
+			}
+			if got.Provider != "anthropic" {
+				t.Errorf("provider = %q, want %q", got.Provider, "anthropic")
+			}
+			if got.Currency != "USD" {
+				t.Errorf("currency = %q, want USD", got.Currency)
+			}
+			cmpOptF64(t, "TotalBudget", got.TotalBudget, tt.wantTotal)
+			cmpOptF64(t, "Used", got.Used, tt.wantUsed)
+			cmpOptF64(t, "Remaining", got.Remaining, tt.wantRem)
+		})
+	}
+}
+
+func TestExtractCodexCost(t *testing.T) {
+	tests := []struct {
+		name    string
+		resp    *CodexUsageResponse
+		wantNil bool
+		wantBal float64
+	}{
+		{name: "nil resp", resp: nil, wantNil: true},
+		{name: "nil credits", resp: &CodexUsageResponse{}, wantNil: true},
+		{
+			name:    "credits present",
+			resp:    &CodexUsageResponse{Credits: &CodexCredits{Balance: 8.20}},
+			wantBal: 8.20,
+		},
+		{
+			name:    "zero balance",
+			resp:    &CodexUsageResponse{Credits: &CodexCredits{Balance: 0}},
+			wantBal: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractCodexCost(tt.resp)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil")
+			}
+			if got.Provider != "codex" {
+				t.Errorf("provider = %q, want codex", got.Provider)
+			}
+			if got.Remaining == nil {
+				t.Fatal("Remaining is nil")
+			}
+			if *got.Remaining != tt.wantBal {
+				t.Errorf("Remaining = %v, want %v", *got.Remaining, tt.wantBal)
+			}
+		})
+	}
+}
+
+func TestExtractCopilotCost(t *testing.T) {
+	tests := []struct {
+		name         string
+		resp         *CopilotUserResponse
+		wantNil      bool
+		wantOverage  int
+		wantRem      float64
+	}{
+		{name: "nil resp", resp: nil, wantNil: true},
+		{name: "no quotas", resp: &CopilotUserResponse{Quotas: CopilotQuotaMap{}}, wantNil: true},
+		{
+			name: "premium_interactions present",
+			resp: &CopilotUserResponse{
+				Quotas: CopilotQuotaMap{
+					"premium_interactions": {
+						Entitlement:  80,
+						Remaining:    12,
+						OverageCount: 3,
+					},
+				},
+			},
+			wantOverage: 3,
+			wantRem:     12,
+		},
+		{
+			name: "no overage",
+			resp: &CopilotUserResponse{
+				Quotas: CopilotQuotaMap{
+					"premium_interactions": {
+						Entitlement:  80,
+						Remaining:    80,
+						OverageCount: 0,
+					},
+				},
+			},
+			wantOverage: 0,
+			wantRem:     80,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractCopilotCost(tt.resp)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil")
+			}
+			if got.Provider != "copilot" {
+				t.Errorf("provider = %q, want copilot", got.Provider)
+			}
+			if got.OverageCount != tt.wantOverage {
+				t.Errorf("OverageCount = %d, want %d", got.OverageCount, tt.wantOverage)
+			}
+			if got.Remaining == nil {
+				t.Fatal("Remaining is nil")
+			}
+			if *got.Remaining != tt.wantRem {
+				t.Errorf("Remaining = %v, want %v", *got.Remaining, tt.wantRem)
+			}
+		})
+	}
+}
+
+func cmpOptF64(t *testing.T, field string, got, want *float64) {
+	t.Helper()
+	if want == nil && got == nil {
+		return
+	}
+	if want == nil {
+		t.Errorf("%s: got %v, want nil", field, *got)
+		return
+	}
+	if got == nil {
+		t.Errorf("%s: got nil, want %v", field, *want)
+		return
+	}
+	if *got != *want {
+		t.Errorf("%s = %v, want %v", field, *got, *want)
+	}
+}


### PR DESCRIPTION
## VC-35 — Cost Tracking & Reporting

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-35

### Description

Summary
Track actual monetary costs from provider APIs and surface them in run reports and daily summaries. Anthropic exposes monthly_limit and used_credits, Codex exposes credits.balance, Copilot tracks premium request overages.
Reference
Epic: VC-29 (Active Token Budget Tracking)
onWatch — reference implementation for cost/credit data extraction
onWatch anthropic_types.go — MonthlyLimit/UsedCredits fields in AnthropicQuotaEntry
onWatch codex_types.go — Credits.Balance field, CreditsBalance in snapshot
onWatch copilot_types.go — OverageCount field in CopilotQuotaSnapshot
Data Sources
ProviderCost DataFromAnthropicmonthly_limit, used_credits (in monthly_limit quota)APICodexcredits.balance (remaining credits)APICopilotoverage_count × overage rateAPIImplementation
New Types
type CostSnapshot struct {
    Provider     string
    TotalBudget  *float64  // monthly limit or total credits
    Used         *float64  // credits consumed
    Remaining    *float64  // credits remaining
    Currency     string    // "USD" or "credits"
    Period       string    // "monthly", "balance"
    CapturedAt   time.Time
}
Integration
internal/usage/costs.go — extract cost data from API responses
internal/reporting/run_report.go — add cost section to run reports
internal/reporting/summary.go — add daily cost summary
internal/db/migrations.go — new cost_snapshots table (optional)
Report Output
## Cost Summary
| Provider  | Used      | Remaining | Budget    |
|-----------|-----------|-----------|-----------|
| Anthropic | $12.40    | $37.60    | $50.00/mo |
| Codex     | -         | $8.20     | credits   |
| Copilot   | 0 overage | 12 left   | 80/mo     |
Acceptance Criteria
[ ] Cost data extracted from Anthropic (monthly_limit/used_credits) and Codex (credits balance) API responses
[ ] Copilot overage counts tracked
[ ] Run reports include cost section when cost data available
[ ] Daily summaries include cost trends (delta from yesterday)
[ ] Cost data stored in DB for historical tracking
[ ] No cost section shown when tracking=passive (graceful)
[ ] make test passes, make build succeeds
Agent Workflow
Branch from main → feat/cost-tracking
Implement cost extraction and reporting
Write tests
Run make test && make build
Create PR targeting main

### Acceptance Criteria

[ ] Cost data extracted from Anthropic (monthly_limit/used_credits) and Codex (credits balance) API responses
[ ] Copilot overage counts tracked
[ ] Run reports include cost section when cost data available
[ ] Daily summaries include cost trends (delta from yesterday)
[ ] Cost data stored in DB for historical tracking
[ ] No cost section shown when tracking=passive (graceful)
[ ] make test passes, make build succeeds
Agent Workflow
Branch from main → feat/cost-tracking
Implement cost extraction and reporting
Write tests
Run make test && make build
Create PR targeting main

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
