### PR TITLE
[VC-65] Trigger fix-review agent on merge conflicts with principal branch

### DIFF
--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -146,21 +146,22 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			// After filtering by lastReworkAt, if nothing remains → skip regardless
 			// of ReviewDecision (it stays CHANGES_REQUESTED until a re-review).
 			// On first run (lastReworkAt zero), fall back to the original heuristic.
-			// Failing CI checks are always current state and not filtered by lastReworkAt.
+			// Failing CI checks and merge conflicts are always current state; not filtered by lastReworkAt.
 			hasFailingChecks := len(reviewState.FailingChecks) > 0
+			hasConflict := reviewState.HasConflict
 			if !lastReworkAt.IsZero() {
-				if len(reviewState.Reviews) == 0 && !hasActionableComments(reviewState) && !hasFailingChecks {
-					o.log.Infof("ticket %s: skipping rework — no new content since lastReworkAt=%s",
-						ticket.Key, lastReworkAt.Format(time.RFC3339))
-					o.emit("  ✓ no new review comments or failing checks since last rework — skipping")
+				if len(reviewState.Reviews) == 0 && !hasActionableComments(reviewState) && !hasFailingChecks && !hasConflict {
+					o.log.Infof("ticket %s: skipping rework — no new content since lastReworkAt=%s conflicts=%v",
+						ticket.Key, lastReworkAt.Format(time.RFC3339), hasConflict)
+					o.emit("  ✓ no new review comments, failing checks, or merge conflicts since last rework — skipping")
 					continue
 				}
 			} else {
 				// No previous rework: proceed only when changes are explicitly requested,
-				// there are actionable inline comments, or CI checks are failing.
-				if reviewState.ReviewDecision != "CHANGES_REQUESTED" && !hasActionableComments(reviewState) && !hasFailingChecks {
-					o.log.Infof("ticket %s: skipping rework — no actionable comments or failing checks", ticket.Key)
-					o.emit("  ✓ no actionable review comments or failing checks — skipping")
+				// there are actionable inline comments, CI checks are failing, or there's a merge conflict.
+				if reviewState.ReviewDecision != "CHANGES_REQUESTED" && !hasActionableComments(reviewState) && !hasFailingChecks && !hasConflict {
+					o.log.Infof("ticket %s: skipping rework — no actionable comments, failing checks, or conflicts", ticket.Key)
+					o.emit("  ✓ no actionable review comments, failing checks, or merge conflicts — skipping")
 					continue
 				}
 			}
@@ -300,6 +301,11 @@ func buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace)
 			}
 		}
 		b.WriteString("\nFix all CI failures before push.\n\n")
+	}
+	if review.HasConflict {
+		b.WriteString("### Merge Conflict\n\n")
+		b.WriteString("This PR has a merge conflict with the base branch (main).\n")
+		b.WriteString("Resolve all conflicts by rebasing or merging main into this branch before push.\n\n")
 	}
 	b.WriteString("### Instructions\n")
 	b.WriteString("Address ALL reviewer feedback. For each comment:\n")

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -303,9 +303,7 @@ func buildReworkPrompt(ticket Ticket, review *PRReviewState, repo RepoWorkspace)
 		b.WriteString("\nFix all CI failures before push.\n\n")
 	}
 	if review.HasConflict {
-		b.WriteString("### Merge Conflict\n\n")
-		b.WriteString("This PR has a merge conflict with the base branch (main).\n")
-		b.WriteString("Resolve all conflicts by rebasing or merging main into this branch before push.\n\n")
+		b.WriteString("### Merge Conflict\nResolve conflicts with base branch before push.\n\n")
 	}
 	b.WriteString("### Instructions\n")
 	b.WriteString("Address ALL reviewer feedback. For each comment:\n")

--- a/internal/jira/pr.go
+++ b/internal/jira/pr.go
@@ -39,6 +39,7 @@ type PRReviewState struct {
 	Comments       []PRComment
 	FailingChecks  []CheckRun // check-runs with a failing conclusion (populated by FetchPRReviewComments)
 	HeadRefOid     string     // head commit SHA; included in FetchPRReviewComments to avoid duplicate gh pr view calls
+	HasConflict    bool       // true when PR is CONFLICTING with base branch
 }
 
 // Review represents a single pull request review.
