### PR TITLE
fix(agents): protect critical prompt instructions from compression

### DIFF
--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -28,6 +28,13 @@ type ExecuteOptions struct {
 	Model           string        // Model to use (optional, uses agent default if empty)
 	ReasoningEffort string        // Reasoning effort (optional; precedence: this value, then agent default, then CLI default)
 	Compression     *CompressConfig // nil = no compression
+	// PromptSuffix is appended to Prompt after compression runs, so critical
+	// output-format instructions are never passed through the compressor.
+	PromptSuffix    string
+	// OnCompress, if provided, is invoked immediately when prompt compression completes
+	// with the CompressStats before the agent process is spawned. This allows UIs
+	// to show compression metrics while the agent runs.
+	OnCompress      func(*CompressStats)
 }
 
 // ExecuteResult holds the outcome of an agent execution.

--- a/internal/agents/compress.go
+++ b/internal/agents/compress.go
@@ -110,13 +110,20 @@ func compressViaAgent(ctx context.Context, cfg *CompressConfig, prompt string) (
 // writePromptFile writes the (optionally compressed) prompt and any file context
 // to a temp file. Returns the file path, cleanup func, and compression stats (nil = no compression).
 func writePromptFile(ctx context.Context, opts ExecuteOptions) (path string, cleanup func(), stats *CompressStats, err error) {
-	prompt, stats := CompressPrompt(ctx, opts.Compression, opts.Prompt)
+	prompt, compStats := CompressPrompt(ctx, opts.Compression, opts.Prompt)
+	// Notify caller immediately when compression completes so UIs can react
+	if compStats != nil && opts.OnCompress != nil {
+		opts.OnCompress(compStats)
+	}
 
 	f, ferr := os.CreateTemp("", "nightshift-prompt-*.md")
 	if ferr != nil {
 		return "", func() {}, nil, fmt.Errorf("create prompt file: %w", ferr)
 	}
 
+	if opts.PromptSuffix != "" {
+		prompt = prompt + opts.PromptSuffix
+	}
 	if _, ferr = f.WriteString(prompt); ferr != nil {
 		_ = f.Close()
 		_ = os.Remove(f.Name())
@@ -137,5 +144,5 @@ func writePromptFile(ctx context.Context, opts ExecuteOptions) (path string, cle
 	}
 
 	name := f.Name()
-	return name, func() { _ = os.Remove(name) }, stats, nil
+	return name, func() { _ = os.Remove(name) }, compStats, nil
 }

--- a/internal/jira/validation.go
+++ b/internal/jira/validation.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/marcus/nightshift/internal/agents"
+	"github.com/marcus/nightshift/internal/logging"
 )
 
 const validationTimeout = 2 * time.Minute
@@ -30,8 +31,14 @@ func ValidateTicket(ctx context.Context, agent agents.Agent, ticket Ticket, comp
 	defer cancel()
 
 	opts := agents.ExecuteOptions{
-		Prompt:      buildValidationPrompt(ticket),
-		Compression: compression,
+		Prompt:       buildValidationContent(ticket),
+		PromptSuffix: validationFormatInstructions,
+		Compression:  compression,
+		OnCompress: func(s *agents.CompressStats) {
+			// Log compression metrics immediately so they appear while the agent runs.
+			logger := logging.Component("jira.validation")
+			logger.Infof("validation compress %d→%d chars (-%d%%) via %s", s.OriginalLen, s.CompressedLen, s.ReductionPct, s.Provider)
+		},
 	}
 	result, err := agent.Execute(ctx, opts)
 	if err != nil {
@@ -45,9 +52,18 @@ func ValidateTicket(ctx context.Context, agent agents.Agent, ticket Ticket, comp
 	return vr, nil
 }
 
-// buildValidationPrompt constructs the prompt sent to the LLM validator.
-// ~42% word reduction vs original (measured: 72 → 42 words static template).
-func buildValidationPrompt(ticket Ticket) string {
+// validationFormatInstructions is the critical output-format spec appended after
+// compression so the compressor cannot mangle the JSON schema.
+const validationFormatInstructions = `
+Respond in JSON only (no markdown, no code fences):
+{"valid": bool, "score": 1-10, "issues": [...], "missing": [...], "suggestions": [...]}
+
+Valid if score >= 6 and no critical issues.`
+
+// buildValidationContent returns the compressible portion of the validation prompt
+// (ticket data only). validationFormatInstructions is appended separately via
+// ExecuteOptions.PromptSuffix so it is never passed through the compressor.
+func buildValidationContent(ticket Ticket) string {
 	var comments strings.Builder
 	for _, c := range ticket.Comments {
 		fmt.Fprintf(&comments, "- %s: %s\n", c.Author, c.Body)
@@ -61,18 +77,19 @@ Description: %s
 Acceptance Criteria: %s
 Comments:
 %s
-Criteria: CLEAR OBJECTIVE, SUFFICIENT CONTEXT, ACCEPTANCE CRITERIA, SCOPE, NO AMBIGUITY
-
-Respond in JSON only (no markdown, no code fences):
-{"valid": bool, "score": 1-10, "issues": [...], "missing": [...], "suggestions": [...]}
-
-Valid if score >= 6 and no critical issues.`,
+Criteria: CLEAR OBJECTIVE, SUFFICIENT CONTEXT, ACCEPTANCE CRITERIA, SCOPE, NO AMBIGUITY`,
 		ticket.Key,
 		ticket.Summary,
 		ticket.Description,
 		ticket.AcceptanceCriteria,
 		comments.String(),
 	)
+}
+
+// buildValidationPrompt returns the full prompt (content + format instructions).
+// Used by tests and callers that do not use compression.
+func buildValidationPrompt(ticket Ticket) string {
+	return buildValidationContent(ticket) + validationFormatInstructions
 }
 
 // parseValidationResponse parses the LLM output into a ValidationResult.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -455,16 +455,15 @@ func (o *Orchestrator) annotatePR(ctx context.Context, prURL string, task *tasks
 
 // plan spawns the plan agent to create an execution plan.
 func (o *Orchestrator) plan(ctx context.Context, task *tasks.Task, workDir string) (*PlanOutput, *agents.CompressStats, error) {
-	prompt := o.buildPlanPrompt(task)
-
 	ctx, cancel := context.WithTimeout(ctx, o.config.AgentTimeout)
 	defer cancel()
 
 	execResult, err := o.agent.Execute(ctx, agents.ExecuteOptions{
-		Prompt:      prompt,
-		WorkDir:     workDir,
-		Timeout:     o.config.AgentTimeout,
-		Compression: o.config.Compression,
+		Prompt:       o.buildPlanContent(task),
+		PromptSuffix: taskPlanOutputSuffix,
+		WorkDir:      workDir,
+		Timeout:      o.config.AgentTimeout,
+		Compression:  o.config.Compression,
 	})
 	if err != nil {
 		if execResult != nil && execResult.Output != "" {
@@ -505,8 +504,6 @@ func (o *Orchestrator) plan(ctx context.Context, task *tasks.Task, workDir strin
 
 // implement spawns the implement agent to execute the plan.
 func (o *Orchestrator) implement(ctx context.Context, task *tasks.Task, plan *PlanOutput, workDir string, iteration int) (*ImplementOutput, *agents.CompressStats, error) {
-	prompt := o.buildImplementPrompt(task, plan, iteration)
-
 	ctx, cancel := context.WithTimeout(ctx, o.config.AgentTimeout)
 	defer cancel()
 
@@ -522,11 +519,12 @@ func (o *Orchestrator) implement(ctx context.Context, task *tasks.Task, plan *Pl
 	}
 
 	execResult, err := o.agent.Execute(ctx, agents.ExecuteOptions{
-		Prompt:      prompt,
-		WorkDir:     workDir,
-		Files:       files,
-		Timeout:     o.config.AgentTimeout,
-		Compression: o.config.Compression,
+		Prompt:       o.buildImplementContent(task, plan, iteration),
+		PromptSuffix: taskImplementOutputSuffix,
+		WorkDir:      workDir,
+		Files:        files,
+		Timeout:      o.config.AgentTimeout,
+		Compression:  o.config.Compression,
 	})
 	if err != nil {
 		if execResult != nil && execResult.Output != "" {
@@ -620,8 +618,6 @@ func filterExistingFiles(files []string, workDir string) ([]string, []string) {
 
 // review spawns the review agent to check the implementation.
 func (o *Orchestrator) review(ctx context.Context, task *tasks.Task, impl *ImplementOutput, workDir string) (*ReviewOutput, *agents.CompressStats, error) {
-	prompt := o.buildReviewPrompt(task, impl)
-
 	ctx, cancel := context.WithTimeout(ctx, o.config.AgentTimeout)
 	defer cancel()
 
@@ -637,11 +633,12 @@ func (o *Orchestrator) review(ctx context.Context, task *tasks.Task, impl *Imple
 	}
 
 	execResult, err := o.agent.Execute(ctx, agents.ExecuteOptions{
-		Prompt:      prompt,
-		WorkDir:     workDir,
-		Files:       files,
-		Timeout:     o.config.AgentTimeout,
-		Compression: o.config.Compression,
+		Prompt:       o.buildReviewContent(task, impl),
+		PromptSuffix: taskReviewOutputSuffix,
+		WorkDir:      workDir,
+		Files:        files,
+		Timeout:      o.config.AgentTimeout,
+		Compression:  o.config.Compression,
 	})
 	if err != nil {
 		if execResult != nil && execResult.Output != "" {
@@ -735,7 +732,23 @@ func (o *Orchestrator) PlanPrompt(task *tasks.Task) string {
 	return o.buildPlanPrompt(task)
 }
 
+// taskPlanOutputSuffix is the JSON schema for plan output — protected from
+// compression via PromptSuffix so the machine-readable spec is never mangled.
+const taskPlanOutputSuffix = `
+7. Output only valid JSON (no markdown, no extra text). The output is read by a machine. Use this schema:
+
+{
+  "steps": ["step1", "step2", ...],
+  "files": ["file1.go", "file2.go", ...],
+  "description": "overall approach"
+}
+`
+
 func (o *Orchestrator) buildPlanPrompt(task *tasks.Task) string {
+	return o.buildPlanContent(task) + taskPlanOutputSuffix
+}
+
+func (o *Orchestrator) buildPlanContent(task *tasks.Task) string {
 	branchInstruction := ""
 	if o.runMeta != nil && o.runMeta.Branch != "" {
 		branchInstruction = fmt.Sprintf("\n   Create your feature branch from `%s`.", o.runMeta.Branch)
@@ -757,18 +770,25 @@ Description: %s
    Nightshift-Ref: https://github.com/marcus/nightshift
 4. Analyze the task requirements
 5. Identify files that need to be modified
-6. Create step-by-step implementation plan
-7. Output only valid JSON (no markdown, no extra text). The output is read by a machine. Use this schema:
+6. Create step-by-step implementation plan`, task.ID, task.Title, task.Description, branchInstruction, task.Type)
+}
+
+// taskImplementOutputSuffix is the JSON schema for implement output — protected
+// from compression via PromptSuffix.
+const taskImplementOutputSuffix = `
+5. Output a summary as JSON:
 
 {
-  "steps": ["step1", "step2", ...],
-  "files": ["file1.go", "file2.go", ...],
-  "description": "overall approach"
+  "files_modified": ["file1.go", ...],
+  "summary": "what was done"
 }
-`, task.ID, task.Title, task.Description, branchInstruction, task.Type)
-}
+`
 
 func (o *Orchestrator) buildImplementPrompt(task *tasks.Task, plan *PlanOutput, iteration int) string {
+	return o.buildImplementContent(task, plan, iteration) + taskImplementOutputSuffix
+}
+
+func (o *Orchestrator) buildImplementContent(task *tasks.Task, plan *PlanOutput, iteration int) string {
 	iterationNote := ""
 	if iteration > 1 {
 		iterationNote = fmt.Sprintf("\n\n## Note\nThis is iteration %d. Previous attempts did not pass review. Pay attention to the feedback in the plan description.", iteration)
@@ -800,17 +820,28 @@ Description: %s
    Nightshift-Ref: https://github.com/marcus/nightshift
 2. Implement the plan step by step
 3. Make all necessary code changes
-4. Ensure tests pass
-5. Output a summary as JSON:
+4. Ensure tests pass`, task.ID, task.Title, task.Description, plan.Description, plan.Steps, iterationNote, branchInstruction, task.Type)
+}
+
+// taskReviewOutputSuffix is the JSON schema for review output — protected from
+// compression via PromptSuffix.
+const taskReviewOutputSuffix = `
+5. Output your review as JSON:
 
 {
-  "files_modified": ["file1.go", ...],
-  "summary": "what was done"
-}
-`, task.ID, task.Title, task.Description, plan.Description, plan.Steps, iterationNote, branchInstruction, task.Type)
+  "passed": true/false,
+  "feedback": "detailed feedback",
+  "issues": ["issue1", "issue2", ...]
 }
 
+Set "passed" to true ONLY if the implementation is correct and complete.
+`
+
 func (o *Orchestrator) buildReviewPrompt(task *tasks.Task, impl *ImplementOutput) string {
+	return o.buildReviewContent(task, impl) + taskReviewOutputSuffix
+}
+
+func (o *Orchestrator) buildReviewContent(task *tasks.Task, impl *ImplementOutput) string {
 	return fmt.Sprintf(`You are a code review agent. Review this implementation.
 
 ## Task
@@ -828,17 +859,7 @@ Description: %s
 1. Confirm work was done on a branch (not primary) and is ready for a PR
 2. Check if implementation meets task requirements
 3. Verify code quality and correctness
-4. Check for bugs or issues
-5. Output your review as JSON:
-
-{
-  "passed": true/false,
-  "feedback": "detailed feedback",
-  "issues": ["issue1", "issue2", ...]
-}
-
-Set "passed" to true ONLY if the implementation is correct and complete.
-`, task.ID, task.Title, task.Description, impl.Summary, impl.FilesModified)
+4. Check for bugs or issues`, task.ID, task.Title, task.Description, impl.Summary, impl.FilesModified)
 }
 
 // prURLPattern matches standard GitHub pull request URLs.


### PR DESCRIPTION
## Summary

- Compression was mangling JSON output-format specs embedded in prompts, causing parse failures and incorrect agent behavior
- Added `PromptSuffix string` to `ExecuteOptions` — appended **after** compression, so critical format instructions are never passed through the compressor
- Applied to all prompts with machine-readable output schemas:
  - Validation prompt: JSON `{valid, score, issues, missing, suggestions}`
  - Task plan prompt: JSON `{steps, files, description}`
  - Task implement prompt: JSON `{files_modified, summary}`
  - Task review prompt: JSON `{passed, feedback, issues}`
- Jira plan/implement/rework prompts output plain text — no fix needed there
- Cleaned up a broken `OnCompress` closure in task orchestrator `plan()` that referenced `result` out of scope

## How it works

Before: entire prompt (content + JSON schema) → compressor → agent  
After: content → compressor → compressed content + JSON schema appended → agent

The format instructions are always delivered intact regardless of compression.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/...` — 1056 passed
- [ ] Manual: run `nightshift run` and `nightshift jira run` with compression enabled, verify all phases produce valid structured output

🤖 Generated with [Claude Code](https://claude.com/claude-code)