### PR TITLE
[VC-72] Add reasoning effort support to ClaudeAgent, CodexAgent, and CopilotAgent

### DIFF
--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -26,7 +26,7 @@ type ExecuteOptions struct {
 	Files   []string      // Optional file paths to include as context
 	Timeout time.Duration // Execution timeout (0 = default)
 	Model           string        // Model to use (optional, uses agent default if empty)
-	ReasoningEffort string        // Reasoning effort (optional, uses CLI default if empty)
+	ReasoningEffort string        // Reasoning effort (optional; precedence: this value, then agent default, then CLI default)
 }
 
 // ExecuteResult holds the outcome of an agent execution.

--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -25,7 +25,8 @@ type ExecuteOptions struct {
 	WorkDir string        // Working directory for execution
 	Files   []string      // Optional file paths to include as context
 	Timeout time.Duration // Execution timeout (0 = default)
-	Model   string        // Model to use (optional, uses agent default if empty)
+	Model           string        // Model to use (optional, uses agent default if empty)
+	ReasoningEffort string        // Reasoning effort (optional, uses CLI default if empty)
 }
 
 // ExecuteResult holds the outcome of an agent execution.

--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -62,6 +62,7 @@ type ClaudeAgent struct {
 	runner     CommandRunner // Command executor (for testing)
 	skipPerms  bool          // Pass --dangerously-skip-permissions
 	model      string        // Default model to use
+	effort     string        // Default reasoning effort
 }
 
 // ClaudeOption configures a ClaudeAgent.
@@ -92,6 +93,13 @@ func WithDangerouslySkipPermissions(enabled bool) ClaudeOption {
 func WithModel(model string) ClaudeOption {
 	return func(a *ClaudeAgent) {
 		a.model = model
+	}
+}
+
+// WithEffort sets the default reasoning effort level.
+func WithEffort(effort string) ClaudeOption {
+	return func(a *ClaudeAgent) {
+		a.effort = effort
 	}
 }
 
@@ -142,6 +150,15 @@ func (a *ClaudeAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execut
 	}
 	if model != "" {
 		args = append(args, "--model", model)
+	}
+
+	// Add reasoning effort if specified
+	effort := opts.ReasoningEffort
+	if effort == "" {
+		effort = a.effort
+	}
+	if effort != "" {
+		args = append(args, "--effort", effort)
 	}
 
 	// Add prompt directly as argument

--- a/internal/agents/claude_test.go
+++ b/internal/agents/claude_test.go
@@ -700,3 +700,45 @@ func TestClaudeAgent_Execute_ModelFromOptions(t *testing.T) {
 		t.Error("expected agent default model to be overridden")
 	}
 }
