### PR TITLE
Enable CI build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,16 @@ jobs:
         with:
           go-version: '1.23'
 
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Download dependencies
         run: go mod download
 
@@ -45,6 +55,16 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Download dependencies
         run: go mod download

--- a/docs/BUILD_OPTIMIZATIONS.md
+++ b/docs/BUILD_OPTIMIZATIONS.md
@@ -1,0 +1,6 @@
+Build optimizations added in this branch
+
+- CI: added actions/cache for Go modules and Go build cache to speed up dependency download and build.
+- Local verification: ran 'go test ./...' successfully. Measure builds by timing 'go test' or CI job timings before/after.
+
+To revert: remove the cache steps from .github/workflows/ci.yml and push a fix.


### PR DESCRIPTION
This PR enables actions/cache in CI to speed up Go dependency download by caching ~/go/pkg/mod and the Go build cache.\n\nChanges: modified .github/workflows/ci.yml to add a cache step for modules in test and lint jobs.\n\nLocal verification: ran 'go test ./...' locally, all tests passed.\n\nReturn-to-branch file: doc/github/nightshift/return-to-branch.txt\n\nNightshift-Task: build-optimize\nNightshift-Ref: https://github.com/marcus/nightshift