### PR TITLE
[VC-67] Cache Anthropic Usage API responses to avoid rate limiting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	golang.org/x/sync v0.16.0
 	modernc.org/sqlite v1.35.0
 )
 

--- a/internal/usage/anthropic_client.go
+++ b/internal/usage/anthropic_client.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"net/http"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -20,7 +22,13 @@ const (
 	bodyLimitBytes          = 64 * 1024 // 64KB
 	requestTimeout          = 30 * time.Second
 	fallbackUserAgent       = "claude-code/2.1.140"
+	defaultCacheTTL         = 5 * time.Minute
 )
+
+type cacheEntry struct {
+	value    AnthropicQuotaResponse
+	storedAt time.Time
+}
 
 // Sentinel errors for HTTP status mapping.
 var (
@@ -37,6 +45,11 @@ type AnthropicClient struct {
 	httpClient *http.Client
 	store      CredentialStore
 	userAgent  string
+
+	cacheMu  sync.Mutex
+	cache    map[string]cacheEntry
+	cacheTTL time.Duration
+	clockFn  func() time.Time
 }
 
 // Option configures an AnthropicClient.
@@ -70,12 +83,29 @@ func WithUserAgent(ua string) Option {
 	}
 }
 
+// WithCacheTTL sets the cache TTL for FetchQuotas results.
+func WithCacheTTL(d time.Duration) Option {
+	return func(c *AnthropicClient) {
+		c.cacheTTL = d
+	}
+}
+
+// withClockFn sets an injectable clock for tests.
+func withClockFn(fn func() time.Time) Option {
+	return func(c *AnthropicClient) {
+		c.clockFn = fn
+	}
+}
+
 // NewAnthropicClient creates a client with optional configuration.
 func NewAnthropicClient(opts ...Option) *AnthropicClient {
 	c := &AnthropicClient{
 		baseURL:    defaultAnthropicBaseURL,
 		httpClient: &http.Client{Timeout: requestTimeout},
 		userAgent:  claudeCodeUserAgent(),
+		cache:      make(map[string]cacheEntry),
+		cacheTTL:   defaultCacheTTL,
+		clockFn:    time.Now,
 	}
 	c.store = NewTokenDiscovery(&ExecKeychainRunner{})
 
@@ -85,7 +115,28 @@ func NewAnthropicClient(opts ...Option) *AnthropicClient {
 	return c
 }
 
+// cacheKey returns a safe non-reversible key for the given token.
+func cacheKey(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return fmt.Sprintf("%x", h[:8])
+}
+
+// Invalidate clears the cached entry for the current token.
+func (c *AnthropicClient) Invalidate(ctx context.Context) error {
+	token, err := c.store.ReadToken(ctx)
+	if err != nil {
+		return fmt.Errorf("reading token: %w", err)
+	}
+	key := cacheKey(token)
+	c.cacheMu.Lock()
+	delete(c.cache, key)
+	c.cacheMu.Unlock()
+	return nil
+}
+
 // FetchQuotas fetches current quota utilization from the Anthropic usage API.
+// Results are cached for cacheTTL. On HTTP 429, the last cached value is
+// returned if available; otherwise ErrRateLimited is surfaced.
 func (c *AnthropicClient) FetchQuotas(ctx context.Context) (AnthropicQuotaResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
@@ -95,7 +146,35 @@ func (c *AnthropicClient) FetchQuotas(ctx context.Context) (AnthropicQuotaRespon
 		return nil, fmt.Errorf("reading token: %w", err)
 	}
 
-	return c.doRequest(ctx, accessToken)
+	key := cacheKey(accessToken)
+	now := c.clockFn()
+
+	c.cacheMu.Lock()
+	entry, hit := c.cache[key]
+	if hit && now.Before(entry.storedAt.Add(c.cacheTTL)) {
+		c.cacheMu.Unlock()
+		return entry.value, nil
+	}
+	c.cacheMu.Unlock()
+
+	result, err := c.doRequest(ctx, accessToken)
+	if err != nil {
+		if errors.Is(err, ErrRateLimited) {
+			c.cacheMu.Lock()
+			stale, hasCached := c.cache[key]
+			c.cacheMu.Unlock()
+			if hasCached {
+				return stale.value, nil
+			}
+		}
+		return nil, err
+	}
+
+	c.cacheMu.Lock()
+	c.cache[key] = cacheEntry{value: result, storedAt: now}
+	c.cacheMu.Unlock()
+
+	return result, nil
 }
 
 // doRequest performs the HTTP GET and parses the response.

--- a/internal/usage/anthropic_client.go
+++ b/internal/usage/anthropic_client.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -46,10 +48,11 @@ type AnthropicClient struct {
 	store      CredentialStore
 	userAgent  string
 
-	cacheMu  sync.Mutex
-	cache    map[string]cacheEntry
-	cacheTTL time.Duration
-	clockFn  func() time.Time
+	cacheMu     sync.Mutex
+	cache       map[string]cacheEntry
+	cacheTTL    time.Duration
+	clockFn     func() time.Time
+	inFlight    singleflight.Group
 }
 
 // Option configures an AnthropicClient.
@@ -137,6 +140,8 @@ func (c *AnthropicClient) Invalidate(ctx context.Context) error {
 // FetchQuotas fetches current quota utilization from the Anthropic usage API.
 // Results are cached for cacheTTL. On HTTP 429, the last cached value is
 // returned if available; otherwise ErrRateLimited is surfaced.
+// Concurrent cache misses are deduplicated via singleflight so only one
+// upstream call is made; others await and reuse the result.
 func (c *AnthropicClient) FetchQuotas(ctx context.Context) (AnthropicQuotaResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
@@ -157,7 +162,12 @@ func (c *AnthropicClient) FetchQuotas(ctx context.Context) (AnthropicQuotaRespon
 	}
 	c.cacheMu.Unlock()
 
-	result, err := c.doRequest(ctx, accessToken)
+	// Use singleflight to deduplicate concurrent cache misses.
+	// Only one goroutine calls doRequest(); others wait for the result.
+	val, err, _ := c.inFlight.Do(key, func() (interface{}, error) {
+		return c.doRequest(ctx, accessToken)
+	})
+
 	if err != nil {
 		if errors.Is(err, ErrRateLimited) {
 			c.cacheMu.Lock()
@@ -170,6 +180,7 @@ func (c *AnthropicClient) FetchQuotas(ctx context.Context) (AnthropicQuotaRespon
 		return nil, err
 	}
 
+	result := val.(AnthropicQuotaResponse)
 	c.cacheMu.Lock()
 	c.cache[key] = cacheEntry{value: result, storedAt: now}
 	c.cacheMu.Unlock()

--- a/internal/usage/anthropic_client_test.go
+++ b/internal/usage/anthropic_client_test.go
@@ -363,7 +363,9 @@ func TestCache_Invalidate(t *testing.T) {
 }
 
 func TestCache_Concurrent(t *testing.T) {
+	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(validQuotaBody())
 	}))
@@ -386,10 +388,17 @@ func TestCache_Concurrent(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+
 	for i, err := range errs {
 		if err != nil {
 			t.Errorf("goroutine %d: %v", i, err)
 		}
+	}
+
+	// Verify that concurrent calls to cold cache are deduplicated via singleflight.
+	// All 20 goroutines should result in exactly 1 HTTP request, not 20.
+	if calls.Load() != 1 {
+		t.Errorf("server called %d times, want 1 (singleflight deduplication)", calls.Load())
 	}
 }
 

--- a/internal/usage/anthropic_client_test.go
+++ b/internal/usage/anthropic_client_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -202,6 +204,192 @@ func TestParseQuotaResponse_InvalidJSON(t *testing.T) {
 	_, err := parseQuotaResponse([]byte("not json"))
 	if err == nil {
 		t.Fatal("expected error on invalid JSON")
+	}
+}
+
+func TestCache_DefaultTTL(t *testing.T) {
+	c := NewAnthropicClient()
+	if c.cacheTTL != defaultCacheTTL {
+		t.Errorf("cacheTTL = %v, want %v", c.cacheTTL, defaultCacheTTL)
+	}
+}
+
+func TestWithCacheTTL(t *testing.T) {
+	c := NewAnthropicClient(WithCacheTTL(10 * time.Minute))
+	if c.cacheTTL != 10*time.Minute {
+		t.Errorf("cacheTTL = %v, want 10m", c.cacheTTL)
+	}
+}
+
+func TestCache_Hit(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(validQuotaBody())
+	}))
+	defer srv.Close()
+
+	client := NewAnthropicClient(
+		WithBaseURL(srv.URL),
+		WithCredentialStore(&mockStore{access: "tok_cache"}),
+		WithCacheTTL(5*time.Minute),
+	)
+
+	_, err := client.FetchQuotas(context.Background())
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	_, err = client.FetchQuotas(context.Background())
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("server called %d times, want 1", calls.Load())
+	}
+}
+
+func TestCache_Miss_AfterTTL(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(validQuotaBody())
+	}))
+	defer srv.Close()
+
+	now := time.Now()
+	client := NewAnthropicClient(
+		WithBaseURL(srv.URL),
+		WithCredentialStore(&mockStore{access: "tok_ttl"}),
+		WithCacheTTL(1*time.Minute),
+		withClockFn(func() time.Time { return now }),
+	)
+
+	_, _ = client.FetchQuotas(context.Background())
+
+	// Advance clock past TTL.
+	now = now.Add(2 * time.Minute)
+
+	_, err := client.FetchQuotas(context.Background())
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("server called %d times, want 2", calls.Load())
+	}
+}
+
+func TestCache_429_FallbackToCached(t *testing.T) {
+	serve429 := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if serve429 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(validQuotaBody())
+	}))
+	defer srv.Close()
+
+	client := NewAnthropicClient(
+		WithBaseURL(srv.URL),
+		WithCredentialStore(&mockStore{access: "tok_429"}),
+		WithCacheTTL(5*time.Minute),
+	)
+
+	// Prime cache.
+	resp, err := client.FetchQuotas(context.Background())
+	if err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	// Now 429.
+	serve429 = true
+	resp2, err := client.FetchQuotas(context.Background())
+	if err != nil {
+		t.Fatalf("429 should return cached, got error: %v", err)
+	}
+	if len(resp2) != len(resp) {
+		t.Errorf("cached response length mismatch")
+	}
+}
+
+func TestCache_429_NoCacheEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client := NewAnthropicClient(
+		WithBaseURL(srv.URL),
+		WithCredentialStore(&mockStore{access: "tok_429_empty"}),
+	)
+
+	_, err := client.FetchQuotas(context.Background())
+	if !errors.Is(err, ErrRateLimited) {
+		t.Errorf("expected ErrRateLimited, got %v", err)
+	}
+}
+
+func TestCache_Invalidate(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(validQuotaBody())
+	}))
+	defer srv.Close()
+
+	client := NewAnthropicClient(
+		WithBaseURL(srv.URL),
+		WithCredentialStore(&mockStore{access: "tok_inv"}),
+		WithCacheTTL(5*time.Minute),
+	)
+
+	_, _ = client.FetchQuotas(context.Background())
+
+	if err := client.Invalidate(context.Background()); err != nil {
+		t.Fatalf("invalidate: %v", err)
+	}
+
+	_, err := client.FetchQuotas(context.Background())
+	if err != nil {
+		t.Fatalf("after invalidate: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("server called %d times, want 2", calls.Load())
+	}
+}
+
+func TestCache_Concurrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(validQuotaBody())
+	}))
+	defer srv.Close()
+
+	client := NewAnthropicClient(
+		WithBaseURL(srv.URL),
+		WithCredentialStore(&mockStore{access: "tok_concurrent"}),
+		WithCacheTTL(5*time.Minute),
+	)
+
+	var wg sync.WaitGroup
+	const goroutines = 20
+	errs := make([]error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, errs[idx] = client.FetchQuotas(context.Background())
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: %v", i, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## VC-67 — Cache Anthropic Usage API responses to avoid rate limiting

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-67

### Description

Summary
Add an in-memory and on-disk cache layer to internal/usage/AnthropicClient so that repeated calls to FetchQuotas() within a short window do not hit the Anthropic Usage API repeatedly. This prevents hitting rate limits when multiple nightshift components call the client in the same run.
Context
VC-30 implemented AnthropicClient.FetchQuotas() which calls GET https://api.anthropic.com/api/oauth/usage. This endpoint is subject to rate limiting. Under concurrent or frequent polling (daemon mode, multiple projects, stats refresh), the client can trigger HTTP 429 responses.
Design
Add a cache inside AnthropicClient (or as a wrapper CachingAnthropicClient):
TTL: configurable, default 5 minutes (aligned with the shortest quota window — five_hour resets — so staleness is acceptable)
Key: per-token hash (different OAuth tokens = different cache entries)
Storage: in-memory (sync.Mutex + map); no persistence needed across process restarts
On 429: return last cached value if present and not expired; otherwise surface ErrRateLimited
Invalidation: explicit Invalidate() method for tests and forced refresh
Thread-safe: all cache operations under mutex
Acceptance Criteria
[ ] FetchQuotas() returns cached result within TTL without making HTTP request
[ ] Cache miss triggers real HTTP call
[ ] On HTTP 429, cached value returned if available; ErrRateLimited returned if cache empty
[ ] TTL configurable via WithCacheTTL(d time.Duration) option on client construction
[ ] Invalidate() clears cached entry for current token
[ ] Thread-safe under concurrent calls
[ ] Existing tests still pass; new tests cover: cache hit, cache miss, TTL expiry, 429 fallback, concurrent access
[ ] make test && make build passes
Implementation Notes
Extend internal/usage/anthropic_client.go — prefer adding cache fields to existing struct over a new wrapper type unless the wrapper is clearly cleaner
Use time.Now() via injectable clock field for testability
Cache key = sha256(accessToken)[:16] — never log the full token
Agent Workflow
Branch feat/usage-cache from main
Add cache fields + options to AnthropicClient
Wrap FetchQuotas() with cache check/store logic
Handle 429 fallback path
Write tests (httptest, fake clock)
Run make test && make build
Open PR targeting main
Refs: VC-30

### Acceptance Criteria

[ ] FetchQuotas() returns cached result within TTL without making HTTP request
[ ] Cache miss triggers real HTTP call
[ ] On HTTP 429, cached value returned if available; ErrRateLimited returned if cache empty
[ ] TTL configurable via WithCacheTTL(d time.Duration) option on client construction
[ ] Invalidate() clears cached entry for current token
[ ] Thread-safe under concurrent calls
[ ] Existing tests still pass; new tests cover: cache hit, cache miss, TTL expiry, 429 fallback, concurrent access
[ ] make test && make build passes
Implementation Notes
Extend internal/usage/anthropic_client.go — prefer adding cache fields to existing struct over a new wrapper type unless the wrapper is clearly cleaner
Use time.Now() via injectable clock field for testability
Cache key = sha256(accessToken)[:16] — never log the full token
Agent Workflow
Branch feat/usage-cache from main
Add cache fields + options to AnthropicClient
Wrap FetchQuotas() with cache check/store logic
Handle 429 fallback path
Write tests (httptest, fake clock)
Run make test && make build
Open PR targeting main
Refs: VC-30

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
