### PR TITLE
[VC-36] Snapshot Collector: API-based collection

### DIFF
--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -45,7 +45,16 @@ var migrations = []Migration{
 		Description: "add jira run history tables: jira_runs, jira_ticket_results, jira_phase_logs",
 		SQL:         migration006SQL,
 	},
+	{
+		Version:     7,
+		Description: "add source column to snapshots",
+		SQL:         migration007SQL,
+	},
 }
+
+const migration007SQL = `
+ALTER TABLE snapshots ADD COLUMN source TEXT NOT NULL DEFAULT 'file';
+`
 
 const migration002SQL = `
 ALTER TABLE snapshots ADD COLUMN session_reset_time TEXT;

--- a/internal/snapshots/collector.go
+++ b/internal/snapshots/collector.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/marcus/nightshift/internal/db"
 	"github.com/marcus/nightshift/internal/tmux"
+	"github.com/marcus/nightshift/internal/usage"
 )
 
 // UsageScraper defines tmux usage scraping behavior.
@@ -38,6 +39,21 @@ type CopilotUsage interface {
 	GetWeeklyTokens() (int64, error)
 }
 
+// AnthropicAPIClient fetches usage quotas from the Anthropic API.
+type AnthropicAPIClient interface {
+	FetchQuotas(ctx context.Context) (usage.AnthropicQuotaResponse, error)
+}
+
+// CodexAPIClient fetches usage data from the Codex/OpenAI API.
+type CodexAPIClient interface {
+	FetchUsage(ctx context.Context) (*usage.CodexUsageResponse, error)
+}
+
+// CopilotAPIClient fetches quota data from the GitHub Copilot API.
+type CopilotAPIClient interface {
+	FetchQuotas(ctx context.Context) (*usage.CopilotUserResponse, error)
+}
+
 // Snapshot represents a stored usage snapshot.
 type Snapshot struct {
 	ID               int64
@@ -54,6 +70,7 @@ type Snapshot struct {
 	Year             int
 	SessionResetTime string // scraped reset time for current session/5h window
 	WeeklyResetTime  string // scraped reset time for weekly window
+	Source           string // "api", "file", or "tmux"
 	ScrapeErr        error  `json:"-"` // not persisted; for CLI diagnostics
 }
 
@@ -71,12 +88,38 @@ type Collector struct {
 	copilot      CopilotUsage
 	scraper      UsageScraper
 	weekStartDay time.Weekday
+	trackingMode string // "passive" | "active" | "hybrid"
+	anthropicAPI AnthropicAPIClient
+	codexAPI     CodexAPIClient
+	copilotAPI   CopilotAPIClient
 }
 
-// NewCollector creates a snapshot collector.
+// NewCollector creates a snapshot collector in passive mode (existing behavior).
 func NewCollector(database *db.DB, claude ClaudeUsage, codex CodexUsage, copilot CopilotUsage, scraper UsageScraper, weekStartDay time.Weekday) *Collector {
+	return NewCollectorWithAPIs(database, claude, codex, copilot, scraper, weekStartDay, "passive", nil, nil, nil)
+}
+
+// NewCollectorWithAPIs creates a snapshot collector with optional API clients.
+// trackingMode must be "passive", "active", or "hybrid".
+func NewCollectorWithAPIs(
+	database *db.DB,
+	claude ClaudeUsage,
+	codex CodexUsage,
+	copilot CopilotUsage,
+	scraper UsageScraper,
+	weekStartDay time.Weekday,
+	trackingMode string,
+	anthropicAPI AnthropicAPIClient,
+	codexAPI CodexAPIClient,
+	copilotAPI CopilotAPIClient,
+) *Collector {
 	if weekStartDay < time.Sunday || weekStartDay > time.Saturday {
 		weekStartDay = time.Monday
+	}
+	switch trackingMode {
+	case "active", "hybrid":
+	default:
+		trackingMode = "passive"
 	}
 	return &Collector{
 		db:           database,
@@ -85,6 +128,10 @@ func NewCollector(database *db.DB, claude ClaudeUsage, codex CodexUsage, copilot
 		copilot:      copilot,
 		scraper:      scraper,
 		weekStartDay: weekStartDay,
+		trackingMode: trackingMode,
+		anthropicAPI: anthropicAPI,
+		codexAPI:     codexAPI,
+		copilotAPI:   copilotAPI,
 	}
 }
 
@@ -102,63 +149,78 @@ func (c *Collector) TakeSnapshot(ctx context.Context, provider string) (Snapshot
 	var scrapedPct *float64
 	var scrapeErr error
 	var sessionResetTime, weeklyResetTime string
+	var source string
+
+	useAPI := c.trackingMode == "active" || c.trackingMode == "hybrid"
 
 	switch provider {
 	case "claude":
-		if c.claude == nil {
-			return Snapshot{}, errors.New("claude provider is nil")
-		}
-		localWeekly, err = c.claude.GetWeeklyUsage()
-		if err != nil {
-			return Snapshot{}, err
-		}
-		localDaily, err = c.claude.GetTodayUsage()
-		if err != nil {
-			return Snapshot{}, err
-		}
-		if c.scraper != nil {
-			result, sErr := c.scraper.ScrapeClaudeUsage(ctx)
-			if sErr != nil {
-				scrapeErr = sErr
-			} else {
-				if result.WeeklyPct >= 0 && result.WeeklyPct <= 100 {
-					pct := result.WeeklyPct
-					scrapedPct = &pct
+		if useAPI && c.anthropicAPI != nil {
+			localWeekly, localDaily, scrapedPct, sessionResetTime, weeklyResetTime, source, err = c.collectClaudeFromAPI(ctx)
+			if err != nil {
+				if c.trackingMode == "hybrid" {
+					// fallback to file/tmux
+					localWeekly, localDaily, scrapedPct, scrapeErr, sessionResetTime, weeklyResetTime, source, err = c.collectClaudeFromFile(ctx)
+					if err != nil {
+						return Snapshot{}, err
+					}
+				} else {
+					return Snapshot{}, fmt.Errorf("claude api: %w", err)
 				}
-				sessionResetTime = result.SessionResetTime
-				weeklyResetTime = result.WeeklyResetTime
+			}
+		} else {
+			if c.claude == nil {
+				return Snapshot{}, errors.New("claude provider is nil")
+			}
+			localWeekly, localDaily, scrapedPct, scrapeErr, sessionResetTime, weeklyResetTime, source, err = c.collectClaudeFromFile(ctx)
+			if err != nil {
+				return Snapshot{}, err
 			}
 		}
 	case "codex":
-		if c.codex == nil {
-			return Snapshot{}, errors.New("codex provider is nil")
-		}
-		localWeekly, localDaily, err = codexTokenTotals(c.codex)
-		if err != nil {
-			return Snapshot{}, err
-		}
-		if c.scraper != nil {
-			result, sErr := c.scraper.ScrapeCodexUsage(ctx)
-			if sErr != nil {
-				scrapeErr = sErr
-			} else {
-				if result.WeeklyPct >= 0 && result.WeeklyPct <= 100 {
-					pct := result.WeeklyPct
-					scrapedPct = &pct
+		if useAPI && c.codexAPI != nil {
+			localWeekly, localDaily, scrapedPct, sessionResetTime, weeklyResetTime, source, err = c.collectCodexFromAPI(ctx)
+			if err != nil {
+				if c.trackingMode == "hybrid" {
+					localWeekly, localDaily, scrapedPct, scrapeErr, sessionResetTime, weeklyResetTime, source, err = c.collectCodexFromFile(ctx)
+					if err != nil {
+						return Snapshot{}, err
+					}
+				} else {
+					return Snapshot{}, fmt.Errorf("codex api: %w", err)
 				}
-				sessionResetTime = result.SessionResetTime
-				weeklyResetTime = result.WeeklyResetTime
+			}
+		} else {
+			if c.codex == nil {
+				return Snapshot{}, errors.New("codex provider is nil")
+			}
+			localWeekly, localDaily, scrapedPct, scrapeErr, sessionResetTime, weeklyResetTime, source, err = c.collectCodexFromFile(ctx)
+			if err != nil {
+				return Snapshot{}, err
 			}
 		}
 	case "copilot":
-		if c.copilot == nil {
-			return Snapshot{}, errors.New("copilot provider is nil")
+		if useAPI && c.copilotAPI != nil {
+			localWeekly, localDaily, scrapedPct, sessionResetTime, weeklyResetTime, source, err = c.collectCopilotFromAPI(ctx)
+			if err != nil {
+				if c.trackingMode == "hybrid" {
+					localWeekly, localDaily, scrapedPct, scrapeErr, sessionResetTime, weeklyResetTime, source, err = c.collectCopilotFromFile()
+					if err != nil {
+						return Snapshot{}, err
+					}
+				} else {
+					return Snapshot{}, fmt.Errorf("copilot api: %w", err)
+				}
+			}
+		} else {
+			if c.copilot == nil {
+				return Snapshot{}, errors.New("copilot provider is nil")
+			}
+			localWeekly, localDaily, scrapedPct, scrapeErr, sessionResetTime, weeklyResetTime, source, err = c.collectCopilotFromFile()
+			if err != nil {
+				return Snapshot{}, err
+			}
 		}
-		localWeekly, localDaily, err = copilotTokenTotals(c.copilot)
-		if err != nil {
-			return Snapshot{}, err
-		}
-		// Note: Copilot doesn't support tmux scraping yet
 	default:
 		return Snapshot{}, fmt.Errorf("unknown provider: %s", provider)
 	}
@@ -175,8 +237,8 @@ func (c *Collector) TakeSnapshot(ctx context.Context, provider string) (Snapshot
 	}
 
 	result, err := c.db.SQL().Exec(
-		`INSERT INTO snapshots (provider, timestamp, week_start, local_tokens, local_daily, scraped_pct, inferred_budget, day_of_week, hour_of_day, week_number, year, session_reset_time, weekly_reset_time)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO snapshots (provider, timestamp, week_start, local_tokens, local_daily, scraped_pct, inferred_budget, day_of_week, hour_of_day, week_number, year, session_reset_time, weekly_reset_time, source)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		provider,
 		now,
 		weekStart,
