### PR TITLE
[VC-88] Remove SMTP email reporting entirely — unwanted feature, config bypasses internal/config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to nightshift are documented in this file.
 
 ### Breaking Changes
 
+- **Removed SMTP email reporting** — `reporting.email` config field and all `NIGHTSHIFT_SMTP_*` env vars
+  are removed. The feature was unwanted and violated config/credential conventions. No replacement.
+
 - **Removed deprecated flat Jira config fields** — `jira.project`, `jira.label`, and `jira.repos`
   top-level fields are removed. Migrate to `jira.projects` list before upgrading:
   ```yaml

--- a/cmd/nightshift/commands/init.go
+++ b/cmd/nightshift/commands/init.go
@@ -200,7 +200,6 @@ logging:
 # Reporting configuration
 reporting:
   morning_summary: true          # Generate morning summary
-  # email: user@example.com      # Optional email notification
   # slack_webhook: https://...   # Optional Slack notification
 `
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,7 +164,6 @@ type LoggingConfig struct {
 // ReportingConfig defines reporting settings.
 type ReportingConfig struct {
 	MorningSummary bool    `mapstructure:"morning_summary"`
-	Email          *string `mapstructure:"email"`         // Optional email notification
 	SlackWebhook   *string `mapstructure:"slack_webhook"` // Optional Slack webhook
 }
 

--- a/internal/reporting/summary.go
+++ b/internal/reporting/summary.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/smtp"
 	"os"
 	"path/filepath"
 	"sort"
@@ -318,14 +317,6 @@ func (g *Generator) SendNotifications(summary *Summary) error {
 
 	var errs []error
 
-	// Send email if configured
-	if g.cfg.Reporting.Email != nil && *g.cfg.Reporting.Email != "" {
-		if err := g.sendEmail(summary, *g.cfg.Reporting.Email); err != nil {
-			g.logger.Errorf("email notification failed: %v", err)
-			errs = append(errs, fmt.Errorf("email: %w", err))
-		}
-	}
-
 	// Send Slack if configured
 	if g.cfg.Reporting.SlackWebhook != nil && *g.cfg.Reporting.SlackWebhook != "" {
 		if err := g.sendSlack(summary, *g.cfg.Reporting.SlackWebhook); err != nil {
@@ -338,45 +329,6 @@ func (g *Generator) SendNotifications(summary *Summary) error {
 		return fmt.Errorf("notification errors: %v", errs)
 	}
 
-	return nil
-}
-
-// sendEmail sends the summary via email.
-func (g *Generator) sendEmail(summary *Summary, to string) error {
-	// Get SMTP settings from environment
-	smtpHost := os.Getenv("NIGHTSHIFT_SMTP_HOST")
-	smtpPort := os.Getenv("NIGHTSHIFT_SMTP_PORT")
-	smtpUser := os.Getenv("NIGHTSHIFT_SMTP_USER")
-	smtpPass := os.Getenv("NIGHTSHIFT_SMTP_PASS")
-	smtpFrom := os.Getenv("NIGHTSHIFT_SMTP_FROM")
-
-	if smtpHost == "" {
-		return fmt.Errorf("NIGHTSHIFT_SMTP_HOST not set")
-	}
-	if smtpPort == "" {
-		smtpPort = "587"
-	}
-	if smtpFrom == "" {
-		smtpFrom = "nightshift@localhost"
-	}
-
-	subject := fmt.Sprintf("Nightshift Summary - %s", summary.Date.Format("2006-01-02"))
-
-	// Build email message
-	msg := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n%s",
-		smtpFrom, to, subject, summary.Content)
-
-	var auth smtp.Auth
-	if smtpUser != "" && smtpPass != "" {
-		auth = smtp.PlainAuth("", smtpUser, smtpPass, smtpHost)
-	}
-
-	addr := fmt.Sprintf("%s:%s", smtpHost, smtpPort)
-	if err := smtp.SendMail(addr, auth, smtpFrom, []string{to}, []byte(msg)); err != nil {
-		return fmt.Errorf("sending email: %w", err)
-	}
-
-	g.logger.Infof("email sent to %s", to)
 	return nil
 }
 


### PR DESCRIPTION
## VC-88 — Remove SMTP email reporting entirely — unwanted feature, config bypasses internal/config

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-88

### Description

Bug
Nightshift ships an SMTP email-reporting feature that is not wanted and should be removed entirely.
Beyond being unwanted, the SMTP config bypasses the project's config convention: five settings are read directly via os.Getenv instead of going through internal/config:
NIGHTSHIFT_SMTP_HOST
NIGHTSHIFT_SMTP_PORT
NIGHTSHIFT_SMTP_USER
NIGHTSHIFT_SMTP_PASS
NIGHTSHIFT_SMTP_FROM
CLAUDE.md convention: "Config access via internal/config/ only; no direct env reads outside that package."
Impact
Dead/unwanted surface area users can accidentally enable.
Config convention violation: SMTP settings invisible to internal/config, nightshift config, and validation.
SMTP credentials handled outside internal/security.
Fix
Remove the SMTP feature completely:
Delete the SMTP sender code and the five NIGHTSHIFT_SMTP_* env reads.
Remove any reporting/email config fields tied to SMTP from internal/config.
Remove SMTP references from docs/ (reporting, operations) and CHANGELOG.md.
No backwards-compat shim — delete fully per CLAUDE.md.
Location
internal/reporting/ (SMTP sender), internal/config/config.go, docs/.

Filed from codebase analysis — automated agent

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
