### PR TITLE
[VC-77] Setup wizard step 8 (task selection): wrong pre-selection and height overflow

### DIFF
--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -229,6 +229,8 @@ type setupModel struct {
 	taskItems          []taskItem
 	taskErr            string
 	preset             setup.Preset
+	windowWidth        int
+	windowHeight       int
 
 	scheduleMode      string
 	scheduleCursor    int
@@ -364,7 +366,23 @@ const (
 	pathActionAdd
 )
 
-const taskViewportHeight = 15
+// calculateTaskViewportHeight computes the number of task items to display
+// based on terminal height, reserving space for header/footer/indicators.
+// Returns at least 5 items even on small terminals.
+func (m *setupModel) calculateTaskViewportHeight() int {
+	// Reserve space: ~8 lines for header/footer/indicators
+	// (title, instruction, above/below indicators, error, footer)
+	const headerFooterReserved = 8
+	if m.windowHeight > 0 {
+		h := m.windowHeight - headerFooterReserved
+		if h < 5 {
+			h = 5 // minimum visible items
+		}
+		return h
+	}
+	// Fallback to original fixed height if window size not yet known
+	return 15
+}
 
 var (
 	styleHeader = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("69"))
@@ -662,6 +680,9 @@ func (m *setupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			codexModels = opts
 			m.codexModelIdx = modelIndex(codexModels, m.cfg.Providers.Codex.Model)
 		}
+	case tea.WindowSizeMsg:
+		m.windowWidth = msg.Width
+		m.windowHeight = msg.Height
 	}
 
 	return m, cmd
