### PR TITLE
[VC-92] internal/agents: heavy duplication across claude/codex/copilot — 15 near-identical options, pointless wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to nightshift are documented in this file.
 
 ## [Unreleased]
 
+### Refactoring
+
+- **agents: deduplicate option constructors (VC-92)** — extracted shared `agentConfig` struct and
+  unified `Option` type into `options.go`. All three agents now use `WithBinaryPath`, `WithDefaultTimeout`,
+  `WithRunner`, `WithModel`, `WithEffort`, and `WithBypassPermissions`. Removed per-agent `extractJSON`
+  method wrappers; `handleExecuteResult` calls `extractJSON` directly. Deprecated type aliases
+  (`ClaudeOption`, `CodexOption`, `CopilotOption`) and function var aliases (`WithCodexRunner`, etc.)
+  kept for one-release backward compatibility.
+
 ### Breaking Changes
 
 - **Removed deprecated flat Jira config fields** — `jira.project`, `jira.label`, and `jira.repos`

--- a/cmd/nightshift/commands/helpers.go
+++ b/cmd/nightshift/commands/helpers.go
@@ -41,7 +41,7 @@ func agentByName(cfg *config.Config, provider string) (agents.Agent, error) {
 	}
 }
 
-func newClaudeAgentFromConfig(cfg *config.Config, extra ...agents.ClaudeOption) *agents.ClaudeAgent {
+func newClaudeAgentFromConfig(cfg *config.Config, extra ...agents.Option) *agents.ClaudeAgent {
 	if cfg == nil {
 		return agents.NewClaudeAgent(extra...)
 	}
@@ -65,7 +65,7 @@ func newClaudeAgentFromConfig(cfg *config.Config, extra ...agents.ClaudeOption) 
 	return agents.NewClaudeAgent(opts...)
 }
 
-func newCodexAgentFromConfig(cfg *config.Config, extra ...agents.CodexOption) *agents.CodexAgent {
+func newCodexAgentFromConfig(cfg *config.Config, extra ...agents.Option) *agents.CodexAgent {
 	if cfg == nil {
 		return agents.NewCodexAgent(extra...)
 	}
@@ -81,19 +81,19 @@ func newCodexAgentFromConfig(cfg *config.Config, extra ...agents.CodexOption) *a
 	// the side of enabling the flag for headless operation is the safe choice;
 	// users who want Codex to prompt for approvals should disable the provider
 	// entirely rather than toggling this flag.
-	opts := []agents.CodexOption{}
+	opts := []agents.Option{}
 	if cfg.Providers.Codex.DangerouslyBypassApprovalsAndSandbox {
-		opts = append(opts, agents.WithDangerouslyBypassApprovalsAndSandbox(true))
+		opts = append(opts, agents.WithBypassPermissions(true))
 	}
 	if cfg.Providers.Codex.Model != "" {
-		opts = append(opts, agents.WithCodexModel(cfg.Providers.Codex.Model))
+		opts = append(opts, agents.WithModel(cfg.Providers.Codex.Model))
 	}
 	if cfg.Providers.Codex.ReasoningEffort != "" {
-		opts = append(opts, agents.WithCodexEffort(cfg.Providers.Codex.ReasoningEffort))
+		opts = append(opts, agents.WithEffort(cfg.Providers.Codex.ReasoningEffort))
 	}
 	if cfg.Providers.Codex.Timeout != "" {
 		if d, err := time.ParseDuration(cfg.Providers.Codex.Timeout); err == nil {
-			opts = append(opts, agents.WithCodexDefaultTimeout(d))
+			opts = append(opts, agents.WithDefaultTimeout(d))
 		} else {
 			logging.Get().Warnf("invalid codex timeout %q, using default: %v", cfg.Providers.Codex.Timeout, err)
 		}
@@ -106,7 +106,7 @@ func newCodexAgentFromConfig(cfg *config.Config, extra ...agents.CodexOption) *a
 // is non-empty it overrides auto-detection; otherwise the binary is resolved
 // from PATH (preferring standalone "copilot", falling back to "gh").
 // Extra CopilotOptions (e.g. phase-specific model/timeout) are applied last.
-func newCopilotAgentFromConfig(cfg *config.Config, binaryPath string, extra ...agents.CopilotOption) *agents.CopilotAgent {
+func newCopilotAgentFromConfig(cfg *config.Config, binaryPath string, extra ...agents.Option) *agents.CopilotAgent {
 	if cfg == nil {
 		return agents.NewCopilotAgent()
 	}
@@ -120,19 +120,19 @@ func newCopilotAgentFromConfig(cfg *config.Config, binaryPath string, extra ...a
 		}
 	}
 
-	opts := []agents.CopilotOption{
-		agents.WithCopilotBinaryPath(binary),
-		agents.WithCopilotDangerouslySkipPermissions(cfg.Providers.Copilot.DangerouslySkipPermissions),
+	opts := []agents.Option{
+		agents.WithBinaryPath(binary),
+		agents.WithBypassPermissions(cfg.Providers.Copilot.DangerouslySkipPermissions),
 	}
 	if cfg.Providers.Copilot.Model != "" {
-		opts = append(opts, agents.WithCopilotModel(cfg.Providers.Copilot.Model))
+		opts = append(opts, agents.WithModel(cfg.Providers.Copilot.Model))
 	}
 	if cfg.Providers.Copilot.ReasoningEffort != "" {
-		opts = append(opts, agents.WithCopilotEffort(cfg.Providers.Copilot.ReasoningEffort))
+		opts = append(opts, agents.WithEffort(cfg.Providers.Copilot.ReasoningEffort))
 	}
 	if cfg.Providers.Copilot.Timeout != "" {
 		if d, err := time.ParseDuration(cfg.Providers.Copilot.Timeout); err == nil {
-			opts = append(opts, agents.WithCopilotDefaultTimeout(d))
+			opts = append(opts, agents.WithDefaultTimeout(d))
 		} else {
 			logging.Get().Warnf("invalid copilot timeout %q, using default: %v", cfg.Providers.Copilot.Timeout, err)
 		}

--- a/cmd/nightshift/commands/helpers.go
+++ b/cmd/nightshift/commands/helpers.go
@@ -45,8 +45,8 @@ func newClaudeAgentFromConfig(cfg *config.Config, extra ...agents.Option) *agent
 	if cfg == nil {
 		return agents.NewClaudeAgent(extra...)
 	}
-	opts := []agents.ClaudeOption{
-		agents.WithDangerouslySkipPermissions(cfg.Providers.Claude.DangerouslySkipPermissions),
+	opts := []agents.Option{
+		agents.WithBypassPermissions(cfg.Providers.Claude.DangerouslySkipPermissions),
 	}
 	if cfg.Providers.Claude.Model != "" {
 		opts = append(opts, agents.WithModel(cfg.Providers.Claude.Model))

--- a/cmd/nightshift/commands/helpers_test.go
+++ b/cmd/nightshift/commands/helpers_test.go
@@ -65,7 +65,7 @@ func TestNewCodexAgentFromConfig_ReasoningEffort(t *testing.T) {
 			cfg := &config.Config{}
 			cfg.Providers.Codex.ReasoningEffort = tt.effort
 
-			a := newCodexAgentFromConfig(cfg, agents.WithCodexRunner(mr))
+			a := newCodexAgentFromConfig(cfg, agents.WithRunner(mr))
 			_, _ = a.Execute(context.Background(), agents.ExecuteOptions{Prompt: "test"})
 
 			hasConfig := slices.Contains(mr.captured, "--config")
@@ -104,7 +104,7 @@ func TestNewCopilotAgentFromConfig_ReasoningEffort(t *testing.T) {
 			cfg := &config.Config{}
 			cfg.Providers.Copilot.ReasoningEffort = tt.effort
 
-			a := newCopilotAgentFromConfig(cfg, "", agents.WithCopilotRunner(mr))
+			a := newCopilotAgentFromConfig(cfg, "", agents.WithRunner(mr))
 			_, _ = a.Execute(context.Background(), agents.ExecuteOptions{Prompt: "test"})
 
 			hasFlag := slices.Contains(mr.captured, "--effort")

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -501,45 +501,7 @@ func createJiraAgent(cfg *config.Config, phase jira.PhaseConfig) (agents.Agent, 
 
 	switch provider {
 	case "codex":
-		var extra []agents.CodexOption
-		if m := phase.Model; m != "" {
-			extra = append(extra, agents.WithCodexModel(m))
-		}
-		if phase.ReasoningEffort != "" {
-			extra = append(extra, agents.WithCodexEffort(phase.ReasoningEffort))
-		}
-		if timeout > 0 {
-			extra = append(extra, agents.WithCodexDefaultTimeout(timeout))
-		}
-		// Jira always requires headless non-interactive execution.
-		extra = append(extra, agents.WithDangerouslyBypassApprovalsAndSandbox(true))
-		a := newCodexAgentFromConfig(cfg, extra...)
-		if !a.Available() {
-			return nil, fmt.Errorf("codex CLI not found in PATH")
-		}
-		return a, nil
-
-	case "copilot":
-		var extra []agents.CopilotOption
-		if m := phase.Model; m != "" {
-			extra = append(extra, agents.WithCopilotModel(m))
-		}
-		if phase.ReasoningEffort != "" {
-			extra = append(extra, agents.WithCopilotEffort(phase.ReasoningEffort))
-		}
-		if timeout > 0 {
-			extra = append(extra, agents.WithCopilotDefaultTimeout(timeout))
-		}
-		// Jira always requires headless non-interactive execution.
-		extra = append(extra, agents.WithCopilotDangerouslySkipPermissions(true))
-		a := newCopilotAgentFromConfig(cfg, "", extra...)
-		if !a.Available() {
-			return nil, fmt.Errorf("copilot CLI not found in PATH")
-		}
-		return a, nil
-
-	default: // "claude" or unrecognized
-		var extra []agents.ClaudeOption
+		var extra []agents.Option
 		if m := phase.Model; m != "" {
 			extra = append(extra, agents.WithModel(m))
 		}
@@ -550,7 +512,45 @@ func createJiraAgent(cfg *config.Config, phase jira.PhaseConfig) (agents.Agent, 
 			extra = append(extra, agents.WithDefaultTimeout(timeout))
 		}
 		// Jira always requires headless non-interactive execution.
-		extra = append(extra, agents.WithDangerouslySkipPermissions(true))
+		extra = append(extra, agents.WithBypassPermissions(true))
+		a := newCodexAgentFromConfig(cfg, extra...)
+		if !a.Available() {
+			return nil, fmt.Errorf("codex CLI not found in PATH")
+		}
+		return a, nil
+
+	case "copilot":
+		var extra []agents.Option
+		if m := phase.Model; m != "" {
+			extra = append(extra, agents.WithModel(m))
+		}
+		if phase.ReasoningEffort != "" {
+			extra = append(extra, agents.WithEffort(phase.ReasoningEffort))
+		}
+		if timeout > 0 {
+			extra = append(extra, agents.WithDefaultTimeout(timeout))
+		}
+		// Jira always requires headless non-interactive execution.
+		extra = append(extra, agents.WithBypassPermissions(true))
+		a := newCopilotAgentFromConfig(cfg, "", extra...)
+		if !a.Available() {
+			return nil, fmt.Errorf("copilot CLI not found in PATH")
+		}
+		return a, nil
+
+	default: // "claude" or unrecognized
+		var extra []agents.Option
+		if m := phase.Model; m != "" {
+			extra = append(extra, agents.WithModel(m))
+		}
+		if phase.ReasoningEffort != "" {
+			extra = append(extra, agents.WithEffort(phase.ReasoningEffort))
+		}
+		if timeout > 0 {
+			extra = append(extra, agents.WithDefaultTimeout(timeout))
+		}
+		// Jira always requires headless non-interactive execution.
+		extra = append(extra, agents.WithBypassPermissions(true))
 		a := newClaudeAgentFromConfig(cfg, extra...)
 		if !a.Available() {
 			return nil, fmt.Errorf("claude CLI not found in PATH")

--- a/docs/dev/agents-internals.md
+++ b/docs/dev/agents-internals.md
@@ -31,6 +31,25 @@ type ExecuteResult struct {
 
 Compressible vs protected: see [Architecture](architecture.md). Putting instructions in `Prompt` risks them being stripped by the compression agent.
 
+## Option Constructors
+
+All three agents share a single `Option` type and set of constructors defined in `options.go`:
+
+```go
+type Option func(*agentConfig)
+
+func WithBinaryPath(p string) Option
+func WithDefaultTimeout(d time.Duration) Option
+func WithRunner(r CommandRunner) Option
+func WithModel(m string) Option
+func WithEffort(e string) Option
+func WithBypassPermissions(v bool) Option
+```
+
+Deprecated type aliases (`ClaudeOption = Option`, `CodexOption = Option`, `CopilotOption = Option`) and function var aliases (`WithCodexRunner = WithRunner`, etc.) are provided for one-release backward compatibility. Prefer the unified names.
+
+Default `bypassPermissions`: `true` for Claude and Codex, `false` for Copilot — matches original behaviour.
+
 ## Three Implementations
 
 | File | Binary | Notable flags |
@@ -86,7 +105,7 @@ func handleExecuteResult(out, errOut string, exitCode int, err error, compressSt
 
 - Maps exit codes → result status
 - Detects timeout (`context.DeadlineExceeded`)
-- Extracts JSON if agent emitted ```json ... ``` block
+- Calls `extractJSON([]byte(stdout))` directly (no longer takes an `extractJSONFn` parameter)
 - Propagates `CompressStats` so token savings show in reports
 
 Use this helper for any new agent — never duplicate exit/timeout/JSON logic.
@@ -158,6 +177,6 @@ Bridge: `compressionConfigFromApp()` in `cmd/nightshift/commands/helpers.go`. Do
 `DefaultTimeout = 30 * time.Minute`. Override via two mechanisms:
 
 1. **Per-call**: set `ExecuteOptions.Timeout` (takes precedence over agent default).
-2. **Config**: set `providers.<name>.timeout` in `nightshift.yaml` (e.g. `"45m"`). The three factory functions in `cmd/nightshift/commands/helpers.go` (`newClaudeAgentFromConfig`, `newCodexAgentFromConfig`, `newCopilotAgentFromConfig`) read this field and call `WithDefaultTimeout`/`WithCodexDefaultTimeout`/`WithCopilotDefaultTimeout` accordingly.
+2. The factory functions in `cmd/nightshift/commands/helpers.go` call `WithDefaultTimeout` for all three agents.
 
 `nightshift setup` exposes this as a global "Agent timeout" row in the providers step (Tab to row 3, press `t` to edit). Jira phase timeouts are configured separately per-phase in the Jira step (press `t` on focused phase row).

--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -5,9 +5,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"syscall"
+	"os/exec"
 	"time"
 )
 
@@ -57,69 +57,21 @@ func (r *ExecRunner) Run(ctx context.Context, name string, args []string, dir st
 
 // ClaudeAgent spawns Claude Code CLI for task execution.
 type ClaudeAgent struct {
-	binaryPath string        // Path to claude binary (default: "claude")
-	timeout    time.Duration // Default timeout
-	runner     CommandRunner // Command executor (for testing)
-	skipPerms  bool          // Pass --dangerously-skip-permissions
-	model      string        // Default model to use
-	effort     string        // Default reasoning effort
-}
-
-// ClaudeOption configures a ClaudeAgent.
-type ClaudeOption func(*ClaudeAgent)
-
-// WithBinaryPath sets a custom path to the claude binary.
-func WithBinaryPath(path string) ClaudeOption {
-	return func(a *ClaudeAgent) {
-		a.binaryPath = path
-	}
-}
-
-// WithDefaultTimeout sets the default execution timeout.
-func WithDefaultTimeout(d time.Duration) ClaudeOption {
-	return func(a *ClaudeAgent) {
-		a.timeout = d
-	}
-}
-
-// WithDangerouslySkipPermissions sets whether to pass --dangerously-skip-permissions.
-func WithDangerouslySkipPermissions(enabled bool) ClaudeOption {
-	return func(a *ClaudeAgent) {
-		a.skipPerms = enabled
-	}
-}
-
-// WithModel sets the default model to use.
-func WithModel(model string) ClaudeOption {
-	return func(a *ClaudeAgent) {
-		a.model = model
-	}
-}
-
-// WithEffort sets the default reasoning effort level.
-func WithEffort(effort string) ClaudeOption {
-	return func(a *ClaudeAgent) {
-		a.effort = effort
-	}
-}
-
-// WithRunner sets a custom command runner (for testing).
-func WithRunner(r CommandRunner) ClaudeOption {
-	return func(a *ClaudeAgent) {
-		a.runner = r
-	}
+	agentConfig
 }
 
 // NewClaudeAgent creates a Claude Code agent.
-func NewClaudeAgent(opts ...ClaudeOption) *ClaudeAgent {
+func NewClaudeAgent(opts ...Option) *ClaudeAgent {
 	a := &ClaudeAgent{
-		binaryPath: "claude",
-		timeout:    DefaultTimeout,
-		runner:     &ExecRunner{},
-		skipPerms:  true,
+		agentConfig: agentConfig{
+			binaryPath:        "claude",
+			timeout:           DefaultTimeout,
+			runner:            &ExecRunner{},
+			bypassPermissions: true,
+		},
 	}
 	for _, opt := range opts {
-		opt(a)
+		opt(&a.agentConfig)
 	}
 	return a
 }
@@ -139,7 +91,7 @@ func (a *ClaudeAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execut
 
 	// Build command args
 	args := []string{"--print"}
-	if a.skipPerms {
+	if a.bypassPermissions {
 		args = append(args, "--dangerously-skip-permissions")
 	}
 
@@ -179,7 +131,7 @@ func (a *ClaudeAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execut
 
 	// Run command
 	stdout, stderr, exitCode, err := a.runner.Run(ctx, a.binaryPath, args, opts.WorkDir, "")
-	return handleExecuteResult(ctx, stdout, stderr, exitCode, err, timeout, start, compressStats, a.extractJSON)
+	return handleExecuteResult(ctx, stdout, stderr, exitCode, err, timeout, start, compressStats)
 }
 
 // ExecuteWithFiles runs claude with file context included.
@@ -191,23 +143,12 @@ func (a *ClaudeAgent) ExecuteWithFiles(ctx context.Context, prompt string, files
 	})
 }
 
-
-func (a *ClaudeAgent) extractJSON(output []byte) []byte {
-	return extractJSON(output)
-}
-
 // Available checks if the claude binary is available in PATH.
 func (a *ClaudeAgent) Available() bool {
-	_, err := exec.LookPath(a.binaryPath)
-	return err == nil
+	return cliAvailable(a.binaryPath)
 }
 
 // Version returns the claude CLI version.
 func (a *ClaudeAgent) Version() (string, error) {
-	cmd := exec.Command(a.binaryPath, "--version")
-	output, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("getting version: %w", err)
-	}
-	return strings.TrimSpace(string(output)), nil
+	return cliVersion(a.binaryPath)
 }

--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -5,9 +5,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os/exec"
 	"strings"
 	"syscall"
-	"os/exec"
 	"time"
 )
 

--- a/internal/agents/claude_test.go
+++ b/internal/agents/claude_test.go
@@ -388,8 +388,6 @@ func TestBuildFileContext(t *testing.T) {
 }
 
 func TestClaudeAgent_extractJSON(t *testing.T) {
-	agent := NewClaudeAgent()
-
 	tests := []struct {
 		name     string
 		input    string
@@ -407,7 +405,7 @@ func TestClaudeAgent_extractJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := agent.extractJSON([]byte(tt.input))
+			result := extractJSON([]byte(tt.input))
 			if tt.wantJSON && result == nil {
 				t.Error("expected JSON, got nil")
 			}

--- a/internal/agents/codex.go
+++ b/internal/agents/codex.go
@@ -4,76 +4,26 @@ package agents
 import (
 	"context"
 	"fmt"
-	"os/exec"
-	"strings"
 	"time"
 )
 
 // CodexAgent spawns Codex CLI for task execution.
 type CodexAgent struct {
-	binaryPath string        // Path to codex binary (default: "codex")
-	timeout    time.Duration // Default timeout
-	runner     CommandRunner // Command executor (for testing)
-	bypassPerm bool          // Pass --dangerously-bypass-approvals-and-sandbox
-	model      string        // Default model to use
-	effort     string        // Default reasoning effort
-}
-
-// CodexOption configures a CodexAgent.
-type CodexOption func(*CodexAgent)
-
-// WithCodexBinaryPath sets a custom path to the codex binary.
-func WithCodexBinaryPath(path string) CodexOption {
-	return func(a *CodexAgent) {
-		a.binaryPath = path
-	}
-}
-
-// WithCodexDefaultTimeout sets the default execution timeout.
-func WithCodexDefaultTimeout(d time.Duration) CodexOption {
-	return func(a *CodexAgent) {
-		a.timeout = d
-	}
-}
-
-// WithDangerouslyBypassApprovalsAndSandbox sets whether to pass --dangerously-bypass-approvals-and-sandbox.
-func WithDangerouslyBypassApprovalsAndSandbox(enabled bool) CodexOption {
-	return func(a *CodexAgent) {
-		a.bypassPerm = enabled
-	}
-}
-
-// WithCodexModel sets the default model to use.
-func WithCodexModel(model string) CodexOption {
-	return func(a *CodexAgent) {
-		a.model = model
-	}
-}
-
-// WithCodexEffort sets the default reasoning effort level.
-func WithCodexEffort(effort string) CodexOption {
-	return func(a *CodexAgent) {
-		a.effort = effort
-	}
-}
-
-// WithCodexRunner sets a custom command runner (for testing).
-func WithCodexRunner(r CommandRunner) CodexOption {
-	return func(a *CodexAgent) {
-		a.runner = r
-	}
+	agentConfig
 }
 
 // NewCodexAgent creates a Codex CLI agent.
-func NewCodexAgent(opts ...CodexOption) *CodexAgent {
+func NewCodexAgent(opts ...Option) *CodexAgent {
 	a := &CodexAgent{
-		binaryPath: "codex",
-		timeout:    DefaultTimeout,
-		runner:     &ExecRunner{},
-		bypassPerm: true,
+		agentConfig: agentConfig{
+			binaryPath:        "codex",
+			timeout:           DefaultTimeout,
+			runner:            &ExecRunner{},
+			bypassPermissions: true,
+		},
 	}
 	for _, opt := range opts {
-		opt(a)
+		opt(&a.agentConfig)
 	}
 	return a
 }
@@ -94,7 +44,7 @@ func (a *CodexAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execute
 	// Build command args for headless/non-interactive execution.
 	// Codex CLI uses the `exec` subcommand for non-interactive mode.
 	args := []string{"exec"}
-	if a.bypassPerm {
+	if a.bypassPermissions {
 		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
 	}
 
@@ -134,7 +84,7 @@ func (a *CodexAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execute
 
 	// Run command
 	stdout, stderr, exitCode, err := a.runner.Run(ctx, a.binaryPath, args, opts.WorkDir, "")
-	return handleExecuteResult(ctx, stdout, stderr, exitCode, err, timeout, start, compressStats, a.extractJSON)
+	return handleExecuteResult(ctx, stdout, stderr, exitCode, err, timeout, start, compressStats)
 }
 
 // ExecuteWithFiles runs codex with file context included.
@@ -146,23 +96,12 @@ func (a *CodexAgent) ExecuteWithFiles(ctx context.Context, prompt string, files 
 	})
 }
 
-
-func (a *CodexAgent) extractJSON(output []byte) []byte {
-	return extractJSON(output)
-}
-
 // Available checks if the codex binary is available in PATH.
 func (a *CodexAgent) Available() bool {
-	_, err := exec.LookPath(a.binaryPath)
-	return err == nil
+	return cliAvailable(a.binaryPath)
 }
 
 // Version returns the codex CLI version.
 func (a *CodexAgent) Version() (string, error) {
-	cmd := exec.Command(a.binaryPath, "--version")
-	output, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("getting version: %w", err)
-	}
-	return strings.TrimSpace(string(output)), nil
+	return cliVersion(a.binaryPath)
 }

--- a/internal/agents/codex_test.go
+++ b/internal/agents/codex_test.go
@@ -27,9 +27,9 @@ func TestNewCodexAgent_Defaults(t *testing.T) {
 func TestNewCodexAgent_WithOptions(t *testing.T) {
 	mockRunner := &MockRunner{}
 	agent := NewCodexAgent(
-		WithCodexBinaryPath("/custom/codex"),
-		WithCodexDefaultTimeout(5*time.Minute),
-		WithCodexRunner(mockRunner),
+		WithBinaryPath("/custom/codex"),
+		WithDefaultTimeout(5*time.Minute),
+		WithRunner(mockRunner),
 	)
 
 	if agent.binaryPath != "/custom/codex" {
@@ -55,7 +55,7 @@ func TestCodexAgent_Execute_Success(t *testing.T) {
 		Stdout:   "Task completed successfully",
 		ExitCode: 0,
 	}
-	agent := NewCodexAgent(WithCodexRunner(mock))
+	agent := NewCodexAgent(WithRunner(mock))
 
 	result, err := agent.Execute(context.Background(), ExecuteOptions{
 		Prompt:  "fix the bug",
@@ -98,7 +98,7 @@ func TestCodexAgent_Execute_JSONOutput(t *testing.T) {
 		Stdout:   `{"status":"success","files_changed":3}`,
 		ExitCode: 0,
 	}
-	agent := NewCodexAgent(WithCodexRunner(mock))
+	agent := NewCodexAgent(WithRunner(mock))
 
 	result, err := agent.Execute(context.Background(), ExecuteOptions{
 		Prompt: "analyze code",
@@ -120,8 +120,8 @@ func TestCodexAgent_Execute_Timeout(t *testing.T) {
 		Delay: 5 * time.Second, // Will be cancelled
 	}
 	agent := NewCodexAgent(
-		WithCodexRunner(mock),
-		WithCodexDefaultTimeout(50*time.Millisecond),
+		WithRunner(mock),
+		WithDefaultTimeout(50*time.Millisecond),
 	)
 
 	result, err := agent.Execute(context.Background(), ExecuteOptions{
@@ -144,8 +144,8 @@ func TestCodexAgent_Execute_WithOptionsTimeout(t *testing.T) {
 		Delay: 5 * time.Second,
 	}
 	agent := NewCodexAgent(
-		WithCodexRunner(mock),
-		WithCodexDefaultTimeout(10*time.Second), // Long default
+		WithRunner(mock),
+		WithDefaultTimeout(10*time.Second), // Long default
 	)
 
 	result, err := agent.Execute(context.Background(), ExecuteOptions{
@@ -168,7 +168,7 @@ func TestCodexAgent_Execute_ExitError(t *testing.T) {
 		ExitCode: 1,
 		Err:      errors.New("exit status 1"),
 	}
-	agent := NewCodexAgent(WithCodexRunner(mock))
+	agent := NewCodexAgent(WithRunner(mock))
 
 	result, err := agent.Execute(context.Background(), ExecuteOptions{
 		Prompt: "bad task",
@@ -190,8 +190,8 @@ func TestCodexAgent_Execute_BinaryNotFound(t *testing.T) {
 		Err: errors.New("executable file not found"),
 	}
 	agent := NewCodexAgent(
-		WithCodexBinaryPath("/nonexistent/codex"),
-		WithCodexRunner(mock),
+		WithBinaryPath("/nonexistent/codex"),
+		WithRunner(mock),
 	)
 
 	result, err := agent.Execute(context.Background(), ExecuteOptions{
@@ -221,7 +221,7 @@ func TestCodexAgent_Execute_WithFiles(t *testing.T) {
 		Stdout:   "analyzed file",
 		ExitCode: 0,
 	}
-	agent := NewCodexAgent(WithCodexRunner(mock))
+	agent := NewCodexAgent(WithRunner(mock))
 
 	result, err := agent.Execute(context.Background(), ExecuteOptions{
 		Prompt: "review code",
@@ -244,7 +244,7 @@ func TestCodexAgent_Execute_WithFiles(t *testing.T) {
 
 func TestCodexAgent_Execute_MissingFile(t *testing.T) {
 	mock := &MockRunner{Stdout: "ok", ExitCode: 0}
-	agent := NewCodexAgent(WithCodexRunner(mock))
+	agent := NewCodexAgent(WithRunner(mock))
 
 	// Missing files are listed by path only — no read, no error.
 	_, err := agent.Execute(context.Background(), ExecuteOptions{
@@ -271,7 +271,7 @@ func TestCodexAgent_ExecuteWithFiles(t *testing.T) {
 		Stdout:   "ok",
 		ExitCode: 0,
 	}
-	agent := NewCodexAgent(WithCodexRunner(mock))
+	agent := NewCodexAgent(WithRunner(mock))
 
 	result, err := agent.ExecuteWithFiles(context.Background(), "analyze", []string{testFile}, tmpDir)
 
@@ -288,8 +288,6 @@ func TestCodexAgent_ExecuteWithFiles(t *testing.T) {
 
 
 func TestCodexAgent_extractJSON(t *testing.T) {
-	agent := NewCodexAgent()
-
 	tests := []struct {
 		name     string
 		input    string
@@ -307,7 +305,7 @@ func TestCodexAgent_extractJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := agent.extractJSON([]byte(tt.input))
+			result := extractJSON([]byte(tt.input))
 			if tt.wantJSON && result == nil {
 				t.Error("expected JSON, got nil")
 			}
@@ -320,20 +318,20 @@ func TestCodexAgent_extractJSON(t *testing.T) {
 
 func TestCodexAgent_Available(t *testing.T) {
 	// Test with known available binary
-	agent := NewCodexAgent(WithCodexBinaryPath("echo"))
+	agent := NewCodexAgent(WithBinaryPath("echo"))
 	if !agent.Available() {
 		t.Error("expected echo to be available")
 	}
 
 	// Test with nonexistent binary
-	agent = NewCodexAgent(WithCodexBinaryPath("/nonexistent/binary"))
+	agent = NewCodexAgent(WithBinaryPath("/nonexistent/binary"))
 	if agent.Available() {
 		t.Error("expected nonexistent binary to not be available")
 	}
 }
 
 func TestCodexAgent_Version(t *testing.T) {
-	agent := NewCodexAgent(WithCodexBinaryPath("/nonexistent/codex"))
+	agent := NewCodexAgent(WithBinaryPath("/nonexistent/codex"))
 	_, err := agent.Version()
 	if err == nil {
 		t.Error("expected error for nonexistent binary")
@@ -345,8 +343,8 @@ func TestCodexAgent_ContextCancellation(t *testing.T) {
 		Delay: 5 * time.Second,
 	}
 	agent := NewCodexAgent(
-		WithCodexRunner(mock),
-		WithCodexDefaultTimeout(10*time.Second),
+		WithRunner(mock),
+		WithDefaultTimeout(10*time.Second),
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -372,8 +370,8 @@ func TestCodexAgent_ImplementsAgentInterface(t *testing.T) {
 func TestCodexAgent_Execute_WithModel(t *testing.T) {
 	mock := &MockRunner{Stdout: "response", ExitCode: 0}
 	agent := NewCodexAgent(
-		WithCodexModel("gpt-5.1-codex"),
-		WithCodexRunner(mock),
+		WithModel("gpt-5.1-codex"),
+		WithRunner(mock),
 	)
 
 	_, err := agent.Execute(context.Background(), ExecuteOptions{Prompt: "test"})
@@ -390,7 +388,7 @@ func TestCodexAgent_Execute_WithModel(t *testing.T) {
 
 func TestCodexAgent_Execute_NoModel(t *testing.T) {
 	mock := &MockRunner{Stdout: "response", ExitCode: 0}
-	agent := NewCodexAgent(WithCodexRunner(mock))
+	agent := NewCodexAgent(WithRunner(mock))
 
 	_, err := agent.Execute(context.Background(), ExecuteOptions{Prompt: "test"})
 	if err != nil {
@@ -404,8 +402,8 @@ func TestCodexAgent_Execute_NoModel(t *testing.T) {
 func TestCodexAgent_Execute_ModelFromOptions(t *testing.T) {
 	mock := &MockRunner{Stdout: "response", ExitCode: 0}
 	agent := NewCodexAgent(
-		WithCodexModel("gpt-5.2"),
-		WithCodexRunner(mock),
+		WithModel("gpt-5.2"),
+		WithRunner(mock),
 	)
 
 	_, err := agent.Execute(context.Background(), ExecuteOptions{
@@ -430,7 +428,7 @@ func TestCodexAgent_Execute_ModelFromOptions(t *testing.T) {
 // config field defaulted to false.
 func TestCodexAgentDefaultsBypassFlag(t *testing.T) {
 	mock := &MockRunner{Stdout: "done"}
-	agent := NewCodexAgent(WithCodexRunner(mock))
+	agent := NewCodexAgent(WithRunner(mock))
 
 	ctx := context.Background()
 	_, err := agent.Execute(ctx, ExecuteOptions{Prompt: "test"})
@@ -467,9 +465,9 @@ func TestCodexAgent_Effort(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &MockRunner{Stdout: "response", ExitCode: 0}
-			opts := []CodexOption{WithCodexRunner(mock)}
+			opts := []Option{WithRunner(mock)}
 			if tt.agentEffort != "" {
-				opts = append(opts, WithCodexEffort(tt.agentEffort))
+				opts = append(opts, WithEffort(tt.agentEffort))
 			}
 			agent := NewCodexAgent(opts...)
 
@@ -509,8 +507,8 @@ func TestCodexAgent_Effort(t *testing.T) {
 func TestCodexAgentExplicitFalseBypassDisablesFlag(t *testing.T) {
 	mock := &MockRunner{Stdout: "done"}
 	agent := NewCodexAgent(
-		WithDangerouslyBypassApprovalsAndSandbox(false),
-		WithCodexRunner(mock),
+		WithBypassPermissions(false),
+		WithRunner(mock),
 	)
 
 	ctx := context.Background()

--- a/internal/agents/codex_test.go
+++ b/internal/agents/codex_test.go
@@ -503,7 +503,7 @@ func TestCodexAgent_Effort(t *testing.T) {
 }
 
 // TestCodexAgentExplicitFalseBypassDisablesFlag verifies that explicitly calling
-// WithDangerouslyBypassApprovalsAndSandbox(false) does disable the flag.
+// WithBypassPermissions(false) does disable the flag.
 func TestCodexAgentExplicitFalseBypassDisablesFlag(t *testing.T) {
 	mock := &MockRunner{Stdout: "done"}
 	agent := NewCodexAgent(

--- a/internal/agents/compress.go
+++ b/internal/agents/compress.go
@@ -85,17 +85,11 @@ func compressViaAgent(ctx context.Context, cfg *CompressConfig, prompt string) (
 	var agent Agent
 	switch strings.ToLower(cfg.Provider) {
 	case "claude":
-		agent = NewClaudeAgent(
-			WithDangerouslySkipPermissions(true),
-		)
+		agent = NewClaudeAgent(WithBypassPermissions(true))
 	case "codex":
-		agent = NewCodexAgent(
-			WithDangerouslyBypassApprovalsAndSandbox(true),
-		)
+		agent = NewCodexAgent(WithBypassPermissions(true))
 	case "copilot":
-		agent = NewCopilotAgent(
-			WithCopilotDangerouslySkipPermissions(true),
-		)
+		agent = NewCopilotAgent(WithBypassPermissions(true))
 	default:
 		return "", fmt.Errorf("unsupported compression provider: %s", cfg.Provider)
 	}

--- a/internal/agents/copilot.go
+++ b/internal/agents/copilot.go
@@ -22,68 +22,21 @@ import (
 // - Standalone: npm install -g @github/copilot or curl script
 // - Usage: copilot -p "<prompt>" --no-ask-user --silent
 type CopilotAgent struct {
-	binaryPath           string        // Path to binary: "gh" or "copilot" (default: "gh")
-	dangerouslySkipPerms bool          // Pass --allow-all-tools --allow-all-urls
-	model                string        // Default model to use
-	effort               string        // Default reasoning effort
-	timeout              time.Duration // Default timeout
-	runner               CommandRunner // Command executor (for testing)
-}
-
-// CopilotOption configures a CopilotAgent.
-type CopilotOption func(*CopilotAgent)
-
-// WithCopilotBinaryPath sets a custom path to the copilot binary ("gh" or "copilot").
-func WithCopilotBinaryPath(path string) CopilotOption {
-	return func(a *CopilotAgent) {
-		a.binaryPath = path
-	}
-}
-
-// WithCopilotDangerouslySkipPermissions sets whether to pass --allow-all-tools and --allow-all-urls.
-func WithCopilotDangerouslySkipPermissions(enabled bool) CopilotOption {
-	return func(a *CopilotAgent) {
-		a.dangerouslySkipPerms = enabled
-	}
-}
-
-// WithCopilotDefaultTimeout sets the default execution timeout.
-func WithCopilotDefaultTimeout(d time.Duration) CopilotOption {
-	return func(a *CopilotAgent) {
-		a.timeout = d
-	}
-}
-
-// WithCopilotModel sets the default model to use.
-func WithCopilotModel(model string) CopilotOption {
-	return func(a *CopilotAgent) {
-		a.model = model
-	}
-}
-
-// WithCopilotEffort sets the default reasoning effort level.
-func WithCopilotEffort(effort string) CopilotOption {
-	return func(a *CopilotAgent) {
-		a.effort = effort
-	}
-}
-
-// WithCopilotRunner sets a custom command runner (for testing).
-func WithCopilotRunner(r CommandRunner) CopilotOption {
-	return func(a *CopilotAgent) {
-		a.runner = r
-	}
+	agentConfig
 }
 
 // NewCopilotAgent creates a GitHub Copilot CLI agent.
-func NewCopilotAgent(opts ...CopilotOption) *CopilotAgent {
+func NewCopilotAgent(opts ...Option) *CopilotAgent {
 	a := &CopilotAgent{
-		binaryPath: "gh",
-		timeout:    DefaultTimeout,
-		runner:     &ExecRunner{},
+		agentConfig: agentConfig{
+			binaryPath:        "gh",
+			timeout:           DefaultTimeout,
+			runner:            &ExecRunner{},
+			bypassPermissions: false,
+		},
 	}
 	for _, opt := range opts {
-		opt(a)
+		opt(&a.agentConfig)
 	}
 	return a
 }
@@ -151,13 +104,13 @@ func (a *CopilotAgent) Execute(ctx context.Context, opts ExecuteOptions) (*Execu
 		args = append(args, "--effort", effort)
 	}
 
-	if a.dangerouslySkipPerms {
+	if a.bypassPermissions {
 		args = append(args, "--allow-all-tools", "--allow-all-urls")
 	}
 
 	// Run command
 	stdout, stderr, exitCode, err := a.runner.Run(ctx, a.binaryPath, args, opts.WorkDir, "")
-	return handleExecuteResult(ctx, stdout, stderr, exitCode, err, timeout, start, compressStats, a.extractJSON)
+	return handleExecuteResult(ctx, stdout, stderr, exitCode, err, timeout, start, compressStats)
 }
 
 // ExecuteWithFiles runs gh copilot with file context included.
@@ -167,10 +120,6 @@ func (a *CopilotAgent) ExecuteWithFiles(ctx context.Context, prompt string, file
 		Files:   files,
 		WorkDir: workDir,
 	})
-}
-
-func (a *CopilotAgent) extractJSON(output []byte) []byte {
-	return extractJSON(output)
 }
 
 // Available checks if the gh binary is available in PATH and copilot extension is installed.

--- a/internal/agents/copilot_test.go
+++ b/internal/agents/copilot_test.go
@@ -44,10 +44,10 @@ func TestNewCopilotAgent_Defaults(t *testing.T) {
 func TestNewCopilotAgent_WithOptions(t *testing.T) {
 	mockRunner := &MockRunner{}
 	agent := NewCopilotAgent(
-		WithCopilotBinaryPath("/custom/gh"),
-		WithCopilotDefaultTimeout(5*time.Minute),
-		WithCopilotRunner(mockRunner),
-		WithCopilotModel("claude-sonnet-4.6"),
+		WithBinaryPath("/custom/gh"),
+		WithDefaultTimeout(5*time.Minute),
+		WithRunner(mockRunner),
+		WithModel("claude-sonnet-4.6"),
 	)
 
 	if agent.binaryPath != "/custom/gh" {
@@ -76,7 +76,7 @@ func TestCopilotAgent_Execute_Success(t *testing.T) {
 		Stdout:   "Here's a solution to your problem",
 		ExitCode: 0,
 	}
-	agent := NewCopilotAgent(WithCopilotRunner(mock))
+	agent := NewCopilotAgent(WithRunner(mock))
 
 	result, err := agent.Execute(context.Background(), ExecuteOptions{
 		Prompt:  "how to list files",
@@ -127,7 +127,7 @@ func TestCopilotAgent_Execute_JSONOutput(t *testing.T) {
 		Stdout:   `{"suggestion":"ls -la","explanation":"Lists all files"}`,
 		ExitCode: 0,
 	}
-	agent := NewCopilotAgent(WithCopilotRunner(mock))
+	agent := NewCopilotAgent(WithRunner(mock))
 
 	result, err := agent.Execute(context.Background(), ExecuteOptions{
 		Prompt: "list files",
@@ -147,7 +147,7 @@ func TestCopilotAgent_Execute_Error(t *testing.T) {
 		ExitCode: 1,
 		Err:      &mockExitError{code: 1},
 	}
-	agent := NewCopilotAgent(WithCopilotRunner(mock))
+	agent := NewCopilotAgent(WithRunner(mock))
 
 	result, err := agent.Execute(context.Background(), ExecuteOptions{
 		Prompt: "test prompt",
@@ -169,7 +169,7 @@ func TestCopilotAgent_Execute_Timeout(t *testing.T) {
 		Delay:    5 * time.Second,
 		ExitCode: -1,
 	}
-	agent := NewCopilotAgent(WithCopilotRunner(mock))
+	agent := NewCopilotAgent(WithRunner(mock))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -201,7 +201,7 @@ func TestCopilotAgent_Execute_WithFiles(t *testing.T) {
 		Stdout:   "Response with context",
 		ExitCode: 0,
 	}
-	agent := NewCopilotAgent(WithCopilotRunner(mock))
+	agent := NewCopilotAgent(WithRunner(mock))
 
 	result, err := agent.Execute(context.Background(), ExecuteOptions{
 		Prompt: "analyze this file",
@@ -238,7 +238,7 @@ func TestCopilotAgent_ExecuteWithFiles(t *testing.T) {
 		Stdout:   "Response",
 		ExitCode: 0,
 	}
-	agent := NewCopilotAgent(WithCopilotRunner(mock))
+	agent := NewCopilotAgent(WithRunner(mock))
 
 	result, err := agent.ExecuteWithFiles(context.Background(), "test prompt", []string{testFile}, "/workdir")
 
@@ -256,9 +256,9 @@ func TestCopilotAgent_ExecuteWithFiles(t *testing.T) {
 func TestCopilotAgent_Execute_WithModel_Standalone(t *testing.T) {
 	mock := &MockRunner{Stdout: "response", ExitCode: 0}
 	agent := NewCopilotAgent(
-		WithCopilotBinaryPath("copilot"),
-		WithCopilotModel("claude-sonnet-4.6"),
-		WithCopilotRunner(mock),
+		WithBinaryPath("copilot"),
+		WithModel("claude-sonnet-4.6"),
+		WithRunner(mock),
 	)
 
 	_, err := agent.Execute(context.Background(), ExecuteOptions{Prompt: "test"})
@@ -277,8 +277,8 @@ func TestCopilotAgent_Execute_WithModel_Standalone(t *testing.T) {
 func TestCopilotAgent_Execute_WithModel_GH(t *testing.T) {
 	mock := &MockRunner{Stdout: "response", ExitCode: 0}
 	agent := NewCopilotAgent(
-		WithCopilotModel("gpt-5.1"),
-		WithCopilotRunner(mock),
+		WithModel("gpt-5.1"),
+		WithRunner(mock),
 	)
 
 	_, err := agent.Execute(context.Background(), ExecuteOptions{Prompt: "test"})
@@ -296,7 +296,7 @@ func TestCopilotAgent_Execute_WithModel_GH(t *testing.T) {
 
 func TestCopilotAgent_Execute_NoModel(t *testing.T) {
 	mock := &MockRunner{Stdout: "response", ExitCode: 0}
-	agent := NewCopilotAgent(WithCopilotRunner(mock))
+	agent := NewCopilotAgent(WithRunner(mock))
 
 	_, err := agent.Execute(context.Background(), ExecuteOptions{Prompt: "test"})
 	if err != nil {
@@ -311,8 +311,8 @@ func TestCopilotAgent_Execute_NoModel(t *testing.T) {
 func TestCopilotAgent_Execute_ModelFromOptions(t *testing.T) {
 	mock := &MockRunner{Stdout: "response", ExitCode: 0}
 	agent := NewCopilotAgent(
-		WithCopilotModel("claude-haiku-4.5"),
-		WithCopilotRunner(mock),
+		WithModel("claude-haiku-4.5"),
+		WithRunner(mock),
 	)
 
 	// ExecuteOptions.Model overrides the agent default
@@ -359,9 +359,9 @@ func TestCopilotAgent_Effort(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &MockRunner{Stdout: "response", ExitCode: 0}
-			opts := []CopilotOption{WithCopilotRunner(mock)}
+			opts := []Option{WithRunner(mock)}
 			if tt.agentEffort != "" {
-				opts = append(opts, WithCopilotEffort(tt.agentEffort))
+				opts = append(opts, WithEffort(tt.agentEffort))
 			}
 			agent := NewCopilotAgent(opts...)
 
@@ -385,8 +385,6 @@ func TestCopilotAgent_Effort(t *testing.T) {
 }
 
 func TestCopilotAgent_ExtractJSON(t *testing.T) {
-	agent := NewCopilotAgent()
-
 	tests := []struct {
 		name   string
 		output string
@@ -421,7 +419,7 @@ func TestCopilotAgent_ExtractJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := agent.extractJSON([]byte(tt.output))
+			result := extractJSON([]byte(tt.output))
 			hasJSON := result != nil
 			if hasJSON != tt.want {
 				t.Errorf("extractJSON() returned JSON = %v, want %v", hasJSON, tt.want)

--- a/internal/agents/options.go
+++ b/internal/agents/options.go
@@ -55,26 +55,70 @@ type ClaudeOption = Option
 type CodexOption = Option
 type CopilotOption = Option
 
-// Deprecated function aliases for backward compatibility — use the unprefixed equivalents.
-var (
-	WithCodexBinaryPath      = WithBinaryPath
-	WithCodexDefaultTimeout  = WithDefaultTimeout
-	WithCodexRunner          = WithRunner
-	WithCodexModel           = WithModel
-	WithCodexEffort          = WithEffort
-	WithCopilotBinaryPath    = WithBinaryPath
-	WithCopilotDefaultTimeout = WithDefaultTimeout
-	WithCopilotRunner        = WithRunner
-	WithCopilotModel         = WithModel
-	WithCopilotEffort        = WithEffort
+// Deprecated: use WithBinaryPath instead.
+func WithCodexBinaryPath(path string) Option {
+	return WithBinaryPath(path)
+}
 
-	// WithDangerouslySkipPermissions was the Claude-specific bypass flag.
-	WithDangerouslySkipPermissions = WithBypassPermissions
-	// WithDangerouslyBypassApprovalsAndSandbox was the Codex-specific bypass flag.
-	WithDangerouslyBypassApprovalsAndSandbox = WithBypassPermissions
-	// WithCopilotDangerouslySkipPermissions was the Copilot-specific bypass flag.
-	WithCopilotDangerouslySkipPermissions = WithBypassPermissions
-)
+// Deprecated: use WithDefaultTimeout instead.
+func WithCodexDefaultTimeout(d time.Duration) Option {
+	return WithDefaultTimeout(d)
+}
+
+// Deprecated: use WithRunner instead.
+func WithCodexRunner(r CommandRunner) Option {
+	return WithRunner(r)
+}
+
+// Deprecated: use WithModel instead.
+func WithCodexModel(model string) Option {
+	return WithModel(model)
+}
+
+// Deprecated: use WithEffort instead.
+func WithCodexEffort(effort string) Option {
+	return WithEffort(effort)
+}
+
+// Deprecated: use WithBinaryPath instead.
+func WithCopilotBinaryPath(path string) Option {
+	return WithBinaryPath(path)
+}
+
+// Deprecated: use WithDefaultTimeout instead.
+func WithCopilotDefaultTimeout(d time.Duration) Option {
+	return WithDefaultTimeout(d)
+}
+
+// Deprecated: use WithRunner instead.
+func WithCopilotRunner(r CommandRunner) Option {
+	return WithRunner(r)
+}
+
+// Deprecated: use WithModel instead.
+func WithCopilotModel(model string) Option {
+	return WithModel(model)
+}
+
+// Deprecated: use WithEffort instead.
+func WithCopilotEffort(effort string) Option {
+	return WithEffort(effort)
+}
+
+// Deprecated: use WithBypassPermissions instead.
+func WithDangerouslySkipPermissions(enabled bool) Option {
+	return WithBypassPermissions(enabled)
+}
+
+// Deprecated: use WithBypassPermissions instead.
+func WithDangerouslyBypassApprovalsAndSandbox(enabled bool) Option {
+	return WithBypassPermissions(enabled)
+}
+
+// Deprecated: use WithBypassPermissions instead.
+func WithCopilotDangerouslySkipPermissions(enabled bool) Option {
+	return WithBypassPermissions(enabled)
+}
 
 // cliAvailable checks if a binary is available in PATH.
 func cliAvailable(binaryPath string) bool {

--- a/internal/agents/options.go
+++ b/internal/agents/options.go
@@ -1,0 +1,93 @@
+package agents
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// agentConfig holds fields common to all three agents.
+type agentConfig struct {
+	binaryPath        string
+	timeout           time.Duration
+	runner            CommandRunner
+	model             string
+	effort            string
+	bypassPermissions bool // each agent maps this to its own CLI flag
+}
+
+// Option configures any agent that embeds agentConfig.
+type Option func(*agentConfig)
+
+// WithBinaryPath sets a custom path to the agent binary.
+func WithBinaryPath(path string) Option {
+	return func(c *agentConfig) { c.binaryPath = path }
+}
+
+// WithDefaultTimeout sets the default execution timeout.
+func WithDefaultTimeout(d time.Duration) Option {
+	return func(c *agentConfig) { c.timeout = d }
+}
+
+// WithRunner sets a custom command runner (for testing).
+func WithRunner(r CommandRunner) Option {
+	return func(c *agentConfig) { c.runner = r }
+}
+
+// WithModel sets the default model to use.
+func WithModel(model string) Option {
+	return func(c *agentConfig) { c.model = model }
+}
+
+// WithEffort sets the default reasoning effort level.
+func WithEffort(effort string) Option {
+	return func(c *agentConfig) { c.effort = effort }
+}
+
+// WithBypassPermissions sets whether to pass the agent-specific bypass-permissions flag.
+func WithBypassPermissions(enabled bool) Option {
+	return func(c *agentConfig) { c.bypassPermissions = enabled }
+}
+
+// Deprecated type aliases — use Option instead.
+type ClaudeOption = Option
+type CodexOption = Option
+type CopilotOption = Option
+
+// Deprecated function aliases for backward compatibility — use the unprefixed equivalents.
+var (
+	WithCodexBinaryPath      = WithBinaryPath
+	WithCodexDefaultTimeout  = WithDefaultTimeout
+	WithCodexRunner          = WithRunner
+	WithCodexModel           = WithModel
+	WithCodexEffort          = WithEffort
+	WithCopilotBinaryPath    = WithBinaryPath
+	WithCopilotDefaultTimeout = WithDefaultTimeout
+	WithCopilotRunner        = WithRunner
+	WithCopilotModel         = WithModel
+	WithCopilotEffort        = WithEffort
+
+	// WithDangerouslySkipPermissions was the Claude-specific bypass flag.
+	WithDangerouslySkipPermissions = WithBypassPermissions
+	// WithDangerouslyBypassApprovalsAndSandbox was the Codex-specific bypass flag.
+	WithDangerouslyBypassApprovalsAndSandbox = WithBypassPermissions
+	// WithCopilotDangerouslySkipPermissions was the Copilot-specific bypass flag.
+	WithCopilotDangerouslySkipPermissions = WithBypassPermissions
+)
+
+// cliAvailable checks if a binary is available in PATH.
+func cliAvailable(binaryPath string) bool {
+	_, err := exec.LookPath(binaryPath)
+	return err == nil
+}
+
+// cliVersion returns the version string reported by a CLI binary via --version.
+func cliVersion(binaryPath string) (string, error) {
+	cmd := exec.Command(binaryPath, "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("getting version: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/internal/agents/util.go
+++ b/internal/agents/util.go
@@ -36,7 +36,6 @@ func handleExecuteResult(
 	timeout time.Duration,
 	start time.Time,
 	compressStats *CompressStats,
-	extractJSONFn func([]byte) []byte,
 ) (*ExecuteResult, error) {
 	result := &ExecuteResult{
 		Output:        stdout,
@@ -70,7 +69,7 @@ func handleExecuteResult(
 		return result, err
 	}
 
-	result.JSON = extractJSONFn([]byte(stdout))
+	result.JSON = extractJSON([]byte(stdout))
 	return result, nil
 }
 


### PR DESCRIPTION
## VC-92 — internal/agents: heavy duplication across claude/codex/copilot — 15 near-identical options, pointless wrappers

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-92

### Description

Bug
The three agent implementations in internal/agents (claude.go, codex.go, copilot.go) share ~80% identical structure, copy-pasted rather than factored:
15 near-identical option constructors — WithModel / WithCodexModel / WithCopilotModel, and the same triplication for BinaryPath, DefaultTimeout, Effort, Runner. Prefix is the only difference.
Pointless extractJSON method wrappers — each agent has a one-line method that just calls the package-level extractJSON. Pure indirection.
Duplicated Available() / Version() — the claude and codex versions are byte-identical.
Impact
~150 LOC of avoidable duplication. Every cross-cutting change (new option, behavior tweak) must be made three times and is easy to miss in one. Inconsistency risk.
Fix
Extract a shared agentConfig struct + generic option constructors; drop the per-agent prefixed variants.
Delete the three extractJSON method wrappers; call the package func directly.
Extract shared lookPath / cliVersion helpers for Available() / Version(); keep only copilot's genuinely-different logic.
Location
internal/agents/claude.go, codex.go, copilot.go.

Filed from codebase analysis — automated agent

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
