### PR TITLE
[VC-91] internal/orchestrator uses raw exec.Command for gh/git — not injectable, untestable

### DIFF
--- a/internal/analysis/analyzer.go
+++ b/internal/analysis/analyzer.go
@@ -16,6 +16,14 @@ type CommitAuthor struct {
 	Commits int
 }
 
+// gitExecFn runs git with the given args in repoPath and returns raw output.
+// Substitutable in tests.
+var gitExecFn = func(repoPath string, args ...string) ([]byte, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoPath
+	return cmd.Output()
+}
+
 // GitParser extracts commit history from a git repository.
 type GitParser struct {
 	repoPath string
@@ -44,10 +52,7 @@ func (gp *GitParser) ParseAuthors(opts ParseOptions) ([]CommitAuthor, error) {
 		args = append(args, "--", opts.FilePath)
 	}
 
-	cmd := exec.Command("git", args...)
-	cmd.Dir = gp.repoPath
-
-	output, err := cmd.Output()
+	output, err := gitExecFn(gp.repoPath, args...)
 	if err != nil {
 		return nil, fmt.Errorf("running git log: %w", err)
 	}

--- a/internal/analysis/analyzer_test.go
+++ b/internal/analysis/analyzer_test.go
@@ -1,6 +1,7 @@
 package analysis
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -173,5 +174,63 @@ func TestParseOptionsWithFilters(t *testing.T) {
 	}
 	if opts.FilePath != "pkg/foo.go" {
 		t.Errorf("expected file path 'pkg/foo.go', got %s", opts.FilePath)
+	}
+}
+
+// --- gitExecFn injectable var tests ---
+
+func TestParseAuthors_Success(t *testing.T) {
+	orig := gitExecFn
+	defer func() { gitExecFn = orig }()
+
+	gitExecFn = func(_ string, _ ...string) ([]byte, error) {
+		return []byte("Alice|alice@a.com\nBob|bob@b.com\n"), nil
+	}
+
+	parser := NewGitParser("/fake")
+	authors, err := parser.ParseAuthors(ParseOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(authors) != 2 {
+		t.Fatalf("expected 2 authors, got %d", len(authors))
+	}
+	for _, a := range authors {
+		if a.Commits != 1 {
+			t.Errorf("author %s: expected Commits=1, got %d", a.Name, a.Commits)
+		}
+	}
+}
+
+func TestParseAuthors_GitError(t *testing.T) {
+	orig := gitExecFn
+	defer func() { gitExecFn = orig }()
+
+	gitExecFn = func(_ string, _ ...string) ([]byte, error) {
+		return nil, errors.New("git not found")
+	}
+
+	parser := NewGitParser("/fake")
+	_, err := parser.ParseAuthors(ParseOptions{})
+	if err == nil {
+		t.Error("expected error from gitExecFn failure")
+	}
+}
+
+func TestParseAuthors_MalformedLines(t *testing.T) {
+	orig := gitExecFn
+	defer func() { gitExecFn = orig }()
+
+	gitExecFn = func(_ string, _ ...string) ([]byte, error) {
+		return []byte("no-separator\nalice@a.com\n\n"), nil
+	}
+
+	parser := NewGitParser("/fake")
+	authors, err := parser.ParseAuthors(ParseOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(authors) != 0 {
+		t.Errorf("expected 0 authors for malformed input, got %d", len(authors))
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -25,6 +25,30 @@ const (
 	DefaultAgentTimeout  = 30 * time.Minute
 )
 
+// ghExec runs a gh subcommand in repoPath and returns trimmed stdout+stderr.
+// Substitutable in tests.
+var ghExec = func(ctx context.Context, repoPath string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Dir = repoPath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("gh %s failed: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// gitExec runs a git subcommand in repoPath and returns trimmed stdout+stderr.
+// Substitutable in tests.
+var gitExec = func(ctx context.Context, repoPath string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = repoPath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s failed: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // TaskStatus represents the outcome of task execution.
 type TaskStatus string
 
@@ -449,14 +473,10 @@ func ParseMetadataBlock(body string) map[string]string {
 // Idempotent: skips if a metadata block already exists.
 func (o *Orchestrator) annotatePR(ctx context.Context, prURL string, task *tasks.Task, result *TaskResult, workDir string) error {
 	// Read current PR body
-	readCmd := exec.CommandContext(ctx, "gh", "pr", "view", prURL, "--json", "body", "-q", ".body")
-	readCmd.Dir = workDir
-	bodyBytes, err := readCmd.CombinedOutput()
+	currentBody, err := ghExec(ctx, workDir, "pr", "view", prURL, "--json", "body", "-q", ".body")
 	if err != nil {
-		return fmt.Errorf("gh pr view: %s: %w", string(bodyBytes), err)
+		return fmt.Errorf("gh pr view: %w", err)
 	}
-
-	currentBody := string(bodyBytes)
 
 	// Skip if metadata already present
 	if ParseMetadataBlock(currentBody) != nil {
@@ -467,10 +487,8 @@ func (o *Orchestrator) annotatePR(ctx context.Context, prURL string, task *tasks
 	newBody := strings.TrimRight(currentBody, "\n") + "\n\n" + metaBlock
 
 	// Update PR body
-	editCmd := exec.CommandContext(ctx, "gh", "pr", "edit", prURL, "--body", newBody)
-	editCmd.Dir = workDir
-	if output, err := editCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("gh pr edit: %s: %w", string(output), err)
+	if _, err = ghExec(ctx, workDir, "pr", "edit", prURL, "--body", newBody); err != nil {
+		return fmt.Errorf("gh pr edit: %w", err)
 	}
 	return nil
 }
@@ -980,24 +998,19 @@ func (o *Orchestrator) log(result *TaskResult, level, msg string, fields map[str
 // CurrentBranch resolves the current git branch in the given directory.
 // Returns an error if the directory is not inside a git repository.
 func CurrentBranch(ctx context.Context, workDir string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")
-	cmd.Dir = workDir
-	out, err := cmd.Output()
+	out, err := gitExec(ctx, workDir, "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("git rev-parse --abbrev-ref HEAD: %w", err)
 	}
-	return strings.TrimSpace(string(out)), nil
+	return out, nil
 }
 
 // validateGitRepo verifies that workDir is inside an existing git repository.
 func validateGitRepo(ctx context.Context, workDir string) error {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
-	cmd.Dir = workDir
-	out, err := cmd.Output()
+	repoRoot, err := gitExec(ctx, workDir, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return fmt.Errorf("not a git repository: %w", err)
 	}
-	repoRoot := strings.TrimSpace(string(out))
 
 	// Ensure the repo root is not $HOME or any parent of it.
 	home, err := os.UserHomeDir()
@@ -1013,12 +1026,8 @@ func validateGitRepo(ctx context.Context, workDir string) error {
 
 // checkoutBranch runs git checkout to restore a branch in the given directory.
 func checkoutBranch(ctx context.Context, workDir, branch string) error {
-	cmd := exec.CommandContext(ctx, "git", "checkout", branch)
-	cmd.Dir = workDir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git checkout %s: %s: %w", branch, strings.TrimSpace(string(out)), err)
-	}
-	return nil
+	_, err := gitExec(ctx, workDir, "checkout", branch)
+	return err
 }
 
 // truncateStr returns s trimmed to maxLen characters, appending "..." if truncated.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -31,10 +31,16 @@ var ghExec = func(ctx context.Context, repoPath string, args ...string) (string,
 	cmd := exec.CommandContext(ctx, "gh", args...)
 	cmd.Dir = repoPath
 	out, err := cmd.CombinedOutput()
+	trimmed := strings.TrimSpace(string(out))
 	if err != nil {
-		return "", fmt.Errorf("gh %s failed: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
+		// Sanitize args to avoid leaking large/sensitive values (e.g., full PR body after --body flag)
+		sanitized := sanitizeArgs(args)
+		if trimmed != "" {
+			return "", fmt.Errorf("gh %s failed: %s: %w", sanitized, trimmed, err)
+		}
+		return "", fmt.Errorf("gh %s failed: %w", sanitized, err)
 	}
-	return strings.TrimSpace(string(out)), nil
+	return trimmed, nil
 }
 
 // gitExec runs a git subcommand in repoPath and returns trimmed stdout+stderr.
@@ -43,10 +49,30 @@ var gitExec = func(ctx context.Context, repoPath string, args ...string) (string
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = repoPath
 	out, err := cmd.CombinedOutput()
+	trimmed := strings.TrimSpace(string(out))
 	if err != nil {
-		return "", fmt.Errorf("git %s failed: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
+		sanitized := strings.Join(args, " ")
+		if trimmed != "" {
+			return "", fmt.Errorf("git %s failed: %s: %w", sanitized, trimmed, err)
+		}
+		return "", fmt.Errorf("git %s failed: %w", sanitized, err)
 	}
-	return strings.TrimSpace(string(out)), nil
+	return trimmed, nil
+}
+
+// sanitizeArgs redacts large/sensitive argument values to prevent leaking them in error messages.
+// Omits values after flags like --body that commonly contain large or sensitive data.
+func sanitizeArgs(args []string) string {
+	var redacted []string
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--body" && i+1 < len(args) {
+			redacted = append(redacted, "--body", "[REDACTED]")
+			i++ // Skip the next arg (the body value)
+		} else {
+			redacted = append(redacted, args[i])
+		}
+	}
+	return strings.Join(redacted, " ")
 }
 
 // TaskStatus represents the outcome of task execution.
@@ -472,8 +498,8 @@ func ParseMetadataBlock(body string) map[string]string {
 // annotatePR appends a metadata block to an existing GitHub PR body.
 // Idempotent: skips if a metadata block already exists.
 func (o *Orchestrator) annotatePR(ctx context.Context, prURL string, task *tasks.Task, result *TaskResult, workDir string) error {
-	// Read current PR body
-	currentBody, err := ghExec(ctx, workDir, "pr", "view", prURL, "--json", "body", "-q", ".body")
+	// Read current PR body (preserving trailing whitespace for Markdown preservation)
+	currentBody, err := getPRBodyVerbatim(ctx, workDir, prURL)
 	if err != nil {
 		return fmt.Errorf("gh pr view: %w", err)
 	}
@@ -491,6 +517,27 @@ func (o *Orchestrator) annotatePR(ctx context.Context, prURL string, task *tasks
 		return fmt.Errorf("gh pr edit: %w", err)
 	}
 	return nil
+}
+
+// getPRBodyVerbatim fetches the PR body while preserving trailing whitespace (Markdown-significant).
+// Only trims the single trailing newline added by gh output. Substitutable in tests.
+var getPRBodyVerbatim = func(ctx context.Context, repoPath string, prURL string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prURL, "--json", "body", "-q", ".body")
+	cmd.Dir = repoPath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(out))
+		if trimmed != "" {
+			return "", fmt.Errorf("gh pr view failed: %s: %w", trimmed, err)
+		}
+		return "", fmt.Errorf("gh pr view failed: %w", err)
+	}
+	// Only trim the trailing newline gh adds, preserve other trailing whitespace
+	body := string(out)
+	if len(body) > 0 && body[len(body)-1] == '\n' {
+		body = body[:len(body)-1]
+	}
+	return body, nil
 }
 
 // plan spawns the plan agent to create an execution plan.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3,6 +3,8 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -918,5 +920,171 @@ func TestRunTaskNoPRURL(t *testing.T) {
 	}
 	if result.OutputRef != "" {
 		t.Errorf("OutputRef = %q, want empty", result.OutputRef)
+	}
+}
+
+// --- ghExec / gitExec injectable var tests ---
+
+func TestAnnotatePR_SkipsWhenMetadataPresent(t *testing.T) {
+	origGh := ghExec
+	defer func() { ghExec = origGh }()
+
+	editCalled := false
+	ghExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		if args[0] == "pr" && args[1] == "view" {
+			return "existing body\n<!-- nightshift:metadata\nkey: val\nnightshift:metadata -->", nil
+		}
+		editCalled = true
+		return "", nil
+	}
+
+	o := New(WithAgent(newMockAgent()))
+	task := &tasks.Task{ID: "t1", Title: "T"}
+	result := &TaskResult{}
+	err := o.annotatePR(context.Background(), "https://github.com/o/r/pull/1", task, result, "/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if editCalled {
+		t.Error("gh pr edit should not be called when metadata already present")
+	}
+}
+
+func TestAnnotatePR_AppendsMetadataBlock(t *testing.T) {
+	origGh := ghExec
+	defer func() { ghExec = origGh }()
+
+	var editBody string
+	ghExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		if args[0] == "pr" && args[1] == "view" {
+			return "existing body", nil
+		}
+		// pr edit — capture --body value
+		for i, a := range args {
+			if a == "--body" && i+1 < len(args) {
+				editBody = args[i+1]
+			}
+		}
+		return "", nil
+	}
+
+	o := New(WithAgent(newMockAgent()))
+	task := &tasks.Task{ID: "t1", Title: "MyTask"}
+	result := &TaskResult{Status: StatusCompleted}
+	err := o.annotatePR(context.Background(), "https://github.com/o/r/pull/1", task, result, "/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(editBody, "nightshift:metadata") {
+		t.Errorf("edited body missing metadata block, got: %q", editBody)
+	}
+	if !strings.Contains(editBody, "existing body") {
+		t.Errorf("edited body missing original content, got: %q", editBody)
+	}
+}
+
+func TestAnnotatePR_ViewError(t *testing.T) {
+	origGh := ghExec
+	defer func() { ghExec = origGh }()
+
+	ghExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		return "", fmt.Errorf("auth error")
+	}
+
+	o := New(WithAgent(newMockAgent()))
+	err := o.annotatePR(context.Background(), "https://github.com/o/r/pull/1", &tasks.Task{}, &TaskResult{}, "/work")
+	if err == nil {
+		t.Error("expected error from ghExec failure")
+	}
+}
+
+func TestCurrentBranch_OK(t *testing.T) {
+	origGit := gitExec
+	defer func() { gitExec = origGit }()
+
+	gitExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		return "main", nil
+	}
+
+	branch, err := CurrentBranch(context.Background(), "/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if branch != "main" {
+		t.Errorf("branch = %q, want main", branch)
+	}
+}
+
+func TestCurrentBranch_Error(t *testing.T) {
+	origGit := gitExec
+	defer func() { gitExec = origGit }()
+
+	gitExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		return "", fmt.Errorf("not a repo")
+	}
+
+	_, err := CurrentBranch(context.Background(), "/work")
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestValidateGitRepo_OK(t *testing.T) {
+	origGit := gitExec
+	defer func() { gitExec = origGit }()
+
+	gitExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		return "/some/project", nil
+	}
+
+	err := validateGitRepo(context.Background(), "/some/project")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateGitRepo_RejectsHome(t *testing.T) {
+	origGit := gitExec
+	defer func() { gitExec = origGit }()
+
+	home, _ := os.UserHomeDir()
+	gitExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		return home, nil
+	}
+
+	err := validateGitRepo(context.Background(), home)
+	if err == nil {
+		t.Error("expected error for HOME as repo root")
+	}
+	if !strings.Contains(err.Error(), "$HOME") {
+		t.Errorf("error should mention $HOME, got: %v", err)
+	}
+}
+
+func TestCheckoutBranch_OK(t *testing.T) {
+	origGit := gitExec
+	defer func() { gitExec = origGit }()
+
+	gitExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		return "", nil
+	}
+
+	err := checkoutBranch(context.Background(), "/work", "feature/x")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCheckoutBranch_Error(t *testing.T) {
+	origGit := gitExec
+	defer func() { gitExec = origGit }()
+
+	gitExec = func(_ context.Context, _ string, args ...string) (string, error) {
+		return "", fmt.Errorf("branch not found")
+	}
+
+	err := checkoutBranch(context.Background(), "/work", "feature/x")
+	if err == nil {
+		t.Error("expected error")
 	}
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -927,15 +927,19 @@ func TestRunTaskNoPRURL(t *testing.T) {
 
 func TestAnnotatePR_SkipsWhenMetadataPresent(t *testing.T) {
 	origGh := ghExec
-	defer func() { ghExec = origGh }()
+	origGetBody := getPRBodyVerbatim
+	defer func() {
+		ghExec = origGh
+		getPRBodyVerbatim = origGetBody
+	}()
 
 	editCalled := false
 	ghExec = func(_ context.Context, _ string, args ...string) (string, error) {
-		if args[0] == "pr" && args[1] == "view" {
-			return "existing body\n<!-- nightshift:metadata\nkey: val\nnightshift:metadata -->", nil
-		}
 		editCalled = true
 		return "", nil
+	}
+	getPRBodyVerbatim = func(_ context.Context, _ string, _ string) (string, error) {
+		return "existing body\n<!-- nightshift:metadata\nkey: val\nnightshift:metadata -->", nil
 	}
 
 	o := New(WithAgent(newMockAgent()))
@@ -952,13 +956,14 @@ func TestAnnotatePR_SkipsWhenMetadataPresent(t *testing.T) {
 
 func TestAnnotatePR_AppendsMetadataBlock(t *testing.T) {
 	origGh := ghExec
-	defer func() { ghExec = origGh }()
+	origGetBody := getPRBodyVerbatim
+	defer func() {
+		ghExec = origGh
+		getPRBodyVerbatim = origGetBody
+	}()
 
 	var editBody string
 	ghExec = func(_ context.Context, _ string, args ...string) (string, error) {
-		if args[0] == "pr" && args[1] == "view" {
-			return "existing body", nil
-		}
 		// pr edit — capture --body value
 		for i, a := range args {
 			if a == "--body" && i+1 < len(args) {
@@ -966,6 +971,9 @@ func TestAnnotatePR_AppendsMetadataBlock(t *testing.T) {
 			}
 		}
 		return "", nil
+	}
+	getPRBodyVerbatim = func(_ context.Context, _ string, _ string) (string, error) {
+		return "existing body", nil
 	}
 
 	o := New(WithAgent(newMockAgent()))
@@ -984,17 +992,17 @@ func TestAnnotatePR_AppendsMetadataBlock(t *testing.T) {
 }
 
 func TestAnnotatePR_ViewError(t *testing.T) {
-	origGh := ghExec
-	defer func() { ghExec = origGh }()
+	origGetBody := getPRBodyVerbatim
+	defer func() { getPRBodyVerbatim = origGetBody }()
 
-	ghExec = func(_ context.Context, _ string, args ...string) (string, error) {
+	getPRBodyVerbatim = func(_ context.Context, _ string, _ string) (string, error) {
 		return "", fmt.Errorf("auth error")
 	}
 
 	o := New(WithAgent(newMockAgent()))
 	err := o.annotatePR(context.Background(), "https://github.com/o/r/pull/1", &tasks.Task{}, &TaskResult{}, "/work")
 	if err == nil {
-		t.Error("expected error from ghExec failure")
+		t.Error("expected error from getPRBodyVerbatim failure")
 	}
 }
 


### PR DESCRIPTION
## VC-91 — internal/orchestrator uses raw exec.Command for gh/git — not injectable, untestable

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-91

### Description

Bug
internal/orchestrator/orchestrator.go invokes gh and git via raw exec.CommandContext, so those code paths cannot be unit-tested:
orchestrator.go:452 — gh pr view
orchestrator.go:470 — gh pr edit
orchestrator.go:983 — git rev-parse --abbrev-ref HEAD
orchestrator.go:994 — git rev-parse --show-toplevel
orchestrator.go:1016 — git checkout
internal/jira already solves this with injectable package-level vars (ghExec, gitExecFn) substituted in tests. internal/orchestrator does not follow that pattern, and internal/analysis/analyzer.go:47 has the same raw-git issue.
Impact
PR-body update and branch save/restore logic (the RunTask defer-checkout flow) is exercised only via real gh/git — no deterministic unit coverage. internal/orchestrator sits at 72.5% coverage; these paths are part of the gap.
Fix
Introduce injectable ghExec / gitExec package vars in internal/orchestrator (mirror the internal/jira pattern).
Route the five call sites through them.
Apply the same to internal/analysis/analyzer.go.
Add unit tests substituting the exec funcs.
Location
internal/orchestrator/orchestrator.go, internal/analysis/analyzer.go.

Filed from codebase analysis — automated agent

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
