### PR TITLE
[VC-85] ProcessFeedback posts "no code changes needed" Jira comment when multi-repo ticket has mixed change/no-change repos

### DIFF
--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -230,7 +230,7 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 	// from re-triggering the agent on the same already-seen review comments.
 	if result.PushedCommits > 0 || result.AcknowledgedOnly {
 		body := result.Summary
-		if result.AcknowledgedOnly {
+		if result.AcknowledgedOnly && result.PushedCommits == 0 {
 			body = "Reviewed open comments — no code changes needed; review feedback already addressed."
 		}
 		o.emit("📝 recording rework acknowledgement on Jira %s", ticket.Key)

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -212,6 +212,8 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 				return nil, fmt.Errorf("jira: feedback: push fixes %s: %w", repo.Name, err)
 			}
 			result.PushedCommits++
+			// If any repo pushes commits, the result is no longer "acknowledged only".
+			result.AcknowledgedOnly = false
 
 			// Post a summary comment on the GitHub PR.
 			o.emit("  posting rework summary to PR %s", prInfo.URL)

--- a/internal/jira/feedback_test.go
+++ b/internal/jira/feedback_test.go
@@ -642,3 +642,71 @@ func TestProcessFeedback_OnlyFnHasChangesSet_NoPanic(t *testing.T) {
 		t.Errorf("expected error to mention 'push fixes' (commit path reached), got: %v", err)
 	}
 }
+
+// TestProcessFeedback_MixedRepoAcknowledgedOnly reproduces VC-85: when repo1 produces no
+// changes (AcknowledgedOnly=true) and repo2 does push commits, the Jira comment body must
+// use the Summary text, not the "no code changes needed" string.
+func TestProcessFeedback_MixedRepoAcknowledgedOnly(t *testing.T) {
+	sc := &stubJiraClient{}
+	ra := &stubAgent{name: "fix", output: "fixed it"}
+
+	callCount := 0
+	fnHasChanges := func(_ context.Context, _ string) (bool, error) {
+		callCount++
+		// repo1: no changes; repo2: has changes
+		return callCount > 1, nil
+	}
+
+	fnFindPR := func(_ context.Context, _, _ string) (*PRInfo, error) {
+		return &PRInfo{URL: "https://github.com/org/repo/pull/1", Number: 1}, nil
+	}
+	fnFetchReviews := func(_ context.Context, _, _ string) (*PRReviewState, error) {
+		return &PRReviewState{
+			ReviewDecision: "CHANGES_REQUESTED",
+			Reviews:        []Review{{Author: "alice", State: "CHANGES_REQUESTED", Body: "fix it"}},
+		}, nil
+	}
+
+	o := &Orchestrator{
+		client:         sc,
+		cfg:            JiraConfig{},
+		reviewFixAgent: ra,
+		fnHasChanges:   fnHasChanges,
+		fnCommitAndPush: noCommit,
+		fnCreatePR: func(_ context.Context, _ RepoWorkspace, _ Ticket, _ string) (*PRInfo, error) {
+			return nil, nil
+		},
+		fnFindPR:        fnFindPR,
+		fnFetchReviews:  fnFetchReviews,
+		fnPostPRComment: noPRComment,
+	}
+
+	ws := &Workspace{
+		TicketKey: "X-1",
+		Repos: []RepoWorkspace{
+			{Name: "repo1", Path: "/tmp/repo1", Branch: "feature/X-1"},
+			{Name: "repo2", Path: "/tmp/repo2", Branch: "feature/X-1"},
+		},
+	}
+
+	result, err := o.ProcessFeedback(context.Background(), Ticket{Key: "X-1"}, ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.PushedCommits == 0 {
+		t.Fatal("expected PushedCommits > 0 from repo2")
+	}
+
+	// Jira comment body must NOT be the acknowledged-only message.
+	if len(sc.postCommentCalls) != 1 {
+		t.Fatalf("expected 1 Jira comment, got %d", len(sc.postCommentCalls))
+	}
+	body := sc.postCommentCalls[0].Body
+	if strings.Contains(body, "no code changes needed") {
+		t.Errorf("Jira comment body must not be acknowledged-only message when commits were pushed; got: %q", body)
+	}
+	if !strings.Contains(body, result.Summary) {
+		t.Errorf("Jira comment body should contain the summary; got: %q, want to contain: %q", body, result.Summary)
+	}
+}


### PR DESCRIPTION
## VC-85 — ProcessFeedback posts "no code changes needed" Jira comment when multi-repo ticket has mixed change/no-change repos

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-85

### Description

Bug
In internal/jira/feedback.go, ProcessFeedback iterates over repo workspaces. When a repo's rework agent produces no file changes, result.AcknowledgedOnly is set to true and the loop continues to the next repo. If a subsequent repo does have changes and commits are pushed (result.PushedCommits > 0), the flag result.AcknowledgedOnly is never cleared.
At the end of ProcessFeedback, the Jira comment body is chosen like this:
if result.PushedCommits > 0 || result.AcknowledgedOnly {
    body := result.Summary
    if result.AcknowledgedOnly {
        body = "Reviewed open comments — no code changes needed; review feedback already addressed."
    }
Because result.AcknowledgedOnly is still true, the branch if result.AcknowledgedOnly is entered and the comment body is overwritten to say "no code changes needed" — even though commits were actually pushed for a later repo.
Impact
Multi-repo tickets where at least one repo had no review changes but another did will get a misleading Jira comment claiming no changes were made, hiding the actual commit activity. The CommentRework timestamp is still recorded correctly, so idempotency is not broken — only the comment body is wrong.
Reproduction
Configure a ticket with two repos.
Ensure the rework agent produces no changes for repo 1 but does produce changes for repo 2.
Observe the Jira comment says "no code changes needed" despite result.PushedCommits > 0.
Fix
Reset result.AcknowledgedOnly to false when a subsequent repo does push commits, or compute the final comment body from result.PushedCommits first and only use the acknowledged-only text when PushedCommits == 0.
if result.PushedCommits > 0 || result.AcknowledgedOnly {
    body := result.Summary
    if result.AcknowledgedOnly && result.PushedCommits == 0 {
        body = "Reviewed open comments — no code changes needed; review feedback already addressed."
    }
    // ...
}
Location
internal/jira/feedback.go — ProcessFeedback(), final Jira comment block (~line 228).

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