@@ -199,7 +200,26 @@ func FetchPRReviewComments(ctx context.Context, repoPath, prURL string) (*PRRevi
 		rs.FailingChecks = checks
 	}
 
+	// Detect merge conflicts — non-fatal; log and continue on error.
+	conflict, err := HasMergeConflict(ctx, repoPath, rs.Number)
+	if err != nil {
+		logging.Get().Warnf("jira: pr: fetch mergeable for PR #%d (%s) in repo %s: %v", rs.Number, prURL, repoPath, err)
+	} else {
+		rs.HasConflict = conflict
+	}
+
 	return rs, nil
+}
+
+// HasMergeConflict returns true when the PR's mergeable state is "CONFLICTING".
+// UNKNOWN (GitHub hasn't computed it yet) is treated as non-blocking and returns false.
+func HasMergeConflict(ctx context.Context, repoPath string, prNumber int) (bool, error) {
+	out, err := ghExec(ctx, repoPath, "pr", "view", fmt.Sprintf("%d", prNumber),
+		"--json", "mergeable", "--jq", ".mergeable")
+	if err != nil {
+		return false, fmt.Errorf("gh pr view mergeable: %w", err)
+	}
+	return strings.TrimSpace(out) == "CONFLICTING", nil
 }
 
 // FetchPRCheckRuns fetches GitHub check-run results for the head commit of a PR and returns

--- a/internal/jira/pr_test.go
+++ b/internal/jira/pr_test.go
@@ -564,3 +564,79 @@ func TestParseCheckRuns_PreservesURLs(t *testing.T) {
 		t.Errorf("LogsURL = %q, want https://example.com/run/123", runs[0].LogsURL)
 	}
 }
+
+// ── HasMergeConflict ──────────────────────────────────────────────────────────
+
+func TestHasMergeConflict(t *testing.T) {
+	tests := []struct {
+		name      string
+		ghOutput  string
+		ghErr     error
+		wantBool  bool
+		wantErr   bool
+	}{
+		{"conflicting", "CONFLICTING", nil, true, false},
+		{"mergeable", "MERGEABLE", nil, false, false},
+		{"unknown", "UNKNOWN", nil, false, false},
+		{"whitespace trimmed", "CONFLICTING\n", nil, true, false},
+		{"api error", "", fmt.Errorf("gh failed"), false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := ghExec
+			ghExec = func(_ context.Context, _ string, args ...string) (string, error) {
+				return tt.ghOutput, tt.ghErr
+			}
+			defer func() { ghExec = orig }()
+
+			got, err := HasMergeConflict(context.Background(), "/repo", 42)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("HasMergeConflict() err=%v, wantErr=%v", err, tt.wantErr)
+			}
+			if err == nil && got != tt.wantBool {
+				t.Errorf("HasMergeConflict() = %v, want %v", got, tt.wantBool)
+			}
+		})
+	}
+}
+
+func TestFetchPRReviewComments_SetsHasConflict(t *testing.T) {
+	orig := ghExec
+	ghExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		// GraphQL review threads call
+		if contains(args, "graphql") {
+			return `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}`, nil
+		}
+		// check-runs API call
+		if len(args) > 1 && args[0] == "api" && strings.HasPrefix(args[1], "repos/") {
+			return `{"check_runs":[]}`, nil
+		}
+		// mergeable call: gh pr view <N> --json mergeable --jq .mergeable
+		if contains(args, "--jq") {
+			return "CONFLICTING", nil
+		}
+		// First call: gh pr view <url> --json url,state,...
+		if contains(args, "--json") {
+			return `{"url":"https://github.com/org/repo/pull/1","number":1,"state":"OPEN","reviewDecision":"","headRefOid":"abc123","reviews":[],"comments":[]}`, nil
+		}
+		return "", fmt.Errorf("unexpected gh call: %v", args)
+	}
+	defer func() { ghExec = orig }()
+
+	rs, err := FetchPRReviewComments(context.Background(), "/repo", "https://github.com/org/repo/pull/1")
+	if err != nil {
+		t.Fatalf("FetchPRReviewComments: %v", err)
+	}
+	if !rs.HasConflict {
+		t.Error("HasConflict should be true when gh returns CONFLICTING")
+	}
+}
+
+func contains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## VC-65 — Trigger fix-review agent on merge conflicts with principal branch

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-65