@@ -190,6 +252,7 @@ func (c *Collector) TakeSnapshot(ctx context.Context, provider string) (Snapshot
 		year,
 		nullString(sessionResetTime),
 		nullString(weeklyResetTime),
+		source,
 	)
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("insert snapshot: %w", err)
@@ -212,8 +275,149 @@ func (c *Collector) TakeSnapshot(ctx context.Context, provider string) (Snapshot
 		Year:             year,
 		SessionResetTime: sessionResetTime,
 		WeeklyResetTime:  weeklyResetTime,
+		Source:           source,
 		ScrapeErr:        scrapeErr,
 	}, nil
+}
+
+// collectClaudeFromAPI fetches Claude usage from the Anthropic API.
+func (c *Collector) collectClaudeFromAPI(ctx context.Context) (localWeekly, localDaily int64, scrapedPct *float64, sessionResetTime, weeklyResetTime, source string, err error) {
+	resp, err := c.anthropicAPI.FetchQuotas(ctx)
+	if err != nil {
+		return 0, 0, nil, "", "", "", err
+	}
+
+	if entry, ok := resp["seven_day"]; ok && entry.IsEnabled {
+		pct := entry.Utilization * 100
+		scrapedPct = &pct
+		if !entry.ResetsAt.IsZero() {
+			weeklyResetTime = entry.ResetsAt.Format(time.RFC3339)
+		} else if entry.ResetsAtRaw != "" {
+			weeklyResetTime = entry.ResetsAtRaw
+		}
+	}
+	if entry, ok := resp["five_hour"]; ok && entry.IsEnabled {
+		if !entry.ResetsAt.IsZero() {
+			sessionResetTime = entry.ResetsAt.Format(time.RFC3339)
+		} else if entry.ResetsAtRaw != "" {
+			sessionResetTime = entry.ResetsAtRaw
+		}
+	}
+
+	return 0, 0, scrapedPct, sessionResetTime, weeklyResetTime, "api", nil
+}
+
+// collectClaudeFromFile fetches Claude usage from local files and tmux.
+func (c *Collector) collectClaudeFromFile(ctx context.Context) (localWeekly, localDaily int64, scrapedPct *float64, scrapeErr error, sessionResetTime, weeklyResetTime, source string, err error) {
+	if c.claude == nil {
+		return 0, 0, nil, nil, "", "", "", errors.New("claude provider is nil")
+	}
+	localWeekly, err = c.claude.GetWeeklyUsage()
+	if err != nil {
+		return 0, 0, nil, nil, "", "", "", err
+	}
+	localDaily, err = c.claude.GetTodayUsage()
+	if err != nil {
+		return 0, 0, nil, nil, "", "", "", err
+	}
+	src := "file"
+	if c.scraper != nil {
+		result, sErr := c.scraper.ScrapeClaudeUsage(ctx)
+		if sErr != nil {
+			scrapeErr = sErr
+		} else {
+			if result.WeeklyPct >= 0 && result.WeeklyPct <= 100 {
+				pct := result.WeeklyPct
+				scrapedPct = &pct
+			}
+			sessionResetTime = result.SessionResetTime
+			weeklyResetTime = result.WeeklyResetTime
+			if scrapedPct != nil {
+				src = "tmux"
+			}
+		}
+	}
+	return localWeekly, localDaily, scrapedPct, scrapeErr, sessionResetTime, weeklyResetTime, src, nil
+}
+
+// collectCodexFromAPI fetches Codex usage from the OpenAI API.
+func (c *Collector) collectCodexFromAPI(ctx context.Context) (localWeekly, localDaily int64, scrapedPct *float64, sessionResetTime, weeklyResetTime, source string, err error) {
+	resp, err := c.codexAPI.FetchUsage(ctx)
+	if err != nil {
+		return 0, 0, nil, "", "", "", err
+	}
+
+	if resp.RateLimit != nil && resp.RateLimit.PrimaryWindow != nil {
+		pw := resp.RateLimit.PrimaryWindow
+		pct := pw.UsedPercent
+		scrapedPct = &pct
+		if !pw.ResetAt.IsZero() {
+			sessionResetTime = pw.ResetAt.Format(time.RFC3339)
+			weeklyResetTime = sessionResetTime
+		}
+	}
+
+	return 0, 0, scrapedPct, sessionResetTime, weeklyResetTime, "api", nil
+}
+
+// collectCodexFromFile fetches Codex usage from local files and tmux.
+func (c *Collector) collectCodexFromFile(ctx context.Context) (localWeekly, localDaily int64, scrapedPct *float64, scrapeErr error, sessionResetTime, weeklyResetTime, source string, err error) {
+	if c.codex == nil {
+		return 0, 0, nil, nil, "", "", "", errors.New("codex provider is nil")
+	}
+	localWeekly, localDaily, err = codexTokenTotals(c.codex)
+	if err != nil {
+		return 0, 0, nil, nil, "", "", "", err
+	}
+	src := "file"
+	if c.scraper != nil {
+		result, sErr := c.scraper.ScrapeCodexUsage(ctx)
+		if sErr != nil {
+			scrapeErr = sErr
+		} else {
+			if result.WeeklyPct >= 0 && result.WeeklyPct <= 100 {
+				pct := result.WeeklyPct
+				scrapedPct = &pct
+			}
+			sessionResetTime = result.SessionResetTime
+			weeklyResetTime = result.WeeklyResetTime
+			if scrapedPct != nil {
+				src = "tmux"
+			}
+		}
+	}
+	return localWeekly, localDaily, scrapedPct, scrapeErr, sessionResetTime, weeklyResetTime, src, nil
+}
+
+// collectCopilotFromAPI fetches Copilot usage from the GitHub API.
+func (c *Collector) collectCopilotFromAPI(ctx context.Context) (localWeekly, localDaily int64, scrapedPct *float64, sessionResetTime, weeklyResetTime, source string, err error) {
+	resp, err := c.copilotAPI.FetchQuotas(ctx)
+	if err != nil {
+		return 0, 0, nil, "", "", "", err
+	}
+
+	if quota, ok := resp.Quotas["premium_interactions"]; ok && !quota.Unlimited {
+		usedPct := 100.0 - quota.PercentRemaining
+		scrapedPct = &usedPct
+	}
+	if resp.QuotaResetDate != "" {
+		weeklyResetTime = resp.QuotaResetDate
+		sessionResetTime = resp.QuotaResetDate
+	}
+
+	return 0, 0, scrapedPct, sessionResetTime, weeklyResetTime, "api", nil
+}
+
+// collectCopilotFromFile fetches Copilot usage from local files.
+func (c *Collector) collectCopilotFromFile() (localWeekly, localDaily int64, scrapedPct *float64, scrapeErr error, sessionResetTime, weeklyResetTime, source string, err error) {
+	if c.copilot == nil {
+		return 0, 0, nil, nil, "", "", "", errors.New("copilot provider is nil")
+	}
+	localWeekly, localDaily, err = copilotTokenTotals(c.copilot)
+	if err != nil {
+		return 0, 0, nil, nil, "", "", "", err
+	}
+	return localWeekly, localDaily, nil, nil, "", "", "file", nil
 }
 
 // GetLatest returns the latest snapshots for a provider.
