### PR TITLE
[VC-73] Wire reasoning_effort from config into agent factory functions

### DIFF
--- a/cmd/nightshift/commands/helpers.go
+++ b/cmd/nightshift/commands/helpers.go
@@ -48,6 +48,9 @@ func newClaudeAgentFromConfig(cfg *config.Config, extra ...agents.ClaudeOption) 
 	if cfg.Providers.Claude.Model != "" {
 		opts = append(opts, agents.WithModel(cfg.Providers.Claude.Model))
 	}
+	if cfg.Providers.Claude.ReasoningEffort != "" {
+		opts = append(opts, agents.WithEffort(cfg.Providers.Claude.ReasoningEffort))
+	}
 	opts = append(opts, extra...)
 	return agents.NewClaudeAgent(opts...)
 }
@@ -74,6 +77,9 @@ func newCodexAgentFromConfig(cfg *config.Config, extra ...agents.CodexOption) *a
 	}
 	if cfg.Providers.Codex.Model != "" {
 		opts = append(opts, agents.WithCodexModel(cfg.Providers.Codex.Model))
+	}
+	if cfg.Providers.Codex.ReasoningEffort != "" {
+		opts = append(opts, agents.WithCodexEffort(cfg.Providers.Codex.ReasoningEffort))
 	}
 	opts = append(opts, extra...)
 	return agents.NewCodexAgent(opts...)
@@ -103,6 +109,9 @@ func newCopilotAgentFromConfig(cfg *config.Config, binaryPath string, extra ...a
 	}
 	if cfg.Providers.Copilot.Model != "" {
 		opts = append(opts, agents.WithCopilotModel(cfg.Providers.Copilot.Model))
+	}
+	if cfg.Providers.Copilot.ReasoningEffort != "" {
+		opts = append(opts, agents.WithCopilotEffort(cfg.Providers.Copilot.ReasoningEffort))
 	}
 	opts = append(opts, extra...)
 	return agents.NewCopilotAgent(opts...)

