### PR TITLE
[VC-87] Daemon scheduler ignores workspace isolation — local tasks run in-place on real repos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,8 @@ internal/
     workspace.go        # Config/RepoConfig/Workspace/RepoWorkspace types; SetupWorkspace() clones
                         # repos into <root>/<name>_<runID>/, writes .nightshift-workspace.json;
                         # CleanupStaleWorkspaces() removes dirs older than TTLDays (default 7);
-                        # ValidateConfig() enforces SSH URLs; gitExecFn var injectable for tests
+                        # ValidateConfig() enforces SSH URLs; gitExecFn var injectable via SetGitExecFn();
+                        # RepoConfig/RepoWorkspace carry Tasks/Pattern/Exclude for per-repo config
 
 docs/                   # All documentation (plain markdown, no static-site generator)
   README.md             # Index pointing at user/operations/dev trees
@@ -411,3 +412,5 @@ Agents MUST follow these rules:
 - **Workspace state key** — in workspace mode, the repo clone path (not the configured repo name) is used as the state key for cooldown/staleness tracking. This means each fresh clone appears "new" to the staleness tracker, which is intentional: workspace runs always pick the highest-priority tasks.
 - **Workspace clone uses `.` as target** — `git clone <url> .` clones into the already-created `<root>/<name>_<runID>/` directory. The directory must exist and be empty before the clone.
 - **`CleanupStaleWorkspaces` walks dir contents for mtime** — on Linux, git operations update file mtimes inside a directory but not the directory entry's own mtime. `CleanupStaleWorkspaces` uses `filepath.WalkDir` to find the newest mtime across all files/subdirs inside each workspace. The directory entry mtime alone is unreliable and was the source of VC-83 (active workspaces deleted early). When writing tests for this, remember that `os.WriteFile` inside a dir updates the dir's own mtime — re-apply `os.Chtimes` on the dir after writing files if you need the dir entry to appear old.
+- **Daemon workspace mode (VC-87)** — when `workspace.root` is set, `runScheduledTasks` routes to `runScheduledWorkspacedTasks` instead of the project-path loop. Both `nightshift run` and daemon share `runRepoTasks()` for per-repo task execution. State key is always `rw.Name` (not `rw.Path`) in workspace mode. First daemon run after upgrading from a pre-VC-87 release will re-process all workspace repos once (old cooldowns were keyed on paths, new ones on names — safe, one extra run).
+- **`runRepoTasks` allowedTasks filter** — when `workspace.repos[*].tasks` is set, `runRepoTasks` filters selected tasks to only those types before execution. Empty/nil means no filter. Filter applied after selector, so cooldown/staleness scoring still runs on all tasks but only matching types are executed.