### Description

Goal
Expand fix-review trigger conditions to include merge conflicts with the principal branch. Review comments and CI status checks already trigger the agent — this adds the missing third condition.
Current Behavior
ProcessFeedback in internal/jira/feedback.go already triggers the fix-review agent when:
New review comments present (filtered by lastReworkAt)
Failing CI checks (hasFailingChecks / FailingChecks from FetchPRCheckRuns)
Merge conflicts are not detected — a branch silently conflicting with main will never get fixed.
New Trigger Condition
Add merge conflict detection as a third trigger. Detection must be pure Go logic — no LLM involvement in the decision.
ConditionDetection methodNew review commentsExisting (filterNewComments)CI checks failedExisting (FetchPRCheckRuns / FailingChecks)Merge conflict with principal branchNew: gh pr view --json mergeable → CONFLICTINGTask
internal/jira/pr.go — add HasMergeConflict(ctx context.Context, repoPath string, prNumber int) (bool, error) using ghExec to call gh pr view <N> --json mergeable; return true only when mergeable == "CONFLICTING", false for MERGEABLE or UNKNOWN
internal/jira/pr.go — populate PRReviewState.HasConflict bool field from HasMergeConflict inside FetchPRReviewComments (same pattern as FailingChecks; non-fatal — log and continue on error)
internal/jira/feedback.go — add hasConflict := reviewState.HasConflict to the two skip-logic branches (mirror how hasFailingChecks is used); conflicts are always current state, not filtered by lastReworkAt
internal/jira/feedback.go — include conflict context in buildReworkPrompt when hasConflict is true so the agent knows to resolve conflicts against main
Tests — unit tests for HasMergeConflict using ghExec injection; table-driven: CONFLICTING → true, MERGEABLE → false, UNKNOWN → false, API error → error
Acceptance Criteria
Fix-review agent triggered when mergeable == "CONFLICTING", in addition to existing conditions
UNKNOWN mergeable state does not trigger (non-blocking)
No LLM call made to decide whether to trigger
Existing idempotency filter (lastReworkAt) preserved; conflict check bypasses it (same as CI checks)
Unit tests pass with ghExec stubbed
Notes
ghExec is a package-level var in internal/jira/pr.go — use same pattern for HasMergeConflict
gh pr view --json mergeable returns CONFLICTING, MERGEABLE, UNKNOWN — GitHub computes this asynchronously; UNKNOWN means not yet computed, treat as non-blocking
Principal branch = main; no config needed since gh pr view uses the PR's own base branch
CI check trigger already fully implemented (FetchPRCheckRuns, FailingChecks, hasFailingChecks) — do not duplicate

### Acceptance Criteria

Fix-review agent triggered when mergeable == "CONFLICTING", in addition to existing conditions
UNKNOWN mergeable state does not trigger (non-blocking)
No LLM call made to decide whether to trigger
Existing idempotency filter (lastReworkAt) preserved; conflict check bypasses it (same as CI checks)
Unit tests pass with ghExec stubbed
Notes
ghExec is a package-level var in internal/jira/pr.go — use same pattern for HasMergeConflict
gh pr view --json mergeable returns CONFLICTING, MERGEABLE, UNKNOWN — GitHub computes this asynchronously; UNKNOWN means not yet computed, treat as non-blocking
Principal branch = main; no config needed since gh pr view uses the PR's own base branch
CI check trigger already fully implemented (FetchPRCheckRuns, FailingChecks, hasFailingChecks) — do not duplicate

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
