### PR TITLE
refactor(jira): remove LintCommand/TestCommand, let agent auto-detect toolchain

### DIFF
--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -2607,7 +2607,7 @@ func writeGlobalConfigToPath(cfg *config.Config, configPath string) error {
 			v.Set("jira.cleanup_after_days", cfg.Jira.CleanupAfterDays)
 		}
 		// Build projects as explicit maps so mapstructure tags are honoured and empty
-		// optional fields (lint_command, test_command, per-project phase overrides) are omitted.
+		// optional fields (per-project phase overrides) are omitted.
 		v.Set("jira.projects", jiraProjectsToMaps(cfg.Jira.Projects))
 		// Write each phase field individually so viper uses the dot-key path instead of
 		// reflecting over a struct (which would lose mapstructure tag key names).
@@ -3467,7 +3467,7 @@ func (m *setupModel) applyJiraConfig() {
 
 // jiraProjectsToMaps serialises Jira project configs into plain maps so viper
 // writes mapstructure-tagged key names (e.g. "base_branch") and omits empty
-// optional fields (lint_command, test_command, per-project phase overrides).
+// optional fields (per-project phase overrides).
 func jiraProjectsToMaps(projects []jiraconfig.ProjectConfig) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(projects))
 	for _, proj := range projects {
@@ -3477,12 +3477,6 @@ func jiraProjectsToMaps(projects []jiraconfig.ProjectConfig) []map[string]interf
 				"name":        r.Name,
 				"url":         r.URL,
 				"base_branch": r.BaseBranch,
-			}
-			if r.LintCommand != "" {
-				repo["lint_command"] = r.LintCommand
-			}
-			if r.TestCommand != "" {
-				repo["test_command"] = r.TestCommand
 			}
 			repoMaps = append(repoMaps, repo)
 		}

--- a/internal/jira/config.go
+++ b/internal/jira/config.go
@@ -60,8 +60,6 @@ type RepoConfig struct {
 	Name        string `mapstructure:"name"`         // subdirectory name
 	URL         string `mapstructure:"url"`          // git clone URL
 	BaseBranch  string `mapstructure:"base_branch"`  // default: "main"
-	LintCommand string `mapstructure:"lint_command"` // optional: command to run linter (e.g. "golangci-lint run ./...")
-	TestCommand string `mapstructure:"test_command"` // optional: command to run tests (e.g. "go test ./...")
 }
 
 // PhaseConfig specifies provider/model for a specific phase.

--- a/internal/jira/feedback.go
+++ b/internal/jira/feedback.go
@@ -291,14 +291,6 @@ func buildReworkContent(ticket Ticket) string {
 // Reviewer comments, inline comments, CI failures, and operational instructions
 // must arrive verbatim — they contain file paths, line numbers, and code snippets.
 func buildReworkSuffix(review *PRReviewState, repo RepoWorkspace) string {
-	lintCmd := repo.LintCommand
-	if lintCmd == "" {
-		lintCmd = "golangci-lint run ./..."
-	}
-	testCmd := repo.TestCommand
-	if testCmd == "" {
-		testCmd = "go test ./..."
-	}
 	var b strings.Builder
 	b.WriteString("\n---\n\n")
 	fmt.Fprintf(&b, "## Review Feedback for PR\n\n")
@@ -340,10 +332,8 @@ func buildReworkSuffix(review *PRReviewState, repo RepoWorkspace) string {
 	b.WriteString("2. On disagreement, explain in code comment\n")
 	b.WriteString("3. Don't modify code unrelated to review feedback\n")
 	b.WriteString("\n### Quality Checks (REQUIRED before finishing)\n")
-	b.WriteString("After feedback addressed, run commands below and fix ALL failures:\n\n")
-	fmt.Fprintf(&b, "- Lint: `%s`\n", lintCmd)
-	fmt.Fprintf(&b, "- Test: `%s`\n\n", testCmd)
-	b.WriteString("Do not finish until both exit code 0. Do not commit or push — handled separately.\n")
+	b.WriteString("Detect the project language/toolchain and run the appropriate lint and test commands.\n")
+	b.WriteString("Fix ALL failures. Do not finish until lint and tests pass. Do not commit or push — handled separately.\n")
 	return b.String()
 }
 

--- a/internal/jira/orchestrator.go
+++ b/internal/jira/orchestrator.go
@@ -935,21 +935,8 @@ func (o *Orchestrator) buildImplementSuffix(plan string, ws *Workspace) string {
 	b.WriteString("7. Never run `git init` under any circumstances\n")
 	if ws != nil && len(ws.Repos) > 0 {
 		b.WriteString("\n## Quality Checks (REQUIRED before finishing)\n")
-		b.WriteString("For each repo above, run commands below and fix ALL failures before stopping:\n\n")
-		for _, repo := range ws.Repos {
-			lintCmd := repo.LintCommand
-			if lintCmd == "" {
-				lintCmd = "golangci-lint run ./..."
-			}
-			testCmd := repo.TestCommand
-			if testCmd == "" {
-				testCmd = "go test ./..."
-			}
-			fmt.Fprintf(&b, "**%s** (`%s`):\n", repo.Name, repo.Path)
-			fmt.Fprintf(&b, "  - Lint: `%s`\n", lintCmd)
-			fmt.Fprintf(&b, "  - Test: `%s`\n\n", testCmd)
-		}
-		b.WriteString("Do not finish until all lint and test commands exit with code 0.\n")
+		b.WriteString("For each repo above, detect the project language/toolchain and run the appropriate lint and test commands.\n")
+		b.WriteString("Fix ALL failures before stopping. Do not finish until lint and tests pass.\n")
 	}
 	return b.String()
 }

--- a/internal/jira/workspace.go
+++ b/internal/jira/workspace.go
@@ -28,8 +28,6 @@ type RepoWorkspace struct {
 	Branch      string
 	BaseBranch  string
 	IsNew       bool
-	LintCommand string // empty means auto-discover
-	TestCommand string // empty means auto-discover
 }
 
 // SetupWorkspace creates (or reuses) an isolated workspace for ticketKey.
@@ -80,8 +78,6 @@ func SetupWorkspace(ctx context.Context, cfg JiraConfig, proj ProjectConfig, tic
 			Branch:      branch,
 			BaseBranch:  baseBranch,
 			IsNew:       isNew,
-			LintCommand: r.LintCommand,
-			TestCommand: r.TestCommand,
 		})
 	}
 	return &Workspace{TicketKey: ticketKey, Root: wsRoot, Repos: repos}, nil


### PR DESCRIPTION
## Summary

- Removes `LintCommand` and `TestCommand` fields from `RepoConfig` and `RepoWorkspace`
- Removes hardcoded `golangci-lint run ./...` / `go test ./...` defaults from implement and rework prompts
- Agent now instructed to detect project language/toolchain and pick appropriate lint/test commands

## Motivation

Hardcoded Go commands silently failed on non-Go repos. Auto-detection is more robust and works across languages.

## Test plan

- [ ] Verify build passes (`make build`)
- [ ] Run `nightshift jira run` on a Go repo — agent should still run lint/tests
- [ ] Run on a non-Go repo — agent should detect correct toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)