--- a/cmd/nightshift/commands/daemon.go
+++ b/cmd/nightshift/commands/daemon.go
@@ -309,6 +309,11 @@ func runScheduledTasks(ctx context.Context, cfg *config.Config, database *db.DB,
 
 	report := newRunReport(time.Now())
 
+	// Workspace mode: clone repos and run tasks in isolation.
+	if cfg.Workspace.Root != "" && len(cfg.Workspace.Repos) > 0 {
+		return runScheduledWorkspacedTasks(ctx, cfg, database, log, st, budgetMgr, report)
+	}
+
 	// Resolve projects
 	projects, err := resolveProjects(cfg, "")
 	if err != nil {
@@ -531,6 +536,117 @@ func runScheduledTasks(ctx context.Context, cfg *config.Config, database *db.DB,
 		"completed": tasksCompleted,
 		"failed":    tasksFailed,
 		"projects":  len(projects),
+	})
+
+	if report != nil {
+		report.finalize(cfg, log)
+	}
+
+	return nil
+}
+
+// runScheduledWorkspacedTasks is the daemon counterpart of workspacedRun.
+// It clones each configured repo into a fresh workspace and runs tasks in isolation,
+// using the repo Name as the state key for cooldown tracking.
+func runScheduledWorkspacedTasks(
+	ctx context.Context,
+	cfg *config.Config,
+	_ *db.DB,
+	log *logging.Logger,
+	st *state.State,
+	budgetMgr *budget.Manager,
+	report *runReport,
+) error {
+	start := time.Now()
+	log.Info("workspace scheduled run starting")
+
+	runID := newRunID()
+
+	// Clone-timeout: give 5 min for workspace setup, same as workspacedRun.
+	cloneCtx, cloneCancel := context.WithTimeout(ctx, 5*time.Minute)
+	ws, err := workspace.SetupWorkspace(cloneCtx, workspaceConfigFromApp(cfg), runID)
+	cloneCancel()
+	if err != nil {
+		log.Errorf("setup workspace: %v", err)
+		return fmt.Errorf("setup workspace: %w", err)
+	}
+
+	choice, err := selectProvider(cfg, budgetMgr, log, false)
+	if err != nil {
+		log.Infof("no provider available: %v", err)
+		return nil
+	}
+
+	orch := orchestrator.New(
+		orchestrator.WithAgent(choice.agent),
+		orchestrator.WithConfig(orchestrator.Config{
+			MaxIterations: 3,
+			AgentTimeout:  daemonTimeoutFlag,
+			Compression:   compressionConfigFromApp(cfg),
+		}),
+		orchestrator.WithLogger(logging.Component("orchestrator")),
+	)
+
+	maxTasks := cfg.Schedule.MaxTasks
+	if maxTasks <= 0 {
+		maxTasks = 5
+	}
+
+	selector := tasks.NewSelector(cfg, st)
+
+	var tasksRun, tasksCompleted, tasksFailed int
+	projectStart := time.Now()
+
+	for _, rw := range ws.Repos {
+		select {
+		case <-ctx.Done():
+			log.Info("workspace run cancelled")
+			return ctx.Err()
+		default:
+		}
+
+		// Use repo name as state key so cooldowns are stable across run IDs.
+		if st.WasProcessedToday(rw.Name) {
+			log.Debugf("skip workspace repo %s (processed today)", rw.Name)
+			continue
+		}
+
+		baseBranch, _ := orchestrator.CurrentBranch(ctx, rw.Path)
+
+		log.InfoCtx("processing workspace repo", map[string]any{
+			"repo":     rw.Name,
+			"path":     rw.Path,
+			"provider": choice.name,
+		})
+
+		run, ok, fail := runRepoTasks(ctx, repoTasksParams{
+			cfg:          cfg,
+			st:           st,
+			selector:     selector,
+			orch:         orch,
+			choice:       choice,
+			repoPath:     rw.Path,
+			stateKey:     rw.Name,
+			allowedTasks: rw.Tasks,
+			maxTasks:     maxTasks,
+			branch:       baseBranch,
+			report:       report,
+			log:          log,
+			projectStart: projectStart,
+			verbose:      false,
+		})
+		tasksRun += run
+		tasksCompleted += ok
+		tasksFailed += fail
+	}
+
+	duration := time.Since(start)
+	log.InfoCtx("workspace scheduled run complete", map[string]any{
+		"duration":  duration.String(),
+		"tasks_run": tasksRun,
+		"completed": tasksCompleted,
+		"failed":    tasksFailed,
+		"run_id":    runID,
 	})
 
 	if report != nil {

--- a/cmd/nightshift/commands/daemon_test.go
+++ b/cmd/nightshift/commands/daemon_test.go
@@ -1,0 +1,182 @@
+package commands
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cedricfarinazzo/nightshift/internal/budget"
+	"github.com/cedricfarinazzo/nightshift/internal/config"
+	"github.com/cedricfarinazzo/nightshift/internal/db"
+	"github.com/cedricfarinazzo/nightshift/internal/logging"
+	"github.com/cedricfarinazzo/nightshift/internal/orchestrator"
+	"github.com/cedricfarinazzo/nightshift/internal/state"
+	"github.com/cedricfarinazzo/nightshift/internal/tasks"
+	"github.com/cedricfarinazzo/nightshift/internal/workspace"
+)
+
+// setupDaemonDB creates a temp DB and state for daemon tests.
+func setupDaemonDB(t *testing.T) (*db.DB, *state.State) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	database, err := db.Open(home + "/nightshift.db")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	st, err := state.New(database)
+	if err != nil {
+		t.Fatalf("init state: %v", err)
+	}
+	return database, st
+}
+
+// noopGitExec is a workspace.gitExecFn replacement that always succeeds.
+func noopGitExec(_ context.Context, _ string, _ ...string) (string, error) {
+	return "", nil
+}
+
+// TestRunScheduledTasks_WorkspaceMode verifies that when workspace config is set,
+// runScheduledTasks routes to the workspace code path (clones repos via gitExecFn)
+// instead of the project-path-based path.
+func TestRunScheduledTasks_WorkspaceMode(t *testing.T) {
+	tmp := t.TempDir()
+	database, st := setupDaemonDB(t)
+
+	// Pre-mark the repo as processed today by name.
+	// This causes the workspace loop to skip it — no agent execution needed.
+	st.RecordProjectRun("test-repo")
+
+	gitCalled := false
+	restore := workspace.SetGitExecFn(func(ctx context.Context, dir string, args ...string) (string, error) {
+		gitCalled = true
+		return noopGitExec(ctx, dir, args...)
+	})
+	defer workspace.SetGitExecFn(restore)
+
+	cfg := &config.Config{
+		Workspace: config.WorkspaceConfig{
+			Root: tmp,
+			Repos: []config.WorkspaceRepoConfig{
+				{URL: "git@github.com:org/repo.git", Name: "test-repo"},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Claude: config.ProviderConfig{Enabled: true},
+		},
+		Budget:   config.BudgetConfig{MaxPercent: 75},
+		Schedule: config.ScheduleConfig{MaxTasks: 1},
+	}
+
+	log := logging.Component("test")
+	_ = runScheduledTasks(context.Background(), cfg, database, log)
+
+	if !gitCalled {
+		t.Fatal("workspace mode not entered: gitExecFn was never called")
+	}
+}
+
+// TestRunScheduledTasks_NonWorkspaceMode verifies that without workspace config,
+// runScheduledTasks does NOT call gitExecFn (no workspace cloning).
+func TestRunScheduledTasks_NonWorkspaceMode(t *testing.T) {
+	database, _ := setupDaemonDB(t)
+
+	gitCalled := false
+	restore := workspace.SetGitExecFn(func(ctx context.Context, dir string, args ...string) (string, error) {
+		gitCalled = true
+		return noopGitExec(ctx, dir, args...)
+	})
+	defer workspace.SetGitExecFn(restore)
+
+	cfg := &config.Config{
+		Providers: config.ProvidersConfig{},
+		Budget:    config.BudgetConfig{MaxPercent: 75},
+		Schedule:  config.ScheduleConfig{MaxTasks: 1},
+	}
+
+	log := logging.Component("test")
+	_ = runScheduledTasks(context.Background(), cfg, database, log)
+
+	if gitCalled {
+		t.Fatal("non-workspace mode erroneously called gitExecFn")
+	}
+}
+
+// TestRunScheduledWorkspacedTasks_StateKey verifies that WasProcessedToday uses
+// rw.Name (not rw.Path) as the state key. We pre-record rw.Name in state; if the
+// function correctly uses rw.Name, the repo is skipped with no agent execution.
+// If it mistakenly used rw.Path, WasProcessedToday would return false and task
+// execution would be attempted (resulting in an error with no real agent in PATH).
+func TestRunScheduledWorkspacedTasks_StateKey(t *testing.T) {
+	tmp := t.TempDir()
+	database, st := setupDaemonDB(t)
+
+	const repoName = "my-repo"
+	// Pre-mark the repo by name, not by any filesystem path.
+	st.RecordProjectRun(repoName)
+
+	restore := workspace.SetGitExecFn(noopGitExec)
+	defer workspace.SetGitExecFn(restore)
+
+	cfg := &config.Config{
+		Workspace: config.WorkspaceConfig{
+			Root: tmp,
+			Repos: []config.WorkspaceRepoConfig{
+				{URL: "git@github.com:org/repo.git", Name: repoName},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Claude: config.ProviderConfig{Enabled: true},
+		},
+		Budget:   config.BudgetConfig{MaxPercent: 75},
+		Schedule: config.ScheduleConfig{MaxTasks: 1},
+	}
+
+	budgetMgr := budget.NewManagerWithTracking(cfg)
+	report := newRunReport(time.Now())
+	log := logging.Component("test")
+
+	err := runScheduledWorkspacedTasks(context.Background(), cfg, database, log, st, budgetMgr, report)
+	if err != nil {
+		t.Fatalf("runScheduledWorkspacedTasks returned unexpected error: %v", err)
+	}
+	// Success: the repo was skipped because WasProcessedToday(repoName) == true.
+	// If state key were rw.Path (a UUID-suffixed temp path), WasProcessedToday
+	// would return false and task execution would be attempted without a provider.
+}
+
+// TestRunRepoTasks_PerRepoTaskFilter verifies that allowedTasks filters out task
+// types not in the list. When the per-repo filter excludes all selected tasks,
+// runRepoTasks returns 0 tasks run without invoking the orchestrator.
+func TestRunRepoTasks_PerRepoTaskFilter(t *testing.T) {
+	st := newTestRunState(t)
+	cfg := newTestRunConfig()
+	selector := tasks.NewSelector(cfg, st)
+
+	// Build a minimal orchestrator — RunTask will not be called because the
+	// per-repo filter will eliminate all selected tasks.
+	orch := orchestrator.New(
+		orchestrator.WithLogger(logging.Component("test")),
+	)
+
+	// allowedTasks contains a task type that is unlikely to be in the
+	// default task catalog; the filter will exclude all real tasks.
+	run, ok, fail := runRepoTasks(context.Background(), repoTasksParams{
+		cfg:          cfg,
+		st:           st,
+		selector:     selector,
+		orch:         orch,
+		choice:       &providerChoice{name: "claude"},
+		repoPath:     t.TempDir(),
+		stateKey:     "filter-test-repo",
+		allowedTasks: []string{"__nonexistent_task_type__"},
+		maxTasks:     5,
+		log:          logging.Component("test"),
+		projectStart: time.Now(),
+	})
+
+	if run != 0 || ok != 0 || fail != 0 {
+		t.Fatalf("expected (0,0,0) with per-repo filter, got (%d,%d,%d)", run, ok, fail)
+	}
+}

--- a/cmd/nightshift/commands/helpers.go
+++ b/cmd/nightshift/commands/helpers.go
@@ -186,7 +186,13 @@ func newBudgetManager(cfg *config.Config, _ *db.DB) *budget.Manager {
 func workspaceConfigFromApp(cfg *config.Config) workspace.Config {
 	repos := make([]workspace.RepoConfig, len(cfg.Workspace.Repos))
 	for i, r := range cfg.Workspace.Repos {
-		repos[i] = workspace.RepoConfig{URL: r.URL, Name: r.Name}
+		repos[i] = workspace.RepoConfig{
+			URL:     r.URL,
+			Name:    r.Name,
+			Tasks:   r.Tasks,
+			Pattern: r.Pattern,
+			Exclude: r.Exclude,
+		}
 	}
 	return workspace.Config{Root: cfg.Workspace.Root, Repos: repos, TTLDays: 7}
 }

--- a/cmd/nightshift/commands/run.go
+++ b/cmd/nightshift/commands/run.go
@@ -622,6 +622,212 @@ func newRunID() string {
 	return hex.EncodeToString(b)
 }
 
+// repoTasksParams holds all parameters for runRepoTasks.
+type repoTasksParams struct {
+	cfg          *config.Config
+	st           *state.State
+	selector     *tasks.Selector
+	orch         *orchestrator.Orchestrator
+	choice       *providerChoice
+	repoPath     string   // filesystem path for agent execution
+	stateKey     string   // key for cooldown / state tracking (rw.Name in workspace mode)
+	allowedTasks []string // per-repo task type filter; nil = no filter
+	taskFilter   string   // --task flag value
+	maxTasks     int
+	randomTask   bool
+	branch       string
+	report       *runReport
+	log          *logging.Logger
+	projectStart time.Time
+	verbose      bool // print task progress to stdout (non-interactive CLI)
+}
+
+// runRepoTasks executes selected tasks for one repo/project and records results.
+// It uses stateKey (not repoPath) for all cooldown / state-record operations.
+// Returns (tasksRun, completed, failed).
+func runRepoTasks(ctx context.Context, p repoTasksParams) (int, int, int) {
+	var selectedTasks []tasks.ScoredTask
+	if p.taskFilter != "" {
+		def, err := tasks.GetDefinition(tasks.TaskType(p.taskFilter))
+		if err != nil {
+			p.log.Errorf("unknown task type: %s", p.taskFilter)
+			return 0, 0, 0
+		}
+		selectedTasks = []tasks.ScoredTask{{
+			Definition: def,
+			Score:      p.selector.ScoreTask(def.Type, p.stateKey),
+			Project:    p.stateKey,
+		}}
+	} else if p.randomTask {
+		if picked := p.selector.SelectRandom(p.stateKey); picked != nil {
+			selectedTasks = []tasks.ScoredTask{*picked}
+		}
+	} else {
+		n := p.maxTasks
+		if n <= 0 {
+			n = 1
+		}
+		selectedTasks = p.selector.SelectTopN(p.stateKey, n)
+	}
+
+	// Apply per-repo task type filter.
+	if len(p.allowedTasks) > 0 {
+		filtered := selectedTasks[:0]
+		for _, st := range selectedTasks {
+			for _, allowed := range p.allowedTasks {
+				if string(st.Definition.Type) == allowed {
+					filtered = append(filtered, st)
+					break
+				}
+			}
+		}
+		selectedTasks = filtered
+	}
+
+	if len(selectedTasks) == 0 {
+		p.log.Infof("no tasks for repo %s", p.stateKey)
+		return 0, 0, 0
+	}
+
+	start := p.projectStart
+	if start.IsZero() {
+		start = time.Now()
+	}
+
+	var tasksRun, completed, failed int
+	projectTaskTypes := make([]string, 0, len(selectedTasks))
+	projectTokensUsed := 0
+
+	for _, scoredTask := range selectedTasks {
+		select {
+		case <-ctx.Done():
+			return tasksRun, completed, failed
+		default:
+		}
+
+		tasksRun++
+		if p.verbose {
+			fmt.Printf("\n--- Running: %s (via %s) ---\n", scoredTask.Definition.Name, p.choice.name)
+		}
+		projectTaskTypes = append(projectTaskTypes, string(scoredTask.Definition.Type))
+
+		p.orch.SetRunMetadata(&orchestrator.RunMetadata{
+			Provider:  p.choice.name,
+			TaskType:  string(scoredTask.Definition.Type),
+			TaskScore: scoredTask.Score,
+			CostTier:  scoredTask.Definition.CostTier.String(),
+			RunStart:  start,
+			Branch:    p.branch,
+		})
+
+		taskInstance := &tasks.Task{
+			ID:          fmt.Sprintf("%s:%s", scoredTask.Definition.Type, p.stateKey),
+			Title:       scoredTask.Definition.Name,
+			Description: scoredTask.Definition.Description,
+			Priority:    int(scoredTask.Score),
+			Type:        scoredTask.Definition.Type,
+		}
+
+		p.st.MarkAssigned(taskInstance.ID, p.stateKey, string(scoredTask.Definition.Type))
+		result, runErr := p.orch.RunTask(ctx, taskInstance, p.repoPath)
+		p.st.ClearAssigned(taskInstance.ID)
+
+		if runErr != nil {
+			failed++
+			p.log.Errorf("task %s failed: %v", taskInstance.ID, runErr)
+			if p.verbose {
+				fmt.Printf("  FAILED: %v\n", runErr)
+			}
+			if p.report != nil {
+				p.report.addTask(reporting.TaskResult{
+					Project:  p.stateKey,
+					TaskType: string(scoredTask.Definition.Type),
+					Title:    scoredTask.Definition.Name,
+					Status:   "failed",
+					Duration: result.Duration,
+				})
+			}
+			continue
+		}
+
+		switch result.Status {
+		case orchestrator.StatusCompleted:
+			completed++
+			p.st.RecordTaskRun(p.stateKey, string(scoredTask.Definition.Type))
+			if p.verbose {
+				fmt.Printf("  COMPLETED in %d iteration(s) (%s)\n", result.Iterations, result.Duration)
+			}
+			_, maxTok := scoredTask.Definition.EstimatedTokens()
+			projectTokensUsed += maxTok
+			if p.report != nil {
+				p.report.addTask(reporting.TaskResult{
+					Project:    p.stateKey,
+					TaskType:   string(scoredTask.Definition.Type),
+					Title:      scoredTask.Definition.Name,
+					Status:     "completed",
+					OutputType: result.OutputType,
+					OutputRef:  result.OutputRef,
+					TokensUsed: maxTok,
+					Duration:   result.Duration,
+					Notes:      compressionNotes(result.Logs),
+				})
+			}
+		case orchestrator.StatusAbandoned:
+			failed++
+			if p.verbose {
+				fmt.Printf("  ABANDONED after %d iteration(s): %s\n", result.Iterations, result.Error)
+			}
+			if p.report != nil {
+				p.report.addTask(reporting.TaskResult{
+					Project:    p.stateKey,
+					TaskType:   string(scoredTask.Definition.Type),
+					Title:      scoredTask.Definition.Name,
+					Status:     "failed",
+					SkipReason: result.Error,
+					Duration:   result.Duration,
+				})
+			}
+		default:
+			failed++
+			if p.verbose {
+				fmt.Printf("  FAILED: %s\n", result.Error)
+			}
+			if p.report != nil {
+				p.report.addTask(reporting.TaskResult{
+					Project:    p.stateKey,
+					TaskType:   string(scoredTask.Definition.Type),
+					Title:      scoredTask.Definition.Name,
+					Status:     "failed",
+					SkipReason: result.Error,
+					Duration:   result.Duration,
+				})
+			}
+		}
+	}
+
+	// Record project run using stateKey so cooldowns work across workspace clones.
+	p.st.RecordProjectRun(p.stateKey)
+	projectStatus := "partial"
+	if failed == 0 && completed > 0 {
+		projectStatus = "success"
+	}
+	if completed == 0 && failed > 0 {
+		projectStatus = "failed"
+	}
+	p.st.AddRunRecord(state.RunRecord{
+		StartTime:  start,
+		EndTime:    time.Now(),
+		Provider:   p.choice.name,
+		Project:    p.stateKey,
+		Tasks:      projectTaskTypes,
+		TokensUsed: projectTokensUsed,
+		Status:     projectStatus,
+		Branch:     p.branch,
+	})
+
+	return tasksRun, completed, failed
+}
+
 // workspacedRun clones each configured repo into a fresh workspace and runs
 // tasks there, using the repo Name as the state key for cooldown tracking.
 func workspacedRun(ctx context.Context, p executeRunParams) error {
@@ -708,14 +914,7 @@ func workspacedRun(ctx context.Context, p executeRunParams) error {
 		default:
 		}
 
-		// Use repo Name as stable state key (not UUID path) so cooldowns work.
-		stateKey := rw.Name
-		projectTaskTypes := make([]string, 0)
-		projectTokensUsed := 0
-		projectCompleted := 0
-		projectFailed := 0
-
-		// Detect branch from cloned workspace repo (or use flag value from params)
+		// Detect branch from cloned workspace repo (or use flag value from params).
 		repoBranch := p.branch
 		if repoBranch == "" {
 			if detected, err := orchestrator.CurrentBranch(ctx, rw.Path); err == nil {
@@ -723,147 +922,32 @@ func workspacedRun(ctx context.Context, p executeRunParams) error {
 			}
 		}
 
-		// Select tasks for this workspace repo using its path as the project key.
-		var selectedTasks []tasks.ScoredTask
-		if p.taskFilter != "" {
-			def, err := tasks.GetDefinition(tasks.TaskType(p.taskFilter))
-			if err != nil {
-				return fmt.Errorf("unknown task type: %s", p.taskFilter)
-			}
-			selectedTasks = []tasks.ScoredTask{{
-				Definition: def,
-				Score:      p.selector.ScoreTask(def.Type, stateKey),
-				Project:    stateKey,
-			}}
-		} else if p.randomTask {
-			if picked := p.selector.SelectRandom(stateKey); picked != nil {
-				selectedTasks = []tasks.ScoredTask{*picked}
-			}
-		} else {
-			n := p.maxTasks
-			if n <= 0 {
-				n = 1
-			}
-			selectedTasks = p.selector.SelectTopN(stateKey, n)
-		}
-
-		if len(selectedTasks) == 0 {
-			p.log.Infof("no tasks for workspace repo %s", rw.Name)
-			continue
-		}
-
 		if !isInteractive() {
 			fmt.Printf("\n=== Workspace Repo: %s (%s) ===\n", rw.Name, rw.Path)
 			fmt.Printf("Provider: %s\n", choice.name)
 		}
 
-		orch.SetRunMetadata(&orchestrator.RunMetadata{
-			Provider: choice.name,
-			RunStart: projectStart,
-			Branch:   repoBranch,
+		run, ok, fail := runRepoTasks(ctx, repoTasksParams{
+			cfg:          p.cfg,
+			st:           p.st,
+			selector:     p.selector,
+			orch:         orch,
+			choice:       choice,
+			repoPath:     rw.Path,
+			stateKey:     rw.Name,
+			allowedTasks: rw.Tasks,
+			taskFilter:   p.taskFilter,
+			maxTasks:     p.maxTasks,
+			randomTask:   p.randomTask,
+			branch:       repoBranch,
+			report:       p.report,
+			log:          p.log,
+			projectStart: projectStart,
+			verbose:      !isInteractive(),
 		})
-
-		for _, scoredTask := range selectedTasks {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-			}
-
-			tasksRun++
-			if !isInteractive() {
-				fmt.Printf("\n--- Running: %s (via %s) ---\n", scoredTask.Definition.Name, choice.name)
-			}
-			projectTaskTypes = append(projectTaskTypes, string(scoredTask.Definition.Type))
-
-			taskInstance := &tasks.Task{
-				ID:          fmt.Sprintf("%s:%s", scoredTask.Definition.Type, stateKey),
-				Title:       scoredTask.Definition.Name,
-				Description: scoredTask.Definition.Description,
-				Priority:    int(scoredTask.Score),
-				Type:        scoredTask.Definition.Type,
-			}
-
-			p.st.MarkAssigned(taskInstance.ID, stateKey, string(scoredTask.Definition.Type))
-			result, runErr := orch.RunTask(ctx, taskInstance, rw.Path)
-			p.st.ClearAssigned(taskInstance.ID)
-
-			if runErr != nil {
-				tasksFailed++
-				projectFailed++
-				p.log.Errorf("task %s failed: %v", taskInstance.ID, runErr)
-				if p.report != nil {
-					p.report.addTask(reporting.TaskResult{
-						Project:  rw.Path,
-						TaskType: string(scoredTask.Definition.Type),
-						Title:    scoredTask.Definition.Name,
-						Status:   "failed",
-						Duration: result.Duration,
-					})
-				}
-				continue
-			}
-
-			switch result.Status {
-			case orchestrator.StatusCompleted:
-				tasksCompleted++
-				projectCompleted++
-				if !isInteractive() {
-					fmt.Printf("  COMPLETED in %d iteration(s) (%s)\n", result.Iterations, result.Duration)
-				}
-				p.st.RecordTaskRun(stateKey, string(scoredTask.Definition.Type))
-				_, maxTok := scoredTask.Definition.EstimatedTokens()
-				projectTokensUsed += maxTok
-				if p.report != nil {
-					p.report.addTask(reporting.TaskResult{
-						Project:    rw.Path,
-						TaskType:   string(scoredTask.Definition.Type),
-						Title:      scoredTask.Definition.Name,
-						Status:     "completed",
-						OutputType: result.OutputType,
-						OutputRef:  result.OutputRef,
-						TokensUsed: maxTok,
-						Duration:   result.Duration,
-						Notes:      compressionNotes(result.Logs),
-					})
-				}
-			default:
-				tasksFailed++
-				projectFailed++
-				if !isInteractive() {
-					fmt.Printf("  FAILED: %s\n", result.Error)
-				}
-				if p.report != nil {
-					p.report.addTask(reporting.TaskResult{
-						Project:    rw.Path,
-						TaskType:   string(scoredTask.Definition.Type),
-						Title:      scoredTask.Definition.Name,
-						Status:     "failed",
-						SkipReason: result.Error,
-						Duration:   result.Duration,
-					})
-				}
-			}
-		}
-
-		p.st.RecordProjectRun(stateKey)
-		projectStatus := "partial"
-		if projectFailed == 0 && projectCompleted > 0 {
-			projectStatus = "success"
-		}
-		if projectCompleted == 0 && projectFailed > 0 {
-			projectStatus = "failed"
-		}
-		p.st.AddRunRecord(state.RunRecord{
-			StartTime:  projectStart,
-			EndTime:    time.Now(),
-			Provider:   choice.name,
-			Project:    rw.Path,
-			Tasks:      projectTaskTypes,
-			TokensUsed: projectTokensUsed,
-			Status:     projectStatus,
-			Branch:     p.branch,
-		})
+		tasksRun += run
+		tasksCompleted += ok
+		tasksFailed += fail
 	}
 
 	duration := time.Since(start)

--- a/docs/dev/workspace.md
+++ b/docs/dev/workspace.md
@@ -107,3 +107,34 @@ For a true clean slate, move the ticket back to TODO and let `CleanupStaleWorksp
 ## Testability
 
 `workspace_test.go` uses a temp dir + a stub `git` executable wrapper. The `Run` function for git commands is a package-level var; substitute in tests.
+
+---
+
+## Task-isolation workspace (`internal/workspace`)
+
+**Note**: This is a separate workspace system from the Jira pipeline workspace described above.
+
+`internal/workspace` manages clone-based isolated working directories for task runs configured via `workspace.root` + `workspace.repos` in the YAML config.
+
+### Daemon workspace mode (VC-87)
+
+When `workspace.root` is set, both `nightshift run` **and** `nightshift daemon` clone repos into fresh workspaces before executing tasks:
+
+- `nightshift run` → `workspacedRun()` in `cmd/nightshift/commands/run.go`
+- `nightshift daemon` → `runScheduledWorkspacedTasks()` in `cmd/nightshift/commands/daemon.go`
+
+Both paths share `runRepoTasks()` for the per-repo task execution loop.
+
+### State key
+
+In workspace mode, the **repo name** (`workspace.repos[*].name`) is used as the state key for cooldown and staleness tracking — not the UUID-suffixed clone path. This ensures cooldowns persist across runs even though each run creates a fresh clone directory.
+
+This applies consistently in both `nightshift run` and `nightshift daemon`.
+
+### Per-repo task filter
+
+`workspace.repos[*].tasks` lists allowed task types for that repo. When set, `runRepoTasks` filters out tasks not in the list before execution. Empty/nil means no filter (all enabled tasks are eligible).
+
+### Exported test helper
+
+`workspace.SetGitExecFn(fn)` replaces the internal git executor and returns the previous function for `defer`-based restoration. Used in `cmd/nightshift/commands/daemon_test.go` to avoid real git clones in tests.

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -156,7 +156,7 @@ reporting:
 
 ## Workspace Mode
 
-When `workspace.root` is set, each task run clones repos into a fresh isolated directory instead of executing inside your live project directories. This keeps your working tree clean.
+When `workspace.root` is set, each task run clones repos into a fresh isolated directory instead of executing inside your live project directories. This keeps your working tree clean. Workspace mode applies to both `nightshift run` and `nightshift daemon`.
 
 ```yaml
 workspace:
@@ -166,11 +166,20 @@ workspace:
       # name defaults to "repo-a" (URL basename without .git)
     - url: git@github.com:org/repo-b.git
       name: repo-b-custom         # optional override
+      tasks:                      # limit to these task types for this repo only
+        - lint-fix
+        - pr-review
+      pattern: "src/**"           # path glob (informational)
+      exclude:                    # paths to exclude (informational)
+        - vendor/
 ```
 
 - `root`: directory where workspace subdirectories are created. Supports `~`.
 - `repos[].url`: SSH URL only (must start with `git@`). HTTPS URLs are rejected at config load.
-- `repos[].name`: optional human name; defaults to the repo basename without `.git`.
+- `repos[].name`: optional human name; defaults to the repo basename without `.git`. Used as the stable cooldown state key across runs.
+- `repos[].tasks`: optional list of task types allowed for this repo. When set, only these tasks run here regardless of global task config. Omit or use `[]` for no restriction.
+- `repos[].pattern`: optional path glob (informational).
+- `repos[].exclude`: optional exclusion paths (informational).
 
 Each run creates `<root>/<name>_<runID>/` per repo, clones fresh, runs tasks there, and leaves the workspace for 7-day automatic cleanup.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,8 +40,11 @@ type WorkspaceConfig struct {
 
 // WorkspaceRepoConfig defines one repository to clone per workspace run.
 type WorkspaceRepoConfig struct {
-	URL  string `mapstructure:"url"`
-	Name string `mapstructure:"name"` // optional; defaults to repo basename without .git
+	URL     string   `mapstructure:"url"`
+	Name    string   `mapstructure:"name"`    // optional; defaults to repo basename without .git
+	Tasks   []string `mapstructure:"tasks"`   // allowed task types for this repo; nil = all enabled
+	Pattern string   `mapstructure:"pattern"` // path glob pattern for discovery
+	Exclude []string `mapstructure:"exclude"` // paths to exclude
 }
 
 // PromptCompressionConfig controls LLM-based prompt compression before agent execution.

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -21,8 +21,11 @@ type Config struct {
 
 // RepoConfig defines a repository to clone for each workspace.
 type RepoConfig struct {
-	URL  string
-	Name string // defaults to repo basename without .git
+	URL     string
+	Name    string   // defaults to repo basename without .git
+	Tasks   []string // allowed task types; nil = all enabled
+	Pattern string   // path glob pattern
+	Exclude []string // paths to exclude
 }
 
 // Workspace is an isolated working directory created for a single run.
@@ -34,9 +37,12 @@ type Workspace struct {
 
 // RepoWorkspace holds the state of one cloned repository inside a Workspace.
 type RepoWorkspace struct {
-	Name string
-	Path string
-	URL  string
+	Name    string
+	Path    string
+	URL     string
+	Tasks   []string // per-repo allowed task types; nil = all enabled
+	Pattern string
+	Exclude []string
 }
 
 // workspaceMeta is stored as .nightshift-workspace.json inside each workspace dir.
@@ -60,6 +66,14 @@ var gitExecFn = func(ctx context.Context, dir string, args ...string) (string, e
 		return "", fmt.Errorf("git %s: %w", sub, err)
 	}
 	return trimmed, nil
+}
+
+// SetGitExecFn replaces the git executor used by SetupWorkspace. Returns the old
+// function so tests can restore it via defer. Intended for testing only.
+func SetGitExecFn(fn func(context.Context, string, ...string) (string, error)) func(context.Context, string, ...string) (string, error) {
+	old := gitExecFn
+	gitExecFn = fn
+	return old
 }
 
 // SetupWorkspace creates a fresh isolated workspace for runID.
@@ -116,7 +130,7 @@ func SetupWorkspace(ctx context.Context, cfg Config, runID string) (*Workspace, 
 			return nil, fmt.Errorf("write metadata for %s: %w", name, err)
 		}
 
-		repos = append(repos, RepoWorkspace{Name: name, Path: wsPath, URL: r.URL})
+		repos = append(repos, RepoWorkspace{Name: name, Path: wsPath, URL: r.URL, Tasks: r.Tasks, Pattern: r.Pattern, Exclude: r.Exclude})
 	}
 
 	return &Workspace{


### PR DESCRIPTION
## VC-87 — Daemon scheduler ignores workspace isolation — local tasks run in-place on real repos

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-87

### Description

Summary
Workspace isolation (workspace.root / workspace.repos) is only wired into the nightshift run command. The daemon scheduler — the path systemd nightshift.service actually uses — never routes through it and runs every task in-place on the real project directory listed under projects:.
Result: autonomous tasks (pii-scanner, bug-finder, etc.) mutate the user's working copies in ~/doc/github/* — checking out branches, leaving untracked artifacts, committing/pushing. Observed in FinPilot.v4: 5 stray scanner output/fixture files + multiple stray local branches left in the working tree after a daemon run.
Evidence
run.go:258 gates correctly: if cfg.Workspace.Root != "" && len(cfg.Workspace.Repos) > 0 { return workspacedRun(...) }.
workspacedRun (run.go:625) clones via workspace.SetupWorkspace() and runs orch.RunTask(ctx, task, rw.Path) against the clone.
runScheduledTasks (daemon.go:295) — the daemon execution loop — has zero references to cfg.Workspace. It calls resolveProjects() then orch.RunTask(ctx, task, projectPath) against the real repo path (daemon.go:432).
Smoking gun: runDaemonLoop (daemon.go:260) calls workspace.CleanupStaleWorkspaces() — GC for workspaces the daemon never creates. The cleanup side was wired; the create/execute side was not.
Latent bugs in existing workspace code
State-key divergence. workspacedRun uses rw.Name as the cooldown state key (run.go:709); runScheduledTasks uses projectPath (daemon.go:404); WasProcessedToday keys off path (daemon.go:338). Mixed-mode runs split cooldown tracking → tasks double-run.
Per-project task config dropped in workspace mode. projects: entries carry tasks / pattern / exclude / config keyed by path; cloned workspace paths match no projects: path:, so per-project filters are silently lost.
Root cause
executeRun, workspacedRun, and runScheduledTasks are three near-duplicate per-project task loops. Workspace isolation was patched into copy #2 only; the copies have drifted.
Proposed fix
Refactor — extract the per-repo task loop into one shared function, e.g. runRepoTasks(ctx, orch, selector, st, repoPath, stateKey, maxTasks, ...). Both daemon and run become thin wrappers:
workspace.root set → SetupWorkspace() → loop ws.Repos, call runRepoTasks(rw.Path, rw.Name, ...)
unset → loop projects:, call runRepoTasks(projectPath, projectPath, ...)
This fixes the daemon and removes the 3-way duplication in one move. Also: standardize the state key (repo name everywhere) and define how workspace.repos carries per-repo task config so bug #2 cannot recur.
Acceptance criteria
Daemon scheduler clones into workspace.root when configured; no task touches a path under projects: directly.
nightshift run behavior unchanged.
Cooldown state key is consistent across both modes.
Per-project task config (tasks/pattern/exclude) still applies in workspace mode.
Tests cover daemon-mode workspace routing.
Notes
Files affected: cmd/nightshift/commands/daemon.go, cmd/nightshift/commands/run.go, internal/workspace/. Jira pipeline (nightshift-jira.service) is unaffected — it has its own jira.workspace_root clone path.

### Acceptance Criteria

Daemon scheduler clones into workspace.root when configured; no task touches a path under projects: directly.
nightshift run behavior unchanged.
Cooldown state key is consistent across both modes.
Per-project task config (tasks/pattern/exclude) still applies in workspace mode.
Tests cover daemon-mode workspace routing.
Notes
Files affected: cmd/nightshift/commands/daemon.go, cmd/nightshift/commands/run.go, internal/workspace/. Jira pipeline (nightshift-jira.service) is unaffected — it has its own jira.workspace_root clone path.

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