+
+func TestClaudeAgent_Effort(t *testing.T) {
+	tests := []struct {
+		name         string
+		agentEffort  string
+		optsEffort   string
+		wantEffort   string
+		wantFlag     bool
+	}{
+		{"agent default used", "high", "", "high", true},
+		{"opts override agent default", "high", "max", "max", true},
+		{"opts alone", "", "low", "low", true},
+		{"no effort set", "", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &MockRunner{Stdout: "response", ExitCode: 0}
+			opts := []ClaudeOption{WithRunner(mock)}
+			if tt.agentEffort != "" {
+				opts = append(opts, WithEffort(tt.agentEffort))
+			}
+			agent := NewClaudeAgent(opts...)
+
+			_, err := agent.Execute(context.Background(), ExecuteOptions{
+				Prompt:          "test",
+				ReasoningEffort: tt.optsEffort,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			hasFlag := containsArg(mock.CapturedArgs, "--effort")
+			if hasFlag != tt.wantFlag {
+				t.Errorf("--effort present = %v, want %v (args: %v)", hasFlag, tt.wantFlag, mock.CapturedArgs)
+			}
+			if tt.wantFlag && !containsArg(mock.CapturedArgs, tt.wantEffort) {
+				t.Errorf("expected effort value %q in args %v", tt.wantEffort, mock.CapturedArgs)
+			}
+		})
+	}
+}

--- a/internal/agents/codex.go
+++ b/internal/agents/codex.go
@@ -16,6 +16,7 @@ type CodexAgent struct {
 	runner     CommandRunner // Command executor (for testing)
 	bypassPerm bool          // Pass --dangerously-bypass-approvals-and-sandbox
 	model      string        // Default model to use
+	effort     string        // Default reasoning effort
 }
 
 // CodexOption configures a CodexAgent.
@@ -46,6 +47,13 @@ func WithDangerouslyBypassApprovalsAndSandbox(enabled bool) CodexOption {
 func WithCodexModel(model string) CodexOption {
 	return func(a *CodexAgent) {
 		a.model = model
+	}
+}
+
+// WithCodexEffort sets the default reasoning effort level.
+func WithCodexEffort(effort string) CodexOption {
+	return func(a *CodexAgent) {
+		a.effort = effort
 	}
 }
 
@@ -97,6 +105,15 @@ func (a *CodexAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execute
 	}
 	if model != "" {
 		args = append(args, "--model", model)
+	}
+
+	// Add reasoning effort if specified (codex uses --config key=value form)
+	effort := opts.ReasoningEffort
+	if effort == "" {
+		effort = a.effort
+	}
+	if effort != "" {
+		args = append(args, "--config", "model_reasoning_effort="+effort)
 	}
 
 	// Add prompt directly as argument

--- a/internal/agents/codex_test.go
+++ b/internal/agents/codex_test.go
@@ -482,6 +482,60 @@ func TestCodexAgentDefaultsBypassFlag(t *testing.T) {
 	}
 }
 
+func TestCodexAgent_Effort(t *testing.T) {
+	tests := []struct {
+		name        string
+		agentEffort string
+		optsEffort  string
+		wantEffort  string
+		wantFlag    bool
+	}{
+		{"agent default used", "medium", "", "medium", true},
+		{"opts override agent default", "medium", "high", "high", true},
+		{"opts alone", "", "xhigh", "xhigh", true},
+		{"no effort set", "", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &MockRunner{Stdout: "response", ExitCode: 0}
+			opts := []CodexOption{WithCodexRunner(mock)}
+			if tt.agentEffort != "" {
+				opts = append(opts, WithCodexEffort(tt.agentEffort))
+			}
+			agent := NewCodexAgent(opts...)
+
+			_, err := agent.Execute(context.Background(), ExecuteOptions{
+				Prompt:          "test",
+				ReasoningEffort: tt.optsEffort,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			wantConfigVal := "model_reasoning_effort=" + tt.wantEffort
+			hasFlag := containsArg(mock.CapturedArgs, "--config")
+			hasVal := containsArg(mock.CapturedArgs, wantConfigVal)
+
+			if tt.wantFlag {
+				if !hasFlag {
+					t.Errorf("expected --config in args %v", mock.CapturedArgs)
+				}
+				if !hasVal {
+					t.Errorf("expected %q in args %v", wantConfigVal, mock.CapturedArgs)
+				}
+			} else {
+				// Ensure no model_reasoning_effort config value present
+				for _, a := range mock.CapturedArgs {
+					if strings.Contains(a, "model_reasoning_effort") {
+						t.Errorf("unexpected model_reasoning_effort in args %v", mock.CapturedArgs)
+					}
+				}
+			}
+		})
+	}
+}
+
 // TestCodexAgentExplicitFalseBypassDisablesFlag verifies that explicitly calling
 // WithDangerouslyBypassApprovalsAndSandbox(false) does disable the flag.
 func TestCodexAgentExplicitFalseBypassDisablesFlag(t *testing.T) {

--- a/internal/agents/copilot.go
+++ b/internal/agents/copilot.go
@@ -25,6 +25,7 @@ type CopilotAgent struct {
 	binaryPath           string        // Path to binary: "gh" or "copilot" (default: "gh")
 	dangerouslySkipPerms bool          // Pass --allow-all-tools --allow-all-urls
 	model                string        // Default model to use
+	effort               string        // Default reasoning effort
 	timeout              time.Duration // Default timeout
 	runner               CommandRunner // Command executor (for testing)
 }
@@ -57,6 +58,13 @@ func WithCopilotDefaultTimeout(d time.Duration) CopilotOption {
 func WithCopilotModel(model string) CopilotOption {
 	return func(a *CopilotAgent) {
 		a.model = model
+	}
+}
+
+// WithCopilotEffort sets the default reasoning effort level.
+func WithCopilotEffort(effort string) CopilotOption {
+	return func(a *CopilotAgent) {
+		a.effort = effort
 	}
 }
 
@@ -116,6 +124,16 @@ func (a *CopilotAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execu
 	if model != "" {
 		args = append(args, "--model", model)
 	}
+
+	// Add reasoning effort if specified
+	effort := opts.ReasoningEffort
+	if effort == "" {
+		effort = a.effort
+	}
+	if effort != "" {
+		args = append(args, "--effort", effort)
+	}
+
 	if a.dangerouslySkipPerms {
 		args = append(args, "--allow-all-tools", "--allow-all-urls")
 	}

--- a/internal/agents/copilot_test.go
+++ b/internal/agents/copilot_test.go
@@ -332,6 +332,48 @@ func containsArg(args []string, val string) bool {
 	return false
 }
 
+func TestCopilotAgent_Effort(t *testing.T) {
+	tests := []struct {
+		name        string
+		agentEffort string
+		optsEffort  string
+		wantEffort  string
+		wantFlag    bool
+	}{
+		{"agent default used", "low", "", "low", true},
+		{"opts override agent default", "low", "high", "high", true},
+		{"opts alone", "", "xhigh", "xhigh", true},
+		{"no effort set", "", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &MockRunner{Stdout: "response", ExitCode: 0}
+			opts := []CopilotOption{WithCopilotRunner(mock)}
+			if tt.agentEffort != "" {
+				opts = append(opts, WithCopilotEffort(tt.agentEffort))
+			}
+			agent := NewCopilotAgent(opts...)
+
+			_, err := agent.Execute(context.Background(), ExecuteOptions{
+				Prompt:          "test",
+				ReasoningEffort: tt.optsEffort,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			hasFlag := containsArg(mock.CapturedArgs, "--effort")
+			if hasFlag != tt.wantFlag {
+				t.Errorf("--effort present = %v, want %v (args: %v)", hasFlag, tt.wantFlag, mock.CapturedArgs)
+			}
+			if tt.wantFlag && !containsArg(mock.CapturedArgs, tt.wantEffort) {
+				t.Errorf("expected effort value %q in args %v", tt.wantEffort, mock.CapturedArgs)
+			}
+		})
+	}
+}
+
 func TestCopilotAgent_ExtractJSON(t *testing.T) {
 	agent := NewCopilotAgent()
 


### PR DESCRIPTION
## VC-72 — Add reasoning effort support to ClaudeAgent, CodexAgent, and CopilotAgent

**Jira:** https://sedinfra.atlassian.net/browse/VC-72

### Changes

**`internal/agents/agent.go`**
- `ReasoningEffort string` added to `ExecuteOptions` (overrides agent default if non-empty)

**`internal/agents/claude.go`**
- `effort string` field + `WithEffort()` option
- `Execute()`: appends `--effort <level>` — `opts.ReasoningEffort` wins over `a.effort`

**`internal/agents/codex.go`**
- `effort string` field + `WithCodexEffort()` option
- `Execute()`: appends `--config model_reasoning_effort=<level>`

**`internal/agents/copilot.go`**
- `effort string` field + `WithCopilotEffort()` option
- `Execute()`: appends `--effort <level>`

**Tests** (`claude_test.go`, `codex_test.go`, `copilot_test.go`)
- Table-driven `TestXxxAgent_Effort` per agent, 4 subtests each: agent-default, opts-overrides-agent, opts-only, no-effort-no-flag

### Precedence

`opts.ReasoningEffort` → `a.effort` → no flag (CLI default). Matches existing `Model` precedence pattern.

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*