### PR TITLE
fix(jira): skip pull --rebase in CommitAndPush when remote branch absent

### DIFF
--- a/internal/jira/branch.go
+++ b/internal/jira/branch.go
@@ -50,8 +50,12 @@ func CommitAndPush(ctx context.Context, repoPath, message string) error {
 		return err
 	}
 	// Sync with remote before pushing to avoid non-fast-forward rejection.
-	// Skip if remote branch doesn't exist yet (first push).
-	if exists, _ := remoteRefExists(ctx, repoPath, "refs/remotes/origin/"+branch); exists {
+	// Skip only when the remote branch genuinely does not exist yet (first push).
+	exists, err := remoteRefExists(ctx, repoPath, "refs/remotes/origin/"+branch)
+	if err != nil {
+		return fmt.Errorf("check remote ref before pull --rebase: %w", err)
+	}
+	if exists {
 		if _, pullErr := gitExec(ctx, repoPath, "pull", "--rebase", "origin", branch); pullErr != nil {
 			return fmt.Errorf("pull --rebase before push: %w", pullErr)
 		}

--- a/internal/jira/branch.go
+++ b/internal/jira/branch.go
@@ -50,8 +50,11 @@ func CommitAndPush(ctx context.Context, repoPath, message string) error {
 		return err
 	}
 	// Sync with remote before pushing to avoid non-fast-forward rejection.
-	if _, pullErr := gitExec(ctx, repoPath, "pull", "--rebase", "origin", branch); pullErr != nil {
-		return fmt.Errorf("pull --rebase before push: %w", pullErr)
+	// Skip if remote branch doesn't exist yet (first push).
+	if exists, _ := remoteRefExists(ctx, repoPath, "refs/remotes/origin/"+branch); exists {
+		if _, pullErr := gitExec(ctx, repoPath, "pull", "--rebase", "origin", branch); pullErr != nil {
+			return fmt.Errorf("pull --rebase before push: %w", pullErr)
+		}
 	}
 	if _, err := gitExec(ctx, repoPath, "push", "origin", branch); err != nil {
 		return err

--- a/internal/jira/branch_test.go
+++ b/internal/jira/branch_test.go
@@ -120,6 +120,41 @@ func TestBranchAheadOfBase_MissingBaseRefErrors(t *testing.T) {
 	}
 }
 
+func TestCommitAndPush_FirstPush(t *testing.T) {
+	workDir := setupRemoteRepoWithMain(t)
+	runGit(t, workDir, "checkout", "-b", "feature/VC-99")
+	writeFile(t, workDir, "change.txt", "hello\n")
+
+	err := CommitAndPush(context.Background(), workDir, "feat: VC-99: first commit")
+	if err != nil {
+		t.Fatalf("CommitAndPush (first push) failed: %v", err)
+	}
+
+	// Verify remote branch now exists.
+	runGit(t, workDir, "fetch", "origin")
+	cmd := exec.Command("git", "rev-parse", "--verify", "refs/remotes/origin/feature/VC-99")
+	cmd.Dir = workDir
+	if out, err2 := cmd.CombinedOutput(); err2 != nil {
+		t.Fatalf("remote branch not found after first push: %v\n%s", err2, out)
+	}
+}
+
+func TestCommitAndPush_SubsequentPush(t *testing.T) {
+	workDir := setupRemoteRepoWithMain(t)
+	runGit(t, workDir, "checkout", "-b", "feature/VC-99")
+	writeFile(t, workDir, "change.txt", "hello\n")
+	runGit(t, workDir, "add", "change.txt")
+	runGit(t, workDir, "commit", "-m", "initial commit")
+	runGit(t, workDir, "push", "-u", "origin", "feature/VC-99")
+
+	writeFile(t, workDir, "change.txt", "updated\n")
+
+	err := CommitAndPush(context.Background(), workDir, "feat: VC-99: second commit")
+	if err != nil {
+		t.Fatalf("CommitAndPush (subsequent push) failed: %v", err)
+	}
+}
+
 func setupRemoteRepoWithMain(t *testing.T) string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- `CommitAndPush` was unconditionally running `git pull --rebase origin <branch>` before pushing
- This fails with `fatal: couldn't find remote ref <branch>` on first push of a new branch
- Fix: check `remoteRefExists` first; skip pull if remote branch doesn't exist yet

## Test plan

- [ ] Run `nightshift jira run` on a ticket whose branch has never been pushed — commit phase should succeed
- [ ] Run again on same ticket — pull --rebase still executes on subsequent pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)