@@ -222,7 +426,7 @@ func (c *Collector) GetLatest(provider string, n int) ([]Snapshot, error) {
 		return []Snapshot{}, nil
 	}
 	rows, err := c.db.SQL().Query(
-		`SELECT id, provider, timestamp, week_start, local_tokens, local_daily, scraped_pct, inferred_budget, day_of_week, hour_of_day, week_number, year, session_reset_time, weekly_reset_time
+		`SELECT id, provider, timestamp, week_start, local_tokens, local_daily, scraped_pct, inferred_budget, day_of_week, hour_of_day, week_number, year, session_reset_time, weekly_reset_time, source
 		 FROM snapshots
 		 WHERE provider = ?
 		 ORDER BY timestamp DESC
@@ -253,7 +457,7 @@ func (c *Collector) GetLatest(provider string, n int) ([]Snapshot, error) {
 func (c *Collector) GetSinceWeekStart(provider string) ([]Snapshot, error) {
 	weekStart := startOfWeek(time.Now(), c.weekStartDay)
 	rows, err := c.db.SQL().Query(
-		`SELECT id, provider, timestamp, week_start, local_tokens, local_daily, scraped_pct, inferred_budget, day_of_week, hour_of_day, week_number, year, session_reset_time, weekly_reset_time
+		`SELECT id, provider, timestamp, week_start, local_tokens, local_daily, scraped_pct, inferred_budget, day_of_week, hour_of_day, week_number, year, session_reset_time, weekly_reset_time, source
 		 FROM snapshots
 		 WHERE provider = ? AND week_start = ?
 		 ORDER BY timestamp ASC`,
@@ -335,6 +539,7 @@ func scanSnapshot(rows *sql.Rows) (Snapshot, error) {
 	var scraped sql.NullFloat64
 	var inferred sql.NullInt64
 	var sessionReset, weeklyReset sql.NullString
+	var source sql.NullString
 	if err := rows.Scan(
 		&snapshot.ID,
 		&snapshot.Provider,
@@ -350,6 +555,7 @@ func scanSnapshot(rows *sql.Rows) (Snapshot, error) {
 		&snapshot.Year,
 		&sessionReset,
 		&weeklyReset,
+		&source,
 	); err != nil {
 		return Snapshot{}, fmt.Errorf("scan snapshot: %w", err)
 	}
@@ -365,6 +571,11 @@ func scanSnapshot(rows *sql.Rows) (Snapshot, error) {
 	}
 	if weeklyReset.Valid {
 		snapshot.WeeklyResetTime = weeklyReset.String
+	}
+	if source.Valid {
+		snapshot.Source = source.String
+	} else {
+		snapshot.Source = "file"
 	}
 	return snapshot, nil
 }

--- a/internal/snapshots/collector.go
+++ b/internal/snapshots/collector.go
@@ -281,6 +281,7 @@ func (c *Collector) TakeSnapshot(ctx context.Context, provider string) (Snapshot
 }
 
 // collectClaudeFromAPI fetches Claude usage from the Anthropic API.
+// Active mode only — returns error on API failure, no file fallback.
 func (c *Collector) collectClaudeFromAPI(ctx context.Context) (localWeekly, localDaily int64, scrapedPct *float64, sessionResetTime, weeklyResetTime, source string, err error) {
 	resp, err := c.anthropicAPI.FetchQuotas(ctx)
 	if err != nil {
@@ -288,7 +289,7 @@ func (c *Collector) collectClaudeFromAPI(ctx context.Context) (localWeekly, loca
 	}
 
 	if entry, ok := resp["seven_day"]; ok && entry.IsEnabled {
-		pct := entry.Utilization * 100
+		pct := clampPct(entry.Utilization * 100)
 		scrapedPct = &pct
 		if !entry.ResetsAt.IsZero() {
 			weeklyResetTime = entry.ResetsAt.Format(time.RFC3339)
@@ -304,7 +305,13 @@ func (c *Collector) collectClaudeFromAPI(ctx context.Context) (localWeekly, loca
 		}
 	}
 
-	return 0, 0, scrapedPct, sessionResetTime, weeklyResetTime, "api", nil
+	// Augment with local token totals so inferred_budget can be computed.
+	if c.claude != nil {
+		localWeekly, _ = c.claude.GetWeeklyUsage()
+		localDaily, _ = c.claude.GetTodayUsage()
+	}
+
+	return localWeekly, localDaily, scrapedPct, sessionResetTime, weeklyResetTime, "api", nil
 }
 
 // collectClaudeFromFile fetches Claude usage from local files and tmux.
@@ -341,6 +348,7 @@ func (c *Collector) collectClaudeFromFile(ctx context.Context) (localWeekly, loc
 }
 
 // collectCodexFromAPI fetches Codex usage from the OpenAI API.
+// Active mode only — returns error on API failure, no file fallback.
 func (c *Collector) collectCodexFromAPI(ctx context.Context) (localWeekly, localDaily int64, scrapedPct *float64, sessionResetTime, weeklyResetTime, source string, err error) {
 	resp, err := c.codexAPI.FetchUsage(ctx)
 	if err != nil {
@@ -349,7 +357,7 @@ func (c *Collector) collectCodexFromAPI(ctx context.Context) (localWeekly, local
 
 	if resp.RateLimit != nil && resp.RateLimit.PrimaryWindow != nil {
 		pw := resp.RateLimit.PrimaryWindow
-		pct := pw.UsedPercent
+		pct := clampPct(pw.UsedPercent)
 		scrapedPct = &pct
 		if !pw.ResetAt.IsZero() {
 			sessionResetTime = pw.ResetAt.Format(time.RFC3339)
@@ -357,7 +365,13 @@ func (c *Collector) collectCodexFromAPI(ctx context.Context) (localWeekly, local
 		}
 	}
 
-	return 0, 0, scrapedPct, sessionResetTime, weeklyResetTime, "api", nil
+	// Augment with local token totals so inferred_budget can be computed.
+	if c.codex != nil {
+		localWeekly, _ = c.codex.GetWeeklyTokens()
+		localDaily, _ = c.codex.GetTodayTokens()
+	}
+
+	return localWeekly, localDaily, scrapedPct, sessionResetTime, weeklyResetTime, "api", nil
 }
 
 // collectCodexFromFile fetches Codex usage from local files and tmux.
@@ -390,15 +404,19 @@ func (c *Collector) collectCodexFromFile(ctx context.Context) (localWeekly, loca
 }
 
 // collectCopilotFromAPI fetches Copilot usage from the GitHub API.
+// Active mode only — returns error on API failure, no file fallback.
 func (c *Collector) collectCopilotFromAPI(ctx context.Context) (localWeekly, localDaily int64, scrapedPct *float64, sessionResetTime, weeklyResetTime, source string, err error) {
 	resp, err := c.copilotAPI.FetchQuotas(ctx)
 	if err != nil {
 		return 0, 0, nil, "", "", "", err
 	}
+	if resp == nil {
+		return 0, 0, nil, "", "", "", errors.New("copilot api: nil response")
+	}
 
 	if quota, ok := resp.Quotas["premium_interactions"]; ok && !quota.Unlimited {
-		usedPct := 100.0 - quota.PercentRemaining
-		scrapedPct = &usedPct
+		pct := clampPct(100.0 - quota.PercentRemaining)
+		scrapedPct = &pct
 	}
 	if resp.QuotaResetDate != "" {
 		weeklyResetTime = resp.QuotaResetDate
@@ -622,6 +640,18 @@ func codexTokenTotals(codex CodexUsage) (int64, int64, error) {
 		return 0, 0, fmt.Errorf("get today tokens: %w", err)
 	}
 	return weekly, daily, nil
+}
+
+// clampPct clamps a percentage value to [0, 100] and returns nil-safe storage.
+// API responses may return values outside this range; inferred_budget would be wrong without clamping.
+func clampPct(pct float64) float64 {
+	if pct < 0 {
+		return 0
+	}
+	if pct > 100 {
+		return 100
+	}
+	return pct
 }
 
 // copilotTokenTotals returns weekly and daily token totals from Copilot usage files.

--- a/internal/snapshots/collector_test.go
+++ b/internal/snapshots/collector_test.go
@@ -273,7 +273,7 @@ func TestActiveModeClaudeAPISuccess(t *testing.T) {
 		"seven_day": {Utilization: 0.42, ResetsAt: resetAt, IsEnabled: true},
 		"five_hour":  {Utilization: 0.10, ResetsAt: resetAt, IsEnabled: true},
 	}
-	collector := NewCollectorWithAPIs(database, nil, nil, nil, nil, time.Monday, "active",
+	collector := NewCollectorWithAPIs(database, fakeClaude{weekly: 500, daily: 80}, nil, nil, nil, time.Monday, "active",
 		fakeAnthropicAPI{resp: apiResp}, nil, nil)
 	snap, err := collector.TakeSnapshot(context.Background(), "claude")
 	if err != nil {
@@ -284,6 +284,13 @@ func TestActiveModeClaudeAPISuccess(t *testing.T) {
 	}
 	if snap.ScrapedPct == nil || *snap.ScrapedPct < 41.9 || *snap.ScrapedPct > 42.1 {
 		t.Fatalf("scraped pct = %v, want ~42", snap.ScrapedPct)
+	}
+	// Local token totals populated from file provider so inferred_budget can be computed.
+	if snap.LocalTokens != 500 {
+		t.Fatalf("local tokens = %d, want 500", snap.LocalTokens)
+	}
+	if snap.InferredBudget == nil {
+		t.Fatalf("inferred budget = nil, want computed value")
 	}
 }
 
@@ -308,7 +315,7 @@ func TestActiveModeCodexAPISuccess(t *testing.T) {
 			},
 		},
 	}
-	collector := NewCollectorWithAPIs(database, nil, nil, nil, nil, time.Monday, "active",
+	collector := NewCollectorWithAPIs(database, nil, fakeCodex{weeklyTokens: 1000, dailyTokens: 100}, nil, nil, time.Monday, "active",
 		nil, fakeCodexAPI{resp: apiResp}, nil)
 	snap, err := collector.TakeSnapshot(context.Background(), "codex")
 	if err != nil {
@@ -319,6 +326,13 @@ func TestActiveModeCodexAPISuccess(t *testing.T) {
 	}
 	if snap.ScrapedPct == nil || *snap.ScrapedPct != 55.0 {
 		t.Fatalf("scraped pct = %v, want 55", snap.ScrapedPct)
+	}
+	// Local token totals populated from file provider so inferred_budget can be computed.
+	if snap.LocalTokens != 1000 {
+		t.Fatalf("local tokens = %d, want 1000", snap.LocalTokens)
+	}
+	if snap.InferredBudget == nil {
+		t.Fatalf("inferred budget = nil, want computed value")
 	}
 }
 
@@ -365,6 +379,31 @@ func TestActiveModeCopilotAPIFail_ReturnsError(t *testing.T) {
 	_, err := collector.TakeSnapshot(context.Background(), "copilot")
 	if err == nil {
 		t.Fatal("expected error in active mode on API failure")
+	}
+}
+
+func TestActiveModeCopilotNilResponse_ReturnsError(t *testing.T) {
+	database := openTestDB(t)
+	collector := NewCollectorWithAPIs(database, nil, nil, nil, nil, time.Monday, "active",
+		nil, nil, fakeCopilotAPI{resp: nil})
+	_, err := collector.TakeSnapshot(context.Background(), "copilot")
+	if err == nil {
+		t.Fatal("expected error when copilot API returns nil response")
+	}
+}
+
+func TestClampPct(t *testing.T) {
+	cases := []struct{ in, want float64 }{
+		{50.0, 50.0},
+		{0.0, 0.0},
+		{100.0, 100.0},
+		{-5.0, 0.0},
+		{105.0, 100.0},
+	}
+	for _, tc := range cases {
+		if got := clampPct(tc.in); got != tc.want {
+			t.Errorf("clampPct(%v) = %v, want %v", tc.in, got, tc.want)
+		}
 	}
 }
 

--- a/internal/snapshots/collector_test.go
+++ b/internal/snapshots/collector_test.go
@@ -2,12 +2,14 @@ package snapshots
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/marcus/nightshift/internal/db"
 	"github.com/marcus/nightshift/internal/tmux"
+	"github.com/marcus/nightshift/internal/usage"
 )
 
 type fakeClaude struct {
@@ -206,6 +208,263 @@ func TestCodexTokenTotalsPropagatesErrors(t *testing.T) {
 		t.Fatal("expected error from codexTokenTotals")
 	}
 }
+
+// --- API client stubs ---
+
+type fakeAnthropicAPI struct {
+	resp usage.AnthropicQuotaResponse
+	err  error
+}
+
+func (f fakeAnthropicAPI) FetchQuotas(_ context.Context) (usage.AnthropicQuotaResponse, error) {
+	return f.resp, f.err
+}
+
+type fakeCodexAPI struct {
+	resp *usage.CodexUsageResponse
+	err  error
+}
+
+func (f fakeCodexAPI) FetchUsage(_ context.Context) (*usage.CodexUsageResponse, error) {
+	return f.resp, f.err
+}
+
+type fakeCopilotAPI struct {
+	resp *usage.CopilotUserResponse
+	err  error
+}
+
+func (f fakeCopilotAPI) FetchQuotas(_ context.Context) (*usage.CopilotUserResponse, error) {
+	return f.resp, f.err
+}
+
+func openTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	database, err := db.Open(filepath.Join(home, "nightshift.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	return database
+}
+
+// --- Passive mode tests ---
+
+func TestPassiveModeSourceIsFile(t *testing.T) {
+	database := openTestDB(t)
+	collector := NewCollector(database, fakeClaude{weekly: 100, daily: 10}, nil, nil, nil, time.Monday)
+	snap, err := collector.TakeSnapshot(context.Background(), "claude")
+	if err != nil {
+		t.Fatalf("take snapshot: %v", err)
+	}
+	if snap.Source != "file" {
+		t.Fatalf("source = %q, want file", snap.Source)
+	}
+}
+
+// --- Active mode tests ---
+
+func TestActiveModeClaudeAPISuccess(t *testing.T) {
+	database := openTestDB(t)
+	resetAt := time.Now().Add(time.Hour)
+	apiResp := usage.AnthropicQuotaResponse{
+		"seven_day": {Utilization: 0.42, ResetsAt: resetAt, IsEnabled: true},
+		"five_hour":  {Utilization: 0.10, ResetsAt: resetAt, IsEnabled: true},
+	}
+	collector := NewCollectorWithAPIs(database, nil, nil, nil, nil, time.Monday, "active",
+		fakeAnthropicAPI{resp: apiResp}, nil, nil)
+	snap, err := collector.TakeSnapshot(context.Background(), "claude")
+	if err != nil {
+		t.Fatalf("take snapshot: %v", err)
+	}
+	if snap.Source != "api" {
+		t.Fatalf("source = %q, want api", snap.Source)
+	}
+	if snap.ScrapedPct == nil || *snap.ScrapedPct < 41.9 || *snap.ScrapedPct > 42.1 {
+		t.Fatalf("scraped pct = %v, want ~42", snap.ScrapedPct)
+	}
+}
+
+func TestActiveModeClaudeAPIFail_ReturnsError(t *testing.T) {
+	database := openTestDB(t)
+	collector := NewCollectorWithAPIs(database, nil, nil, nil, nil, time.Monday, "active",
+		fakeAnthropicAPI{err: errors.New("api down")}, nil, nil)
+	_, err := collector.TakeSnapshot(context.Background(), "claude")
+	if err == nil {
+		t.Fatal("expected error in active mode on API failure")
+	}
+}
+
+func TestActiveModeCodexAPISuccess(t *testing.T) {
+	database := openTestDB(t)
+	resetAt := usage.UnixTime{Time: time.Now().Add(time.Hour)}
+	apiResp := &usage.CodexUsageResponse{
+		RateLimit: &usage.CodexAPIRateLimit{
+			PrimaryWindow: &usage.CodexWindow{
+				UsedPercent: 55.0,
+				ResetAt:     resetAt,
+			},
+		},
+	}
+	collector := NewCollectorWithAPIs(database, nil, nil, nil, nil, time.Monday, "active",
+		nil, fakeCodexAPI{resp: apiResp}, nil)
+	snap, err := collector.TakeSnapshot(context.Background(), "codex")
+	if err != nil {
+		t.Fatalf("take snapshot: %v", err)
+	}
+	if snap.Source != "api" {
+		t.Fatalf("source = %q, want api", snap.Source)
+	}
+	if snap.ScrapedPct == nil || *snap.ScrapedPct != 55.0 {
+		t.Fatalf("scraped pct = %v, want 55", snap.ScrapedPct)
+	}
+}
+
+func TestActiveModeCodexAPIFail_ReturnsError(t *testing.T) {
+	database := openTestDB(t)
+	collector := NewCollectorWithAPIs(database, nil, nil, nil, nil, time.Monday, "active",
+		nil, fakeCodexAPI{err: errors.New("api down")}, nil)
+	_, err := collector.TakeSnapshot(context.Background(), "codex")
+	if err == nil {
+		t.Fatal("expected error in active mode on API failure")
+	}
+}
+
+func TestActiveModeCopilotAPISuccess(t *testing.T) {
+	database := openTestDB(t)
+	apiResp := &usage.CopilotUserResponse{
+		QuotaResetDate: "2026-05-20",
+		Quotas: usage.CopilotQuotaMap{
+			"premium_interactions": {PercentRemaining: 30.0, Unlimited: false},
+		},
+	}
+	collector := NewCollectorWithAPIs(database, nil, nil, nil, nil, time.Monday, "active",
+		nil, nil, fakeCopilotAPI{resp: apiResp})
+	snap, err := collector.TakeSnapshot(context.Background(), "copilot")
+	if err != nil {
+		t.Fatalf("take snapshot: %v", err)
+	}
+	if snap.Source != "api" {
+		t.Fatalf("source = %q, want api", snap.Source)
+	}
+	// 100 - 30 = 70% used
+	if snap.ScrapedPct == nil || *snap.ScrapedPct != 70.0 {
+		t.Fatalf("scraped pct = %v, want 70", snap.ScrapedPct)
+	}
+	if snap.WeeklyResetTime != "2026-05-20" {
+		t.Fatalf("weekly reset = %q, want 2026-05-20", snap.WeeklyResetTime)
+	}
+}
+
+func TestActiveModeCopilotAPIFail_ReturnsError(t *testing.T) {
+	database := openTestDB(t)
+	collector := NewCollectorWithAPIs(database, nil, nil, nil, nil, time.Monday, "active",
+		nil, nil, fakeCopilotAPI{err: errors.New("api down")})
+	_, err := collector.TakeSnapshot(context.Background(), "copilot")
+	if err == nil {
+		t.Fatal("expected error in active mode on API failure")
+	}
+}
+
+// --- Hybrid mode tests ---
+
+func TestHybridModeAPISuccess_SourceAPI(t *testing.T) {
+	database := openTestDB(t)
+	apiResp := usage.AnthropicQuotaResponse{
+		"seven_day": {Utilization: 0.60, IsEnabled: true},
+	}
+	collector := NewCollectorWithAPIs(database, fakeClaude{weekly: 100, daily: 10}, nil, nil, nil, time.Monday, "hybrid",
+		fakeAnthropicAPI{resp: apiResp}, nil, nil)
+	snap, err := collector.TakeSnapshot(context.Background(), "claude")
+	if err != nil {
+		t.Fatalf("take snapshot: %v", err)
+	}
+	if snap.Source != "api" {
+		t.Fatalf("source = %q, want api", snap.Source)
+	}
+}
+
+func TestHybridModeAPIFail_FallsBackToFile(t *testing.T) {
+	database := openTestDB(t)
+	collector := NewCollectorWithAPIs(database, fakeClaude{weekly: 200, daily: 20}, nil, nil, nil, time.Monday, "hybrid",
+		fakeAnthropicAPI{err: errors.New("api down")}, nil, nil)
+	snap, err := collector.TakeSnapshot(context.Background(), "claude")
+	if err != nil {
+		t.Fatalf("hybrid fallback should not error: %v", err)
+	}
+	if snap.Source != "file" {
+		t.Fatalf("source = %q, want file after fallback", snap.Source)
+	}
+	if snap.LocalTokens != 200 {
+		t.Fatalf("local tokens = %d, want 200", snap.LocalTokens)
+	}
+}
+
+func TestHybridModeCodexAPIFail_FallsBackToFile(t *testing.T) {
+	database := openTestDB(t)
+	collector := NewCollectorWithAPIs(database, nil, fakeCodex{weeklyTokens: 500, dailyTokens: 50}, nil, nil, time.Monday, "hybrid",
+		nil, fakeCodexAPI{err: errors.New("api down")}, nil)
+	snap, err := collector.TakeSnapshot(context.Background(), "codex")
+	if err != nil {
+		t.Fatalf("hybrid fallback should not error: %v", err)
+	}
+	if snap.Source != "file" {
+		t.Fatalf("source = %q, want file after fallback", snap.Source)
+	}
+}
+
+func TestHybridModeCopilotAPIFail_FallsBackToFile(t *testing.T) {
+	database := openTestDB(t)
+	copilot := fakeCopilotUsage{weekly: 100, daily: 10}
+	collector := NewCollectorWithAPIs(database, nil, nil, copilot, nil, time.Monday, "hybrid",
+		nil, nil, fakeCopilotAPI{err: errors.New("api down")})
+	snap, err := collector.TakeSnapshot(context.Background(), "copilot")
+	if err != nil {
+		t.Fatalf("hybrid fallback should not error: %v", err)
+	}
+	if snap.Source != "file" {
+		t.Fatalf("source = %q, want file after fallback", snap.Source)
+	}
+}
+
+// --- Source persisted and read back ---
+
+func TestSourcePersistedAndReadBack(t *testing.T) {
+	database := openTestDB(t)
+	apiResp := usage.AnthropicQuotaResponse{
+		"seven_day": {Utilization: 0.30, IsEnabled: true},
+	}
+	collector := NewCollectorWithAPIs(database, nil, nil, nil, nil, time.Monday, "active",
+		fakeAnthropicAPI{resp: apiResp}, nil, nil)
+	_, err := collector.TakeSnapshot(context.Background(), "claude")
+	if err != nil {
+		t.Fatalf("take snapshot: %v", err)
+	}
+	snaps, err := collector.GetLatest("claude", 1)
+	if err != nil {
+		t.Fatalf("get latest: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot")
+	}
+	if snaps[0].Source != "api" {
+		t.Fatalf("source = %q, want api", snaps[0].Source)
+	}
+}
+
+// fakeCopilotUsage implements CopilotUsage for tests.
+type fakeCopilotUsage struct {
+	weekly int64
+	daily  int64
+	err    error
+}
+
+func (f fakeCopilotUsage) GetWeeklyTokens() (int64, error) { return f.weekly, f.err }
+func (f fakeCopilotUsage) GetTodayTokens() (int64, error)  { return f.daily, f.err }
+
+// --- Original tests below ---
 
 func TestTakeSnapshotStoresResetTimes(t *testing.T) {
 	home := t.TempDir()


### PR DESCRIPTION
## VC-36 — Snapshot Collector: API-based collection

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-36

### Description

Summary
Update internal/snapshots/collector.go to optionally use the new API clients instead of tmux scraping + file parsing when tracking=active|hybrid. Snapshots become more accurate and don't depend on tmux session visibility.
Reference
Epic: VC-29 (Active Token Budget Tracking)
onWatch — see how their snapshot types (AnthropicSnapshot, CodexSnapshot, CopilotSnapshot) convert API responses to storage format
onWatch anthropic_types.go — ToSnapshot() pattern
onWatch codex_types.go — ToSnapshot() pattern
onWatch copilot_types.go — ToSnapshot() pattern
Current Behavior
collector.TakeSnapshot() collects usage via:
Tmux session scraping (fragile, requires specific pane layout)
File parsing (Claude stats-cache.json, Codex session JSONL)
Stores in SQLite via internal/db/
New Behavior
When tracking=active|hybrid:
Call API clients first (anthropic.FetchQuotas, codex.FetchUsage, copilot.FetchQuotas)
Convert API responses to existing snapshot format
Tag snapshots with source: "api" vs source: "file" for provenance
Fall back to existing file/tmux collection on API failure
Implementation
Modify: internal/snapshots/collector.go
Accept optional API clients in constructor
Add collectFromAPI(ctx, provider) method
Existing collectFromFile(provider) remains as fallback
TakeSnapshot() checks tracking config to decide source
Acceptance Criteria
[ ] tracking=passive → existing snapshot collection unchanged
[ ] tracking=active → snapshots from API clients
[ ] tracking=hybrid → API where available, file where not
[ ] Snapshot records include source field (api/file/tmux)
[ ] API failure → automatic fallback to file collection
[ ] No new DB migrations needed (or minimal: add source column)
[ ] make test passes, make build succeeds
Agent Workflow
Branch from main → feat/snapshot-api-collection
Modify collector
Write tests
Run make test && make build
Create PR targeting main

### Acceptance Criteria

[ ] tracking=passive → existing snapshot collection unchanged
[ ] tracking=active → snapshots from API clients
[ ] tracking=hybrid → API where available, file where not
[ ] Snapshot records include source field (api/file/tmux)
[ ] API failure → automatic fallback to file collection
[ ] No new DB migrations needed (or minimal: add source column)
[ ] make test passes, make build succeeds
Agent Workflow
Branch from main → feat/snapshot-api-collection
Modify collector
Write tests
Run make test && make build
Create PR targeting main

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