--- a/cmd/nightshift/commands/helpers_test.go
+++ b/cmd/nightshift/commands/helpers_test.go
@@ -1,0 +1,119 @@
+package commands
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/marcus/nightshift/internal/agents"
+	"github.com/marcus/nightshift/internal/config"
+)
+
+// mockRunner captures args for helpers tests.
+type mockRunner struct {
+	captured []string
+}
+
+func (m *mockRunner) Run(_ context.Context, _ string, args []string, _ string, _ string) (string, string, int, error) {
+	m.captured = args
+	return "ok", "", 0, nil
+}
+
+func TestNewClaudeAgentFromConfig_ReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name       string
+		effort     string
+		wantFlag   bool
+		wantEffort string
+	}{
+		{"effort set", "high", true, "high"},
+		{"effort empty", "", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mr := &mockRunner{}
+			cfg := &config.Config{}
+			cfg.Providers.Claude.ReasoningEffort = tt.effort
+
+			a := newClaudeAgentFromConfig(cfg, agents.WithRunner(mr))
+			_, _ = a.Execute(context.Background(), agents.ExecuteOptions{Prompt: "test"})
+
+			hasFlag := slices.Contains(mr.captured, "--effort")
+			if hasFlag != tt.wantFlag {
+				t.Errorf("--effort present = %v, want %v (args: %v)", hasFlag, tt.wantFlag, mr.captured)
+			}
+			if tt.wantFlag && !slices.Contains(mr.captured, tt.wantEffort) {
+				t.Errorf("effort value %q not in args %v", tt.wantEffort, mr.captured)
+			}
+		})
+	}
+}
+
+func TestNewCodexAgentFromConfig_ReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name       string
+		effort     string
+		wantFlag   bool
+		wantEffort string
+	}{
+		{"effort set", "medium", true, "model_reasoning_effort=medium"},
+		{"effort empty", "", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mr := &mockRunner{}
+			cfg := &config.Config{}
+			cfg.Providers.Codex.ReasoningEffort = tt.effort
+
+			a := newCodexAgentFromConfig(cfg, agents.WithCodexRunner(mr))
+			_, _ = a.Execute(context.Background(), agents.ExecuteOptions{Prompt: "test"})
+
+			hasConfig := slices.Contains(mr.captured, "--config")
+			hasVal := slices.Contains(mr.captured, tt.wantEffort)
+			if tt.wantFlag {
+				if !hasConfig {
+					t.Errorf("--config not in args %v", mr.captured)
+				}
+				if !hasVal {
+					t.Errorf("effort value %q not in args %v", tt.wantEffort, mr.captured)
+				}
+			} else {
+				for _, a := range mr.captured {
+					if len(a) > 22 && a[:22] == "model_reasoning_effort" {
+						t.Errorf("unexpected model_reasoning_effort in args %v", mr.captured)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestNewCopilotAgentFromConfig_ReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name       string
+		effort     string
+		wantFlag   bool
+		wantEffort string
+	}{
+		{"effort set", "xhigh", true, "xhigh"},
+		{"effort empty", "", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mr := &mockRunner{}
+			cfg := &config.Config{}
+			cfg.Providers.Copilot.ReasoningEffort = tt.effort
+
+			a := newCopilotAgentFromConfig(cfg, "", agents.WithCopilotRunner(mr))
+			_, _ = a.Execute(context.Background(), agents.ExecuteOptions{Prompt: "test"})
+
+			hasFlag := slices.Contains(mr.captured, "--effort")
+			if hasFlag != tt.wantFlag {
+				t.Errorf("--effort present = %v, want %v (args: %v)", hasFlag, tt.wantFlag, mr.captured)
+			}
+			if tt.wantFlag && !slices.Contains(mr.captured, tt.wantEffort) {
+				t.Errorf("effort value %q not in args %v", tt.wantEffort, mr.captured)
+			}
+		})
+	}
+}

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -502,6 +502,9 @@ func createJiraAgent(cfg *config.Config, phase jira.PhaseConfig) (agents.Agent, 
 		if m := phase.Model; m != "" {
 			extra = append(extra, agents.WithCodexModel(m))
 		}
+		if phase.ReasoningEffort != "" {
+			extra = append(extra, agents.WithCodexEffort(phase.ReasoningEffort))
+		}
 		if timeout > 0 {
 			extra = append(extra, agents.WithCodexDefaultTimeout(timeout))
 		}
@@ -518,6 +521,9 @@ func createJiraAgent(cfg *config.Config, phase jira.PhaseConfig) (agents.Agent, 
 		if m := phase.Model; m != "" {
 			extra = append(extra, agents.WithCopilotModel(m))
 		}
+		if phase.ReasoningEffort != "" {
+			extra = append(extra, agents.WithCopilotEffort(phase.ReasoningEffort))
+		}
 		if timeout > 0 {
 			extra = append(extra, agents.WithCopilotDefaultTimeout(timeout))
 		}
@@ -533,6 +539,9 @@ func createJiraAgent(cfg *config.Config, phase jira.PhaseConfig) (agents.Agent, 
 		var extra []agents.ClaudeOption
 		if m := phase.Model; m != "" {
 			extra = append(extra, agents.WithModel(m))
+		}
+		if phase.ReasoningEffort != "" {
+			extra = append(extra, agents.WithEffort(phase.ReasoningEffort))
 		}
 		if timeout > 0 {
 			extra = append(extra, agents.WithDefaultTimeout(timeout))

--- a/cmd/nightshift/commands/jira_run_test.go
+++ b/cmd/nightshift/commands/jira_run_test.go
@@ -239,6 +239,47 @@ func TestCreateJiraAgent_CaseInsensitiveProvider(t *testing.T) {
 	}
 }
 
+func TestCreateJiraAgent_ReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name     string
+		phase    jira.PhaseConfig
+		wantName string
+	}{
+		{
+			name:     "claude with effort",
+			phase:    jira.PhaseConfig{Provider: "claude", ReasoningEffort: "high"},
+			wantName: "claude",
+		},
+		{
+			name:     "codex with effort",
+			phase:    jira.PhaseConfig{Provider: "codex", ReasoningEffort: "medium"},
+			wantName: "codex",
+		},
+		{
+			name:     "copilot with effort",
+			phase:    jira.PhaseConfig{Provider: "copilot", ReasoningEffort: "low"},
+			wantName: "copilot",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			a, err := createJiraAgent(cfg, tt.phase)
+			if err != nil {
+				if strings.Contains(err.Error(), "not found in PATH") {
+					t.Skipf("%s CLI not available: %v", tt.wantName, err)
+				}
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if a.Name() != tt.wantName {
+				t.Errorf("agent name = %q, want %q", a.Name(), tt.wantName)
+			}
+		})
+	}
+}
+
+
 func TestRunJira_MissingConfig(t *testing.T) {
 	// Validate() catches missing required fields.
 	cfg := jira.JiraConfig{}


### PR DESCRIPTION
## VC-73 — Wire reasoning_effort from config into agent factory functions

**Jira:** https://sedinfra.atlassian.net/browse/VC-73

### Changes

**`cmd/nightshift/commands/helpers.go`**
- `newClaudeAgentFromConfig`: appends `WithEffort()` when `cfg.Providers.Claude.ReasoningEffort` non-empty
- `newCodexAgentFromConfig`: appends `WithCodexEffort()` when `cfg.Providers.Codex.ReasoningEffort` non-empty
- `newCopilotAgentFromConfig`: appends `WithCopilotEffort()` when `cfg.Providers.Copilot.ReasoningEffort` non-empty

**`cmd/nightshift/commands/jira_run.go`**
- `createJiraAgent()`: passes `phase.ReasoningEffort` to matching `With*Effort()` for all three provider cases (codex, copilot, claude/default)

**`cmd/nightshift/commands/helpers_test.go`** _(new file)_
- Table-driven tests for each factory using injected `mockRunner` to verify `--effort` / `--config model_reasoning_effort=` flags in captured args

**`cmd/nightshift/commands/jira_run_test.go`**
- `TestCreateJiraAgent_ReasoningEffort`: verifies no error when effort is set for each provider (skips if CLI not in PATH)

### Notes

- Wiring is construction-time only via `With*Effort()` — no `ExecuteOptions.ReasoningEffort` call sites changed
- Empty effort → no flag emitted (CLI uses its own default)

### Depends on

- VC-70 (`ProviderConfig.ReasoningEffort`)
- VC-71 (`PhaseConfig.ReasoningEffort`)
- VC-72 (agent `With*Effort()` options)

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*