### PR TITLE
[VC-86] CommitMessage always uses "feat:" prefix regardless of ticket IssueType — bug tickets committed as features

### DIFF
--- a/docs/dev/workspace.md
+++ b/docs/dev/workspace.md
@@ -67,7 +67,7 @@ E.g. `feature/VC-42`. Always rooted at `feature/`.
 
 ## Commit Message
 
-`CommitMessage(ticket, summary)`:
+`CommitMessage(ticketKey, issueType, scope, description)`:
 
 ```
 <type>(<scope>): <summary>

--- a/internal/jira/branch.go
+++ b/internal/jira/branch.go
@@ -14,18 +14,33 @@ func BranchName(ticketKey string) string {
 	return "feature/" + ticketKey
 }
 
-// CommitMessage formats a conventional commit message for a Jira ticket.
-// If scope is empty the format is "feat: ticketKey: description".
-func CommitMessage(ticketKey, scope, description string) string {
-	if scope != "" {
-		return fmt.Sprintf("feat(%s): %s: %s", scope, ticketKey, description)
+// issueTypeToCC maps a Jira issue type to a Conventional Commits prefix.
+// Matching is case-insensitive; unknown types default to "feat".
+func issueTypeToCC(issueType string) string {
+	switch strings.ToLower(issueType) {
+	case "bug":
+		return "fix"
+	case "chore", "maintenance":
+		return "chore"
+	default:
+		return "feat"
 	}
-	return fmt.Sprintf("feat: %s: %s", ticketKey, description)
+}
+
+// CommitMessage formats a conventional commit message for a Jira ticket.
+// issueType is mapped to a Conventional Commits prefix (e.g. "Bug" → "fix:").
+// If scope is empty the format is "<prefix>: ticketKey: description".
+func CommitMessage(ticketKey, issueType, scope, description string) string {
+	prefix := issueTypeToCC(issueType)
+	if scope != "" {
+		return fmt.Sprintf("%s(%s): %s: %s", prefix, scope, ticketKey, description)
+	}
+	return fmt.Sprintf("%s: %s: %s", prefix, ticketKey, description)
 }
 
 // PRTitle returns a pull request title for a Jira ticket (same format as CommitMessage).
-func PRTitle(ticketKey, scope, description string) string {
-	return CommitMessage(ticketKey, scope, description)
+func PRTitle(ticketKey, issueType, scope, description string) string {
+	return CommitMessage(ticketKey, issueType, scope, description)
 }
 
 // HasChanges reports whether the repo at repoPath has uncommitted changes.

--- a/internal/jira/branch_test.go
+++ b/internal/jira/branch_test.go
@@ -29,19 +29,25 @@ func TestBranchName(t *testing.T) {
 func TestCommitMessage(t *testing.T) {
 	tests := []struct {
 		ticketKey   string
+		issueType   string
 		scope       string
 		description string
 		want        string
 	}{
-		{"VC-7", "api", "add login endpoint", "feat(api): VC-7: add login endpoint"},
-		{"VC-7", "", "add login endpoint", "feat: VC-7: add login endpoint"},
-		{"PROJ-123", "auth", "implement OAuth", "feat(auth): PROJ-123: implement OAuth"},
+		{"VC-7", "Story", "api", "add login endpoint", "feat(api): VC-7: add login endpoint"},
+		{"VC-7", "Story", "", "add login endpoint", "feat: VC-7: add login endpoint"},
+		{"PROJ-123", "Story", "auth", "implement OAuth", "feat(auth): PROJ-123: implement OAuth"},
+		{"VC-42", "Bug", "", "fix nil pointer", "fix: VC-42: fix nil pointer"},
+		{"VC-42", "Bug", "api", "fix nil pointer", "fix(api): VC-42: fix nil pointer"},
+		{"VC-42", "bug", "", "case insensitive", "fix: VC-42: case insensitive"},
+		{"VC-10", "Chore", "", "update deps", "chore: VC-10: update deps"},
+		{"VC-10", "", "", "unknown type defaults", "feat: VC-10: unknown type defaults"},
 	}
 	for _, tt := range tests {
-		got := CommitMessage(tt.ticketKey, tt.scope, tt.description)
+		got := CommitMessage(tt.ticketKey, tt.issueType, tt.scope, tt.description)
 		if got != tt.want {
-			t.Errorf("CommitMessage(%q, %q, %q) = %q, want %q",
-				tt.ticketKey, tt.scope, tt.description, got, tt.want)
+			t.Errorf("CommitMessage(%q, %q, %q, %q) = %q, want %q",
+				tt.ticketKey, tt.issueType, tt.scope, tt.description, got, tt.want)
 		}
 	}
 }
@@ -49,18 +55,20 @@ func TestCommitMessage(t *testing.T) {
 func TestPRTitleConventional(t *testing.T) {
 	tests := []struct {
 		ticketKey   string
+		issueType   string
 		scope       string
 		description string
 		want        string
 	}{
-		{"VC-7", "api", "add workspace support", "feat(api): VC-7: add workspace support"},
-		{"VC-7", "", "add workspace support", "feat: VC-7: add workspace support"},
+		{"VC-7", "Story", "api", "add workspace support", "feat(api): VC-7: add workspace support"},
+		{"VC-7", "Story", "", "add workspace support", "feat: VC-7: add workspace support"},
+		{"VC-7", "Bug", "", "fix crash", "fix: VC-7: fix crash"},
 	}
 	for _, tt := range tests {
-		got := PRTitle(tt.ticketKey, tt.scope, tt.description)
+		got := PRTitle(tt.ticketKey, tt.issueType, tt.scope, tt.description)
 		if got != tt.want {
-			t.Errorf("PRTitle(%q, %q, %q) = %q, want %q",
-				tt.ticketKey, tt.scope, tt.description, got, tt.want)
+			t.Errorf("PRTitle(%q, %q, %q, %q) = %q, want %q",
+				tt.ticketKey, tt.issueType, tt.scope, tt.description, got, tt.want)
 		}
 	}
 }

--- a/internal/jira/e2e_test.go
+++ b/internal/jira/e2e_test.go
@@ -433,9 +433,9 @@ func TestE2E_VC7_CommitMessage(t *testing.T) {
 		{"", "feat: VC-7: add workspace"},
 	}
 	for _, tt := range tests {
-		got := CommitMessage("VC-7", tt.scope, "add workspace")
+		got := CommitMessage("VC-7", "Story", tt.scope, "add workspace")
 		if got != tt.want {
-			t.Errorf("CommitMessage(VC-7, %q, ...) = %q, want %q", tt.scope, got, tt.want)
+			t.Errorf("CommitMessage(VC-7, Story, %q, ...) = %q, want %q", tt.scope, got, tt.want)
 		}
 	}
 }

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -206,7 +206,7 @@ func (o *Orchestrator) ProcessFeedback(ctx context.Context, ticket Ticket, ws *W
 			}
 
 			result.FixesMade++
-			msg := CommitMessage(ticket.Key, "", "address review feedback")
+			msg := CommitMessage(ticket.Key, ticket.IssueType, "", "address review feedback")
 			o.emit("  committing + pushing review fixes → %s", repo.Branch)
 			if err := o.fnCommitAndPush(ctx, repo.Path, msg); err != nil {
 				return nil, fmt.Errorf("jira: feedback: push fixes %s: %w", repo.Name, err)

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -603,7 +603,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, ticket Ticket, ws *Wor
 					skippedRepos = append(skippedRepos, repo)
 					continue
 				}
-				msg := CommitMessage(ticket.Key, "", ticket.Summary)
+				msg := CommitMessage(ticket.Key, ticket.IssueType, "", ticket.Summary)
 				o.emit("  committing + pushing %s → %s", repo.Name, repo.Branch)
 				if err := o.fnCommitAndPush(ctx, repo.Path, msg); err != nil {
 					o.postErrorComment(ctx, ticket.Key, PhaseCommit, err)


### PR DESCRIPTION
## VC-86 — CommitMessage always uses "feat:" prefix regardless of ticket IssueType — bug tickets committed as features

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-86

### Description

Bug
CommitMessage in internal/jira/branch.go hardcodes the feat: Conventional Commits type for every commit:
func CommitMessage(ticketKey, scope, description string) string {
    if scope != "" {
        return fmt.Sprintf("feat(%s): %s: %s", scope, ticketKey, description)
    }
    return fmt.Sprintf("feat: %s: %s", ticketKey, description)
}
The Ticket struct already carries IssueType string (e.g. "Bug", "Story", "Task", "Epic"), but CommitMessage ignores it. Both call sites pass the ticket key but not the issue type:
orchestrator.go:601 — CommitMessage(ticket.Key, "", ticket.Summary)
feedback.go:209 — CommitMessage(ticket.Key, "", "address review feedback")
Impact
Bug fix commits are recorded as feat: in git history, breaking Conventional Commits tooling (changelogs, semantic-release, PR titles). A bug fix should produce fix: VC-42: ..., not feat: VC-42: ....
Fix
Add an issueType parameter to CommitMessage (or a variant) and map Jira issue types to Conventional Commits prefixes:
Jira IssueTypeCC prefixBugfixStory, Task, FeaturefeatChore, Maintenancechore(default)featUpdate both call sites to pass ticket.IssueType.
Location
internal/jira/branch.go — CommitMessage() (line 19)
internal/jira/orchestrator.go — line 601
internal/jira/feedback.go — line 209

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