@@ -786,8 +807,9 @@ func (m *setupModel) View() string {
 			b.WriteString(styleWarn.Render("No task definitions found."))
 			b.WriteString("\n")
 		} else {
+			vh := m.calculateTaskViewportHeight()
 			start := m.taskViewportOffset
-			end := start + taskViewportHeight
+			end := start + vh
 			if end > len(m.taskItems) {
 				end = len(m.taskItems)
 			}
@@ -939,6 +961,8 @@ func (m *setupModel) View() string {
 func (m *setupModel) setStep(step setupStep) tea.Cmd {
 	m.step = step
 	switch step {
+	case stepTaskSelect:
+		m.taskViewportOffset = 0
 	case stepJira:
 		m.jiraSubStep = 0
 		m.jiraErr = ""
@@ -1218,11 +1242,12 @@ func (m *setupModel) handleTaskInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.setStep(stepSchedule)
 	}
 	// Clamp viewport so cursor stays visible.
+	vh := m.calculateTaskViewportHeight()
 	if m.taskCursor < m.taskViewportOffset {
 		m.taskViewportOffset = m.taskCursor
 	}
-	if m.taskCursor >= m.taskViewportOffset+taskViewportHeight {
-		m.taskViewportOffset = m.taskCursor - taskViewportHeight + 1
+	if m.taskCursor >= m.taskViewportOffset+vh {
+		m.taskViewportOffset = m.taskCursor - vh + 1
 	}
 	return m, nil
 }

--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -229,8 +229,7 @@ type setupModel struct {
 	taskItems          []taskItem
 	taskErr            string
 	preset             setup.Preset
-	windowWidth        int
-	windowHeight       int
+	windowHeight int
 
 	scheduleMode      string
 	scheduleCursor    int
@@ -380,8 +379,8 @@ func (m *setupModel) calculateTaskViewportHeight() int {
 		}
 		return h
 	}
-	// Fallback to original fixed height if window size not yet known
-	return 15
+	// Fallback before first WindowSizeMsg — conservative to avoid initial overflow
+	return 10
 }
 
 var (
@@ -681,7 +680,6 @@ func (m *setupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.codexModelIdx = modelIndex(codexModels, m.cfg.Providers.Codex.Model)
 		}
 	case tea.WindowSizeMsg:
-		m.windowWidth = msg.Width
 		m.windowHeight = msg.Height
 	}
 

--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -223,11 +223,12 @@ type setupModel struct {
 	codexEffortIdx   int
 	copilotEffortIdx int
 
-	taskPresetCursor int
-	taskCursor       int
-	taskItems        []taskItem
-	taskErr          string
-	preset           setup.Preset
+	taskPresetCursor   int
+	taskCursor         int
+	taskViewportOffset int
+	taskItems          []taskItem
+	taskErr            string
+	preset             setup.Preset
 
 	scheduleMode      string
 	scheduleCursor    int
@@ -362,6 +363,8 @@ const (
 	pathActionSkip pathAction = iota
 	pathActionAdd
 )
+
+const taskViewportHeight = 15
 
 var (
 	styleHeader = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("69"))
@@ -783,7 +786,16 @@ func (m *setupModel) View() string {
 			b.WriteString(styleWarn.Render("No task definitions found."))
 			b.WriteString("\n")
 		} else {
-			for i, item := range m.taskItems {
+			start := m.taskViewportOffset
+			end := start + taskViewportHeight
+			if end > len(m.taskItems) {
+				end = len(m.taskItems)
+			}
+			if start > 0 {
+				fmt.Fprintf(&b, "  ... (%d more above)\n", start)
+			}
+			for i := start; i < end; i++ {
+				item := m.taskItems[i]
 				cursor := " "
 				if i == m.taskCursor {
 					cursor = ">"
@@ -793,6 +805,9 @@ func (m *setupModel) View() string {
 					check = "x"
 				}
 				fmt.Fprintf(&b, " %s [%s] %-22s %s\n", cursor, check, item.def.Type, item.def.Name)
+			}
+			if end < len(m.taskItems) {
+				fmt.Fprintf(&b, "  ... (%d more below)\n", len(m.taskItems)-end)
 			}
 		}
 		if m.taskErr != "" {
@@ -1142,6 +1157,7 @@ func (m *setupModel) handlePresetInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		presets := []setup.Preset{setup.PresetBalanced, setup.PresetSafe, setup.PresetAggressive}
 		m.preset = presets[m.taskPresetCursor]
 		m.taskItems = makeTaskItems(m.cfg, m.projects, m.preset)
+		m.taskViewportOffset = 0
 		return m, m.setStep(stepTaskSelect)
 	}
 	return m, nil
@@ -1200,6 +1216,13 @@ func (m *setupModel) handleTaskInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.applyTasks()
 		m.taskErr = ""
 		return m, m.setStep(stepSchedule)
+	}
+	// Clamp viewport so cursor stays visible.
+	if m.taskCursor < m.taskViewportOffset {
+		m.taskViewportOffset = m.taskCursor
+	}
+	if m.taskCursor >= m.taskViewportOffset+taskViewportHeight {
+		m.taskViewportOffset = m.taskCursor - taskViewportHeight + 1
 	}
 	return m, nil
 }
@@ -2199,10 +2222,15 @@ func scheduleFieldHelp(cursor int, mode string) string {
 
 func makeTaskItems(cfg *config.Config, projects []string, preset setup.Preset) []taskItem {
 	defs := tasks.AllDefinitionsSorted()
-	signals := setup.DetectRepoSignals(projects)
-	selected := setup.PresetTasks(preset, defs, signals)
-	for _, enabled := range cfg.Tasks.Enabled {
-		selected[tasks.TaskType(enabled)] = true
+	var selected map[tasks.TaskType]bool
+	if len(cfg.Tasks.Enabled) > 0 {
+		selected = make(map[tasks.TaskType]bool, len(cfg.Tasks.Enabled))
+		for _, enabled := range cfg.Tasks.Enabled {
+			selected[tasks.TaskType(enabled)] = true
+		}
+	} else {
+		signals := setup.DetectRepoSignals(projects)
+		selected = setup.PresetTasks(preset, defs, signals)
 	}
 
 	items := make([]taskItem, 0, len(defs))

--- a/cmd/nightshift/commands/setup_test.go
+++ b/cmd/nightshift/commands/setup_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -75,6 +76,55 @@ func TestHandleTaskInput_NoTasksDoesNotPanic(t *testing.T) {
 	m := &setupModel{}
 	if _, _ = m.handleTaskInput(tea.KeyMsg{Type: tea.KeySpace}); m.taskErr != "" {
 		t.Fatalf("taskErr = %q, want empty for non-enter input", m.taskErr)
+	}
+}
+
+func TestHandleTaskInput_ViewportOffsetClamps(t *testing.T) {
+	// Create a model with many tasks and simulate cursor navigation
+	// to verify viewport offset advances and clamps correctly.
+	m := &setupModel{
+		windowHeight: 30, // terminal height
+		taskItems:    make([]taskItem, 0, 50),
+	}
+
+	// Create 50 dummy tasks
+	for i := 0; i < 50; i++ {
+		m.taskItems = append(m.taskItems, taskItem{
+			def:      tasks.TaskDefinition{Type: tasks.TaskType("task-" + fmt.Sprintf("%02d", i))},
+			selected: false,
+		})
+	}
+
+	// calculateTaskViewportHeight should return ~22 (30 - 8 reserved)
+	vh := m.calculateTaskViewportHeight()
+	if vh < 5 {
+		t.Fatalf("calculateTaskViewportHeight = %d, want >= 5", vh)
+	}
+
+	// Initial state: cursor at 0, viewport starts at 0
+	if m.taskViewportOffset != 0 {
+		t.Fatalf("initial taskViewportOffset = %d, want 0", m.taskViewportOffset)
+	}
+
+	// Move down past the viewport: cursor goes beyond offset+vh
+	for i := 0; i < vh+5; i++ {
+		m.handleTaskInput(tea.KeyMsg{Type: tea.KeyDown})
+	}
+
+	// After moving past viewport, offset should advance to keep cursor visible
+	expectedOffset := m.taskCursor - vh + 1
+	if m.taskViewportOffset != expectedOffset {
+		t.Fatalf("after moving down past viewport, offset = %d, want %d", m.taskViewportOffset, expectedOffset)
+	}
+
+	// Move back up to position 5: offset should clamp down when cursor reaches viewport start
+	for i := 0; i < vh; i++ { // Move back to position vh+5-vh = 5
+		m.handleTaskInput(tea.KeyMsg{Type: tea.KeyUp})
+	}
+
+	// At cursor position 5, offset should clamp to 5 (since 5 < offset)
+	if m.taskViewportOffset != m.taskCursor {
+		t.Fatalf("after moving up to top of view, offset = %d, want %d (cursor position)", m.taskViewportOffset, m.taskCursor)
 	}
 }
 
@@ -154,6 +204,34 @@ func TestMakeTaskItems_PreservesExplicitEnabledTasks(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("expected bug-finder task to exist in setup list")
+	}
+}
+
+func TestMakeTaskItems_ExcludesPresetWhenEnabledNonEmpty(t *testing.T) {
+	// When cfg.Tasks.Enabled is non-empty, preset selections must be ignored.
+	// Only the explicitly enabled tasks should be selected.
+	cfg := &config.Config{
+		Tasks: config.TasksConfig{
+			// Enable only TaskBugFinder, which may not be in the preset
+			Enabled: []string{string(tasks.TaskBugFinder)},
+		},
+	}
+
+	items := makeTaskItems(cfg, nil, setup.PresetBalanced)
+
+	// Verify only the explicitly enabled task is selected
+	selectedCount := 0
+	for _, item := range items {
+		if item.selected {
+			selectedCount++
+			if item.def.Type != tasks.TaskBugFinder {
+				t.Fatalf("expected only TaskBugFinder to be selected, but %s is also selected", item.def.Type)
+			}
+		}
+	}
+
+	if selectedCount != 1 {
+		t.Fatalf("expected exactly 1 selected task, got %d", selectedCount)
 	}
 }
 


### PR DESCRIPTION
## VC-77 — Setup wizard step 8 (task selection): wrong pre-selection and height overflow

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-77

### Description

Summary
Two bugs in setup wizard step 8 — Task Selection (stepTaskSelect in cmd/nightshift/commands/setup.go).

Bug 1 — Tasks not correctly pre-selected from config
Expected
When the user has tasks.enabled set in their config file, those tasks (and only those) appear pre-checked when entering step 8, consistent with how other steps load existing config values.
Actual
makeTaskItems() (setup.go ~line 2200) unions preset tasks + config tasks: it calls setup.PresetTasks(preset, defs, signals) first, then adds cfg.Tasks.Enabled on top. Result: tasks selected by the detected preset (not by the user) are also checked. On exit, this merged list overwrites the user's actual tasks.enabled with a wrong set.
Root Cause
// setup.go ~2200
func makeTaskItems(cfg *config.Config, projects []string, preset setup.Preset) []taskItem {
    defs := tasks.AllDefinitionsSorted()
    signals := setup.DetectRepoSignals(projects)
    selected := setup.PresetTasks(preset, defs, signals)   // ← preset always applied
    for _, enabled := range cfg.Tasks.Enabled {
        selected[tasks.TaskType(enabled)] = true            // ← config added on top, not replacing
    }
    ...
}
Fix
When cfg.Tasks.Enabled is non-empty, skip PresetTasks entirely and use the config list exclusively. Only fall back to preset when config has no enabled tasks (fresh setup).

Bug 2 — Task list overflows terminal height
Expected
All ~59 task definitions are accessible without the wizard header or top list items being pushed off-screen.
Actual
The task list renders at full height (~59 rows + labels), exceeding the terminal window. The wizard header and the first N tasks are scrolled off the top and invisible, making them unselectable.
Fix
Add scroll or pagination to the task list within a fixed viewport. Preferred: scrollable list with cursor-based viewport (show N items, scroll as cursor moves — same pattern used by bubbles/list). Page up/down keybindings acceptable as alternative.

Steps to Reproduce
Set tasks.enabled: [lint-fix, dead-code] in nightshift config
Run nightshift setup, advance to step 8 (Task Selection)
Observe: tasks other than lint-fix and dead-code are pre-checked (Bug 1)
Observe: wizard header and top tasks are off-screen (Bug 2)
Affected File
cmd/nightshift/commands/setup.go — makeTaskItems(), step 8 render/update handlers

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
