### PR TITLE
[VC-96] scheduler: cron job errors silently dropped, no metric/counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to nightshift are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **scheduler: surface job failures (VC-96)** — scheduler job errors are no longer silently discarded.
+  - `_ = job(ctx)` replaced with error capture; failures logged at ERROR level via `schedulerFailureSink`.
+  - Per-job failure counter (`Scheduler.FailureCount`, `TotalFailures`) guarded by existing mutex.
+  - Failures persisted to new `scheduler_job_failures` table (migration 010: job_name, failed_at, error_text).
+  - `nightshift status` shows last failure per job (timestamp + message) when any exist.
+  - `nightshift doctor` reports `FAIL` when any job has ≥ N failures within N scheduled intervals (configurable: `scheduler.unhealthy_failure_count`, default 3); reports `WARN` for fewer or older failures.
+  - New `FailureSink` interface keeps `internal/scheduler` decoupled from `internal/db` / `internal/logging`.
+  - New config field: `scheduler.unhealthy_failure_count` (int, default 3).
+
 ### Refactoring
 
 - **agents: deduplicate option constructors (VC-92)** — extracted shared `agentConfig` struct and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,11 @@ internal/
   db/                   # SQLite persistence layer — all SQL lives here, nowhere else
     db.go               # DB struct; DefaultPath = ~/.local/share/nightshift/nightshift.db;
                         # Open() applies pragmas + auto-runs migrations
-    migrations.go       # Versioned schema migrations (001–009); auto-applied on Open();
-                        # migration009 adds UNIQUE index on jira_ticket_results(run_id, ticket_key)
+    migrations.go       # Versioned schema migrations (001–010); auto-applied on Open();
+                        # migration009: UNIQUE index on jira_ticket_results(run_id, ticket_key);
+                        # migration010: scheduler_job_failures table
+    scheduler_failures.go # RecordSchedulerFailure, LastSchedulerFailure, RecentSchedulerFailures,
+                          # CountSchedulerFailuresSince, DistinctSchedulerJobNames
     import.go           # Bulk data import utilities
 
   jira/                 # Jira autonomous system — drives ticket lifecycle via AI agents
@@ -144,7 +147,8 @@ internal/
 
   scheduler/            # Cron-based scheduling
     scheduler.go        # Wraps robfig/cron with SkipIfStillRunning middleware (prevents concurrent fires);
-                        # reads schedule config; triggers runs
+                        # reads schedule config; triggers runs; FailureSink interface for error capture;
+                        # AddNamedJob/AddJob; FailureCount/TotalFailures accessors
 
   security/             # Credential management — env vars only, never config files
     credentials.go      # CredentialManager: validates ANTHROPIC_API_KEY, OPENAI_API_KEY;
@@ -415,3 +419,5 @@ Agents MUST follow these rules:
 - **Daemon workspace mode (VC-87)** — when `workspace.root` is set, `runScheduledTasks` routes to `runScheduledWorkspacedTasks` instead of the project-path loop. Both `nightshift run` and daemon share `runRepoTasks()` for per-repo task execution. State key is always `rw.Name` (not `rw.Path`) in workspace mode. First daemon run after upgrading from a pre-VC-87 release will re-process all workspace repos once (old cooldowns were keyed on paths, new ones on names — safe, one extra run).
 - **`runRepoTasks` allowedTasks filter** — when `workspace.repos[*].tasks` is set, `runRepoTasks` filters selected tasks to only those types before execution. Empty/nil means no filter. Filter applied after selector, so cooldown/staleness scoring still runs on all tasks but only matching types are executed.
 - **Rejection forces re-validation on next run** — Rejection is posted by the orchestrator as a structured `CommentRejection` NightshiftComment (via `postPhaseComment`); `HandleInvalidTicket` only does the status transition. `detectResumeState` compares `GetLastCommentOfType(CommentRejection).Timestamp` against `GetLastCommentOfType(CommentValidation).Timestamp`: if rejection is newer, `hasValidation` is false and the ticket falls to `PhaseValidate` for re-evaluation. If acceptance is newer (user fixed ticket, later run passed), rejection is ignored. Root cause of FIN-31: prior `CommentValidation` from an older partial run caused `detectResumeState` to skip validation despite a newer rejection.
+- **Scheduler FailureSink decoupling (VC-96)** — `internal/scheduler` must NOT import `internal/db` or `internal/logging` (would introduce import cycle). The `FailureSink` interface lives in `scheduler`; the concrete `schedulerFailureSink` (which does DB writes + logging) lives in `cmd/nightshift/commands/scheduler_sink.go` and is wired in `runDaemonLoop`. Counter is in-memory only; persistent failure history is in the `scheduler_job_failures` table (migration 010). Do not add direct DB/logging calls inside `scheduler.go`.
+- **`scheduler.unhealthy_failure_count` config** — controls the doctor FAIL threshold (default 3). The window is `threshold × derived_interval`. Interval is derived from `sched.NextRuns(2)` delta; falls back to 24h if the schedule is unconfigured or delta is zero.

--- a/cmd/nightshift/commands/daemon.go
+++ b/cmd/nightshift/commands/daemon.go
@@ -247,8 +247,11 @@ func runDaemonLoop(cfg *config.Config) error {
 		return fmt.Errorf("init scheduler: %w", err)
 	}
 
+	// Wire failure sink so job errors are logged and persisted.
+	sched.WithFailureSink(&schedulerFailureSink{database: database, log: log})
+
 	// Add the main run job
-	sched.AddJob(func(jobCtx context.Context) error {
+	sched.AddNamedJob("scheduled-run", func(jobCtx context.Context) error {
 		return runScheduledTasks(jobCtx, cfg, database, log)
 	})
 

--- a/cmd/nightshift/commands/doctor.go
+++ b/cmd/nightshift/commands/doctor.go
@@ -296,8 +296,11 @@ func checkSchedulerHealth(cfg *config.Config, database *db.DB, add func(string, 
 			allOK = false
 		} else {
 			// Check if any historical failure exists at all.
-			_, _, ok, _ := db.LastSchedulerFailure(ctx, database, name)
-			if ok {
+			_, _, ok, lastErr := db.LastSchedulerFailure(ctx, database, name)
+			if lastErr != nil {
+				add(fmt.Sprintf("scheduler.%s", name), statusWarn, fmt.Sprintf("query error: %v", lastErr))
+				allOK = false
+			} else if ok {
 				add(fmt.Sprintf("scheduler.%s", name), statusWarn, "past failure(s) recorded (outside current window)")
 				allOK = false
 			} else {

--- a/cmd/nightshift/commands/doctor.go
+++ b/cmd/nightshift/commands/doctor.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -89,6 +91,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	checkCLIs(cfg, add)
 	checkProviders(cfg, add)
 	checkBudget(cfg, database, add)
+	checkSchedulerHealth(cfg, database, add)
 
 	printDoctorResults(results)
 
@@ -252,6 +255,76 @@ func checkBudget(cfg *config.Config, _ *db.DB, add func(string, checkStatus, str
 			add("budget.codex", statusOK, fmt.Sprintf("%.1f%% used", usedPct))
 		}
 	}
+}
+
+func checkSchedulerHealth(cfg *config.Config, database *db.DB, add func(string, checkStatus, string)) {
+	ctx := context.Background()
+
+	names, err := db.DistinctSchedulerJobNames(ctx, database)
+	if err != nil {
+		add("scheduler.failures", statusWarn, fmt.Sprintf("could not query failures: %v", err))
+		return
+	}
+	if len(names) == 0 {
+		add("scheduler.failures", statusOK, "no failures recorded")
+		return
+	}
+
+	// Derive one-interval window from schedule config.
+	threshold := cfg.Scheduler.UnhealthyFailureCount
+	if threshold <= 0 {
+		threshold = 3
+	}
+
+	window := deriveSchedulerWindow(cfg, threshold)
+
+	allOK := true
+	for _, name := range names {
+		count, err := db.CountSchedulerFailuresSince(ctx, database, name, time.Now().Add(-window))
+		if err != nil {
+			add(fmt.Sprintf("scheduler.%s", name), statusWarn, fmt.Sprintf("query error: %v", err))
+			allOK = false
+			continue
+		}
+		if count >= threshold {
+			add(fmt.Sprintf("scheduler.%s", name), statusFail,
+				fmt.Sprintf("%d failures in last %s (threshold %d)", count, window.Round(time.Minute), threshold))
+			allOK = false
+		} else if count > 0 {
+			add(fmt.Sprintf("scheduler.%s", name), statusWarn,
+				fmt.Sprintf("%d failure(s) in last %s", count, window.Round(time.Minute)))
+			allOK = false
+		} else {
+			// Check if any historical failure exists at all.
+			_, _, ok, _ := db.LastSchedulerFailure(ctx, database, name)
+			if ok {
+				add(fmt.Sprintf("scheduler.%s", name), statusWarn, "past failure(s) recorded (outside current window)")
+				allOK = false
+			} else {
+				add(fmt.Sprintf("scheduler.%s", name), statusOK, "no recent failures")
+			}
+		}
+	}
+	if allOK {
+		add("scheduler.failures", statusOK, "no recent failures")
+	}
+}
+
+// deriveSchedulerWindow returns threshold * one-interval as the health window.
+func deriveSchedulerWindow(cfg *config.Config, threshold int) time.Duration {
+	sched, err := scheduler.NewFromConfig(&cfg.Schedule)
+	if err != nil {
+		return time.Duration(threshold) * 24 * time.Hour
+	}
+	runs, err := sched.NextRuns(2)
+	if err != nil || len(runs) < 2 {
+		return time.Duration(threshold) * 24 * time.Hour
+	}
+	interval := runs[1].Sub(runs[0])
+	if interval <= 0 {
+		return time.Duration(threshold) * 24 * time.Hour
+	}
+	return interval * time.Duration(threshold)
 }
 
 func printDoctorResults(results []checkResult) {

--- a/cmd/nightshift/commands/scheduler_sink.go
+++ b/cmd/nightshift/commands/scheduler_sink.go
@@ -1,0 +1,23 @@
+package commands
+
+import (
+	"context"
+	"time"
+
+	"github.com/cedricfarinazzo/nightshift/internal/db"
+	"github.com/cedricfarinazzo/nightshift/internal/logging"
+)
+
+// schedulerFailureSink satisfies scheduler.FailureSink.
+// It logs the error and persists it to the DB so status/doctor can surface it.
+type schedulerFailureSink struct {
+	database *db.DB
+	log      *logging.Logger
+}
+
+func (s *schedulerFailureSink) RecordSchedulerFailure(ctx context.Context, jobName string, failedAt time.Time, errText string) {
+	s.log.Errorf("scheduler: job %s failed: %s", jobName, errText)
+	if err := db.RecordSchedulerFailure(ctx, s.database, jobName, failedAt, errText); err != nil {
+		s.log.Errorf("scheduler: failed to persist failure for job %s: %v", jobName, err)
+	}
+}

--- a/cmd/nightshift/commands/status.go
+++ b/cmd/nightshift/commands/status.go
@@ -167,7 +167,11 @@ func formatTokens(tokens int) string {
 func showSchedulerFailures(database *db.DB) {
 	ctx := context.Background()
 	names, err := db.DistinctSchedulerJobNames(ctx, database)
-	if err != nil || len(names) == 0 {
+	if err != nil {
+		fmt.Printf("\nScheduler failures: (query error: %v)\n", err)
+		return
+	}
+	if len(names) == 0 {
 		return
 	}
 

--- a/cmd/nightshift/commands/status.go
+++ b/cmd/nightshift/commands/status.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -40,9 +41,16 @@ Shows the last N runs (default: 5) or today's activity summary.`,
 		}
 
 		if today {
-			return showTodaySummary(st)
+			if err := showTodaySummary(st); err != nil {
+				return err
+			}
+		} else {
+			if err := showLastRuns(st, last); err != nil {
+				return err
+			}
 		}
-		return showLastRuns(st, last)
+		showSchedulerFailures(database)
+		return nil
 	},
 }
 
@@ -153,6 +161,24 @@ func formatTokens(tokens int) string {
 		return fmt.Sprintf("%.1fK", float64(tokens)/1000)
 	}
 	return fmt.Sprintf("%d", tokens)
+}
+
+// showSchedulerFailures prints the last failure per job name, if any exist.
+func showSchedulerFailures(database *db.DB) {
+	ctx := context.Background()
+	names, err := db.DistinctSchedulerJobNames(ctx, database)
+	if err != nil || len(names) == 0 {
+		return
+	}
+
+	fmt.Printf("\nScheduler failures:\n")
+	for _, name := range names {
+		failedAt, errText, ok, err := db.LastSchedulerFailure(ctx, database, name)
+		if err != nil || !ok {
+			continue
+		}
+		fmt.Printf("  [%s] %s: %s\n", failedAt.Local().Format("2006-01-02 15:04"), name, errText)
+	}
 }
 
 func formatDuration(d time.Duration) string {

--- a/docs/dev/database.md
+++ b/docs/dev/database.md
@@ -22,6 +22,7 @@ SQLite at `~/.local/share/nightshift/nightshift.db`. Driver: `modernc.org/sqlite
 | `snapshots` | Provider usage snapshots (timestamp + utilisation) |
 | `bus_factor_results` | Bus-factor analysis output |
 | `jira_ticket_results` | Jira pipeline outcomes per ticket |
+| `scheduler_job_failures` | Scheduler job failure history (job_name, failed_at, error_text) — migration 010 |
 
 ## Migrations
 
@@ -38,7 +39,7 @@ flowchart TD
     Loop -- all applied --> Ready(["DB ready"])
 ```
 
-`internal/db/migrations.go` — numbered functions `migration001`, `migration002`, ... `migration009` etc. Schema version stored in `schema_version` table; `Open()` runs each pending migration in order inside a transaction.
+`internal/db/migrations.go` — numbered functions `migration001`, `migration002`, ... `migration010` etc. Schema version stored in `schema_version` table; `Open()` runs each pending migration in order inside a transaction.
 
 Migrations are **forward-only** — no downs. To revert, you write a new forward migration that reverses the change.
 

--- a/docs/dev/database.md
+++ b/docs/dev/database.md
@@ -39,38 +39,31 @@ flowchart TD
     Loop -- all applied --> Ready(["DB ready"])
 ```
 
-`internal/db/migrations.go` — numbered functions `migration001`, `migration002`, ... `migration010` etc. Schema version stored in `schema_version` table; `Open()` runs each pending migration in order inside a transaction.
+`internal/db/migrations.go` — `[]Migration` slice of `Migration{Version, Description, SQL}` structs, each referencing a `migrationNNNSQL` constant. Schema version stored in `schema_version` table; `Open()` runs each pending migration in order inside a transaction via `tx.Exec(m.SQL)`.
 
 Migrations are **forward-only** — no downs. To revert, you write a new forward migration that reverses the change.
 
 ### Adding a migration
 
-1. Append `migrationNNN` function at the bottom of `migrations.go`
-2. Register it in the `migrations` slice
-3. Increment the version constant
-4. Add tests (`migrations_test.go`)
-5. Document in `CHANGELOG.md` if it's user-visible
+1. Add a `migrationNNNSQL` constant at the bottom of `migrations.go` with the DDL.
+2. Append a `Migration{Version: NNN, Description: "...", SQL: migrationNNNSQL}` entry to the `migrations` slice.
+3. Add tests (`migrations_test.go`)
+4. Document in `CHANGELOG.md` if it's user-visible
 
 Example skeleton:
 
 ```go
-func migration010(tx *sql.Tx) error {
-    _, err := tx.Exec(`
-        ALTER TABLE run_history
-        ADD COLUMN compression_savings_pct REAL DEFAULT 0;
-    `)
-    return err
-}
-```
+const migrationNNNSQL = `
+    ALTER TABLE run_history
+    ADD COLUMN compression_savings_pct REAL DEFAULT 0;
+`
 
-Then:
-
-```go
-var migrations = []migration{
-    {1, migration001},
-    ...
-    {10, migration010},
-}
+// in the migrations slice:
+{
+    Version:     NNN,
+    Description: "add compression_savings_pct to run_history",
+    SQL:         migrationNNNSQL,
+},
 ```
 
 ## Recent migration (009)

--- a/docs/dev/scheduling-internals.md
+++ b/docs/dev/scheduling-internals.md
@@ -96,8 +96,61 @@ cron tick
 4. Drives the orchestrator
 5. Writes report + updates state
 
+## Failure Capture (VC-96)
+
+Job errors are now surfaced instead of silently discarded.
+
+```
+job returns error
+  → Scheduler.recordFailure(ctx, jobName, err)
+       → failureCounts[jobName]++           (in-memory, guarded by mu)
+       → FailureSink.RecordSchedulerFailure (if wired)
+            → log.Errorf(...)               (daemon wires schedulerFailureSink)
+            → db.RecordSchedulerFailure(...)  (persists to scheduler_job_failures table)
+```
+
+### FailureSink interface
+
+```go
+type FailureSink interface {
+    RecordSchedulerFailure(ctx context.Context, jobName string, failedAt time.Time, errText string)
+}
+```
+
+Scheduler stays decoupled from `internal/db` and `internal/logging`. The sink is wired in `cmd/nightshift/commands/daemon.go` via `sched.WithFailureSink(...)`.
+
+### Named jobs
+
+`AddNamedJob(name, job)` registers a job with an explicit name used in failure records.
+`AddJob(job)` (deprecated) auto-names as `job-0`, `job-1`, etc. for back-compat.
+
+The daemon registers the main job as `"scheduled-run"`.
+
+### Health surface
+
+- `nightshift status` — shows last failure per job (timestamp + message) when any exist.
+- `nightshift doctor` — checks failures within N scheduled intervals (configurable via `scheduler.unhealthy_failure_count`, default 3):
+  - **FAIL**: ≥ N failures within the window.
+  - **WARN**: 1–(N-1) failures within the window, or past failures outside the window.
+  - **OK**: no failures.
+
+### DB table
+
+`scheduler_job_failures` (migration 010):
+
+| column     | type    | notes                |
+|------------|---------|----------------------|
+| id         | INTEGER | PK autoincrement     |
+| job_name   | TEXT    | named job identifier |
+| failed_at  | DATETIME | UTC RFC3339Nano      |
+| error_text | TEXT    | err.Error() string   |
+
+Index on `(job_name, failed_at DESC)` for fast last-failure and count-since queries.
+
 ## Gotchas
 
 - Config changes do not require a daemon restart — `runFunc` re-loads on each fire.
 - Schedule changes (cron/interval) DO require restart — the cron job is registered once.
 - `SkipIfStillRunning` is on the cron instance, not per-job — registering multiple jobs would need refactoring.
+- `failureCounts` is in-memory only — resets on daemon restart. Persistent counts come from the DB via `CountSchedulerFailuresSince`.
+- Sink errors (e.g. DB write failure) are logged by the sink itself and do not propagate into the scheduler — job failure is already recorded in the counter even if the sink fails.

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -2,7 +2,24 @@
 
 ## `nightshift doctor` is the first step
 
-Run it. It checks PATH, env vars, config, agent binaries, and credentials.
+Run it. It checks PATH, env vars, config, agent binaries, credentials, and **scheduler job health**.
+
+If any scheduled job has failed N or more times within N scheduled intervals (default N=3), doctor reports `[FAIL] scheduler.<job>`. For fewer failures it reports `[WARN]`.
+
+## Daemon scheduled runs failing silently
+
+`nightshift status` now shows the last scheduler failure per job when any have been recorded:
+
+```
+Scheduler failures:
+  [2026-05-22 02:00] scheduled-run: resolve projects: open db: ...
+```
+
+To diagnose further, grep the logs:
+
+```bash
+jq 'select(.message | test("scheduler.*failed"))' ~/.local/share/nightshift/logs/*.log
+```
 
 ## Agent binary not found
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ import (
 // Config holds all nightshift configuration.
 type Config struct {
 	Schedule          ScheduleConfig          `mapstructure:"schedule"`
+	Scheduler         SchedulerConfig         `mapstructure:"scheduler"`
 	Budget            BudgetConfig            `mapstructure:"budget"`
 	Providers         ProvidersConfig         `mapstructure:"providers"`
 	Projects          []ProjectConfig         `mapstructure:"projects"`
@@ -29,6 +30,13 @@ type Config struct {
 	Jira              jira.JiraConfig         `mapstructure:"jira"`
 	PromptCompression PromptCompressionConfig `mapstructure:"prompt_compression"`
 	Workspace         WorkspaceConfig         `mapstructure:"workspace"`
+}
+
+// SchedulerConfig holds runtime health settings for the scheduler.
+type SchedulerConfig struct {
+	// UnhealthyFailureCount is the number of failures within N scheduled intervals
+	// that causes nightshift doctor to report FAIL. Default 3.
+	UnhealthyFailureCount int `mapstructure:"unhealthy_failure_count"`
 }
 
 // WorkspaceConfig enables clone-based isolated task execution.
@@ -300,6 +308,9 @@ func setDefaults(v *viper.Viper) {
 
 	// Jira systemd defaults
 	v.SetDefault("jira.systemd_on_calendar", "*-*-* 22:00:00")
+
+	// Scheduler health defaults
+	v.SetDefault("scheduler.unhealthy_failure_count", 3)
 
 	// Prompt compression defaults
 	v.SetDefault("prompt_compression.enabled", false)

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -60,7 +60,23 @@ var migrations = []Migration{
 		Description: "add unique constraint on jira_ticket_results(run_id, ticket_key)",
 		SQL:         migration009SQL,
 	},
+	{
+		Version:     10,
+		Description: "add scheduler_job_failures table",
+		SQL:         migration010SQL,
+	},
 }
+
+const migration010SQL = `
+CREATE TABLE IF NOT EXISTS scheduler_job_failures (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_name    TEXT     NOT NULL,
+    failed_at   DATETIME NOT NULL,
+    error_text  TEXT     NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_scheduler_job_failures_name_time
+    ON scheduler_job_failures(job_name, failed_at DESC);
+`
 
 const migration008SQL = `
 ALTER TABLE snapshots ADD COLUMN source TEXT NOT NULL DEFAULT 'file';

--- a/internal/db/scheduler_failures.go
+++ b/internal/db/scheduler_failures.go
@@ -1,0 +1,117 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// SchedulerFailure records a single scheduler job failure.
+type SchedulerFailure struct {
+	ID        int64
+	JobName   string
+	FailedAt  time.Time
+	ErrorText string
+}
+
+// RecordSchedulerFailure inserts a failure row for jobName.
+func RecordSchedulerFailure(ctx context.Context, database *DB, jobName string, failedAt time.Time, errText string) error {
+	_, err := database.sql.ExecContext(ctx,
+		`INSERT INTO scheduler_job_failures(job_name, failed_at, error_text) VALUES(?,?,?)`,
+		jobName, failedAt.UTC().Format(time.RFC3339Nano), errText,
+	)
+	if err != nil {
+		return fmt.Errorf("record scheduler failure: %w", err)
+	}
+	return nil
+}
+
+// LastSchedulerFailure returns the most recent failure for jobName.
+// ok is false when no failure exists.
+func LastSchedulerFailure(ctx context.Context, database *DB, jobName string) (failedAt time.Time, errText string, ok bool, err error) {
+	row := database.sql.QueryRowContext(ctx,
+		`SELECT failed_at, error_text FROM scheduler_job_failures WHERE job_name=? ORDER BY failed_at DESC LIMIT 1`,
+		jobName,
+	)
+	var ts string
+	if scanErr := row.Scan(&ts, &errText); scanErr != nil {
+		if scanErr == sql.ErrNoRows {
+			return time.Time{}, "", false, nil
+		}
+		return time.Time{}, "", false, fmt.Errorf("last scheduler failure: %w", scanErr)
+	}
+	failedAt, err = time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		// Try fallback RFC3339
+		failedAt, err = time.Parse(time.RFC3339, ts)
+		if err != nil {
+			return time.Time{}, "", false, fmt.Errorf("parse failed_at: %w", err)
+		}
+	}
+	return failedAt, errText, true, nil
+}
+
+// RecentSchedulerFailures returns up to limit failures for jobName, newest first.
+func RecentSchedulerFailures(ctx context.Context, database *DB, jobName string, limit int) ([]SchedulerFailure, error) {
+	rows, err := database.sql.QueryContext(ctx,
+		`SELECT id, job_name, failed_at, error_text FROM scheduler_job_failures WHERE job_name=? ORDER BY failed_at DESC LIMIT ?`,
+		jobName, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("recent scheduler failures: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []SchedulerFailure
+	for rows.Next() {
+		var f SchedulerFailure
+		var ts string
+		if err := rows.Scan(&f.ID, &f.JobName, &ts, &f.ErrorText); err != nil {
+			return nil, fmt.Errorf("scan scheduler failure: %w", err)
+		}
+		f.FailedAt, err = time.Parse(time.RFC3339Nano, ts)
+		if err != nil {
+			f.FailedAt, err = time.Parse(time.RFC3339, ts)
+			if err != nil {
+				return nil, fmt.Errorf("parse failed_at: %w", err)
+			}
+		}
+		results = append(results, f)
+	}
+	return results, rows.Err()
+}
+
+// CountSchedulerFailuresSince returns the number of failures for jobName since the given time.
+func CountSchedulerFailuresSince(ctx context.Context, database *DB, jobName string, since time.Time) (int, error) {
+	row := database.sql.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM scheduler_job_failures WHERE job_name=? AND failed_at >= ?`,
+		jobName, since.UTC().Format(time.RFC3339Nano),
+	)
+	var n int
+	if err := row.Scan(&n); err != nil {
+		return 0, fmt.Errorf("count scheduler failures: %w", err)
+	}
+	return n, nil
+}
+
+// DistinctSchedulerJobNames returns all job names that have recorded failures.
+func DistinctSchedulerJobNames(ctx context.Context, database *DB) ([]string, error) {
+	rows, err := database.sql.QueryContext(ctx,
+		`SELECT DISTINCT job_name FROM scheduler_job_failures ORDER BY job_name`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("distinct scheduler job names: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan job name: %w", err)
+		}
+		names = append(names, name)
+	}
+	return names, rows.Err()
+}

--- a/internal/db/scheduler_failures_test.go
+++ b/internal/db/scheduler_failures_test.go
@@ -1,0 +1,126 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func openSchedulerTestDB(t *testing.T) *DB {
+	t.Helper()
+	database, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	return database
+}
+
+func TestRecordAndLastSchedulerFailure(t *testing.T) {
+	database := openSchedulerTestDB(t)
+	ctx := context.Background()
+
+	ts1 := time.Now().UTC().Truncate(time.Second)
+	ts2 := ts1.Add(time.Minute)
+
+	if err := RecordSchedulerFailure(ctx, database, "job-a", ts1, "first error"); err != nil {
+		t.Fatalf("RecordSchedulerFailure: %v", err)
+	}
+	if err := RecordSchedulerFailure(ctx, database, "job-a", ts2, "second error"); err != nil {
+		t.Fatalf("RecordSchedulerFailure: %v", err)
+	}
+
+	failedAt, errText, ok, err := LastSchedulerFailure(ctx, database, "job-a")
+	if err != nil {
+		t.Fatalf("LastSchedulerFailure: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if errText != "second error" {
+		t.Errorf("errText = %q, want %q", errText, "second error")
+	}
+	if !failedAt.Equal(ts2) {
+		t.Errorf("failedAt = %v, want %v", failedAt, ts2)
+	}
+}
+
+func TestLastSchedulerFailure_NoRows(t *testing.T) {
+	database := openSchedulerTestDB(t)
+	ctx := context.Background()
+
+	_, _, ok, err := LastSchedulerFailure(ctx, database, "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false for empty table")
+	}
+}
+
+func TestRecentSchedulerFailures_Ordering(t *testing.T) {
+	database := openSchedulerTestDB(t)
+	ctx := context.Background()
+
+	base := time.Now().UTC().Truncate(time.Second)
+	for i := 0; i < 5; i++ {
+		if err := RecordSchedulerFailure(ctx, database, "job-b", base.Add(time.Duration(i)*time.Minute), "err"); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	results, err := RecentSchedulerFailures(ctx, database, "job-b", 3)
+	if err != nil {
+		t.Fatalf("RecentSchedulerFailures: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("got %d results, want 3", len(results))
+	}
+	// Newest first.
+	if !results[0].FailedAt.After(results[1].FailedAt) {
+		t.Errorf("results not ordered newest-first")
+	}
+}
+
+func TestCountSchedulerFailuresSince(t *testing.T) {
+	database := openSchedulerTestDB(t)
+	ctx := context.Background()
+
+	base := time.Now().UTC().Truncate(time.Second)
+	// 3 recent + 2 old
+	for i := 0; i < 3; i++ {
+		_ = RecordSchedulerFailure(ctx, database, "job-c", base.Add(time.Duration(i)*time.Minute), "err")
+	}
+	for i := 0; i < 2; i++ {
+		_ = RecordSchedulerFailure(ctx, database, "job-c", base.Add(-time.Duration(i+1)*time.Hour), "old err")
+	}
+
+	count, err := CountSchedulerFailuresSince(ctx, database, "job-c", base.Add(-30*time.Minute))
+	if err != nil {
+		t.Fatalf("CountSchedulerFailuresSince: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+}
+
+func TestDistinctSchedulerJobNames(t *testing.T) {
+	database := openSchedulerTestDB(t)
+	ctx := context.Background()
+
+	ts := time.Now().UTC()
+	_ = RecordSchedulerFailure(ctx, database, "alpha", ts, "e")
+	_ = RecordSchedulerFailure(ctx, database, "beta", ts, "e")
+	_ = RecordSchedulerFailure(ctx, database, "alpha", ts.Add(time.Second), "e")
+
+	names, err := DistinctSchedulerJobNames(ctx, database)
+	if err != nil {
+		t.Fatalf("DistinctSchedulerJobNames: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("got %d names, want 2: %v", len(names), names)
+	}
+	if names[0] != "alpha" || names[1] != "beta" {
+		t.Errorf("names = %v, want [alpha beta]", names)
+	}
+}

--- a/internal/db/scheduler_failures_test.go
+++ b/internal/db/scheduler_failures_test.go
@@ -89,10 +89,14 @@ func TestCountSchedulerFailuresSince(t *testing.T) {
 	base := time.Now().UTC().Truncate(time.Second)
 	// 3 recent + 2 old
 	for i := 0; i < 3; i++ {
-		_ = RecordSchedulerFailure(ctx, database, "job-c", base.Add(time.Duration(i)*time.Minute), "err")
+		if err := RecordSchedulerFailure(ctx, database, "job-c", base.Add(time.Duration(i)*time.Minute), "err"); err != nil {
+			t.Fatalf("insert recent: %v", err)
+		}
 	}
 	for i := 0; i < 2; i++ {
-		_ = RecordSchedulerFailure(ctx, database, "job-c", base.Add(-time.Duration(i+1)*time.Hour), "old err")
+		if err := RecordSchedulerFailure(ctx, database, "job-c", base.Add(-time.Duration(i+1)*time.Hour), "old err"); err != nil {
+			t.Fatalf("insert old: %v", err)
+		}
 	}
 
 	count, err := CountSchedulerFailuresSince(ctx, database, "job-c", base.Add(-30*time.Minute))
@@ -109,9 +113,15 @@ func TestDistinctSchedulerJobNames(t *testing.T) {
 	ctx := context.Background()
 
 	ts := time.Now().UTC()
-	_ = RecordSchedulerFailure(ctx, database, "alpha", ts, "e")
-	_ = RecordSchedulerFailure(ctx, database, "beta", ts, "e")
-	_ = RecordSchedulerFailure(ctx, database, "alpha", ts.Add(time.Second), "e")
+	if err := RecordSchedulerFailure(ctx, database, "alpha", ts, "e"); err != nil {
+		t.Fatalf("insert alpha: %v", err)
+	}
+	if err := RecordSchedulerFailure(ctx, database, "beta", ts, "e"); err != nil {
+		t.Fatalf("insert beta: %v", err)
+	}
+	if err := RecordSchedulerFailure(ctx, database, "alpha", ts.Add(time.Second), "e"); err != nil {
+		t.Fatalf("insert alpha2: %v", err)
+	}
 
 	names, err := DistinctSchedulerJobNames(ctx, database)
 	if err != nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -28,6 +28,18 @@ var (
 // Job is a function to execute on schedule.
 type Job func(ctx context.Context) error
 
+// FailureSink receives notifications when a scheduled job returns an error.
+// Implementations handle logging and persistence; the scheduler stays decoupled from db/logging.
+type FailureSink interface {
+	RecordSchedulerFailure(ctx context.Context, jobName string, failedAt time.Time, errText string)
+}
+
+// namedJob pairs a job function with a human-readable name for diagnostics.
+type namedJob struct {
+	name string
+	fn   Job
+}
+
 // Scheduler manages scheduled nightshift runs.
 type Scheduler struct {
 	mu sync.RWMutex
@@ -40,13 +52,17 @@ type Scheduler struct {
 
 	// Runtime state
 	cron         *cron.Cron
-	jobs         []Job
+	jobs         []namedJob
 	running      bool
 	stopCh       chan struct{}
 	doneCh       chan struct{}
 	nextRun      time.Time
 	entryID      cron.EntryID
 	stopTimeoutD time.Duration // overridable in tests; 0 means use default (30s)
+
+	// Failure tracking
+	failureSink   FailureSink
+	failureCounts map[string]uint64
 }
 
 // Window represents a time window constraint.
@@ -88,14 +104,23 @@ func (t TimeOfDay) Minutes() int {
 // New creates an empty scheduler.
 func New() *Scheduler {
 	return &Scheduler{
-		location: time.Local,
+		location:      time.Local,
+		failureCounts: make(map[string]uint64),
 	}
+}
+
+// WithFailureSink sets the sink that receives job failure notifications.
+func (s *Scheduler) WithFailureSink(sink FailureSink) {
+	s.mu.Lock()
+	s.failureSink = sink
+	s.mu.Unlock()
 }
 
 // NewFromConfig creates a scheduler from configuration.
 func NewFromConfig(cfg *config.ScheduleConfig) (*Scheduler, error) {
 	s := &Scheduler{
-		location: time.Local,
+		location:      time.Local,
+		failureCounts: make(map[string]uint64),
 	}
 
 	// Parse cron expression
@@ -183,11 +208,51 @@ func (s *Scheduler) SetWindow(cfg *config.WindowConfig) error {
 	return nil
 }
 
-// AddJob adds a job to be executed on schedule.
+// AddJob adds a job to be executed on schedule with an auto-generated name.
+// Deprecated: Prefer AddNamedJob so failures are identifiable.
 func (s *Scheduler) AddJob(job Job) {
 	s.mu.Lock()
-	s.jobs = append(s.jobs, job)
+	name := fmt.Sprintf("job-%d", len(s.jobs))
+	s.jobs = append(s.jobs, namedJob{name: name, fn: job})
 	s.mu.Unlock()
+}
+
+// AddNamedJob adds a job with an explicit name used in failure reporting.
+func (s *Scheduler) AddNamedJob(name string, job Job) {
+	s.mu.Lock()
+	s.jobs = append(s.jobs, namedJob{name: name, fn: job})
+	s.mu.Unlock()
+}
+
+// FailureCount returns the in-memory failure counter for the named job.
+func (s *Scheduler) FailureCount(jobName string) uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.failureCounts[jobName]
+}
+
+// TotalFailures returns the sum of all in-memory failure counters.
+func (s *Scheduler) TotalFailures() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var total uint64
+	for _, v := range s.failureCounts {
+		total += v
+	}
+	return total
+}
+
+// recordFailure increments the counter and notifies the sink.
+func (s *Scheduler) recordFailure(ctx context.Context, jobName string, err error) {
+	now := time.Now()
+	s.mu.Lock()
+	s.failureCounts[jobName]++
+	sink := s.failureSink
+	s.mu.Unlock()
+
+	if sink != nil {
+		sink.RecordSchedulerFailure(ctx, jobName, now, err.Error())
+	}
 }
 
 // Start begins the scheduler loop.
@@ -274,16 +339,18 @@ func (s *Scheduler) runJobs(ctx context.Context) {
 	}
 
 	s.mu.RLock()
-	jobs := make([]Job, len(s.jobs))
+	jobs := make([]namedJob, len(s.jobs))
 	copy(jobs, s.jobs)
 	s.mu.RUnlock()
 
-	for _, job := range jobs {
+	for _, nj := range jobs {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			_ = job(ctx) // Errors handled by job itself
+			if err := nj.fn(ctx); err != nil {
+				s.recordFailure(ctx, nj.name, err)
+			}
 		}
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -745,7 +745,7 @@ func TestFailureCount_Concurrent(t *testing.T) {
 	}
 }
 
-func TestAddNamedJob_AutoName(t *testing.T) {
+func TestAddJob_AutoName(t *testing.T) {
 	s := New()
 	s.AddJob(func(_ context.Context) error { return nil })
 	s.AddJob(func(_ context.Context) error { return nil })

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -639,5 +640,123 @@ func TestNextWindowStartForWindow_ExactStartTime(t *testing.T) {
 	expectedTomorrow := time.Date(2026, 1, 16, 22, 0, 0, 0, time.UTC)
 	if !result3.Equal(expectedTomorrow) {
 		t.Errorf("after start time: got %v, want %v (tomorrow)", result3, expectedTomorrow)
+	}
+}
+
+// fakeSink records calls to RecordSchedulerFailure for assertion.
+type fakeSink struct {
+	mu       sync.Mutex
+	calls    []fakeSinkCall
+}
+
+type fakeSinkCall struct {
+	jobName   string
+	failedAt  time.Time
+	errorText string
+}
+
+func (f *fakeSink) RecordSchedulerFailure(_ context.Context, jobName string, failedAt time.Time, errText string) {
+	f.mu.Lock()
+	f.calls = append(f.calls, fakeSinkCall{jobName, failedAt, errText})
+	f.mu.Unlock()
+}
+
+func (f *fakeSink) Calls() []fakeSinkCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakeSinkCall, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+func TestRunJobs_FailureRecorded(t *testing.T) {
+	s := New()
+	sink := &fakeSink{}
+	s.WithFailureSink(sink)
+
+	s.AddNamedJob("test-job", func(_ context.Context) error {
+		return errors.New("boom")
+	})
+
+	ctx := context.Background()
+	s.runJobs(ctx)
+
+	if s.FailureCount("test-job") != 1 {
+		t.Errorf("FailureCount = %d, want 1", s.FailureCount("test-job"))
+	}
+	if s.TotalFailures() != 1 {
+		t.Errorf("TotalFailures = %d, want 1", s.TotalFailures())
+	}
+
+	calls := sink.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("sink calls = %d, want 1", len(calls))
+	}
+	if calls[0].jobName != "test-job" {
+		t.Errorf("sink.jobName = %q, want %q", calls[0].jobName, "test-job")
+	}
+	if calls[0].errorText != "boom" {
+		t.Errorf("sink.errorText = %q, want %q", calls[0].errorText, "boom")
+	}
+}
+
+func TestRunJobs_SuccessNoRecord(t *testing.T) {
+	s := New()
+	sink := &fakeSink{}
+	s.WithFailureSink(sink)
+
+	s.AddNamedJob("ok-job", func(_ context.Context) error {
+		return nil
+	})
+
+	s.runJobs(context.Background())
+
+	if s.FailureCount("ok-job") != 0 {
+		t.Errorf("FailureCount = %d, want 0", s.FailureCount("ok-job"))
+	}
+	if len(sink.Calls()) != 0 {
+		t.Errorf("sink calls = %d, want 0", len(sink.Calls()))
+	}
+}
+
+func TestFailureCount_Concurrent(t *testing.T) {
+	s := New()
+	sink := &fakeSink{}
+	s.WithFailureSink(sink)
+
+	s.AddNamedJob("race-job", func(_ context.Context) error {
+		return errors.New("err")
+	})
+
+	const goroutines = 20
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			s.runJobs(context.Background())
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+
+	if s.FailureCount("race-job") != goroutines {
+		t.Errorf("FailureCount = %d, want %d", s.FailureCount("race-job"), goroutines)
+	}
+}
+
+func TestAddNamedJob_AutoName(t *testing.T) {
+	s := New()
+	s.AddJob(func(_ context.Context) error { return nil })
+	s.AddJob(func(_ context.Context) error { return nil })
+
+	if len(s.jobs) != 2 {
+		t.Fatalf("expected 2 jobs, got %d", len(s.jobs))
+	}
+	if s.jobs[0].name != "job-0" {
+		t.Errorf("first job name = %q, want %q", s.jobs[0].name, "job-0")
+	}
+	if s.jobs[1].name != "job-1" {
+		t.Errorf("second job name = %q, want %q", s.jobs[1].name, "job-1")
 	}
 }


### PR DESCRIPTION
## VC-96 — scheduler: cron job errors silently dropped, no metric/counter

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-96

### Description

Problem
internal/scheduler/scheduler.go:286 does _ = job(ctx). Failed scheduled runs leave no trace beyond per-job log lines; no central error counter, no health surface for nightshift status / nightshift doctor.
Operator running as daemon has no way to know that the last N scheduled fires failed without grepping daily log files.
NOTE: may be obsoleted by VC-102 (remove daemon). If VC-102 lands first, close this as won't-fix.
Proposed solution
Increment a per-job failure counter on non-nil return
Persist last-error timestamp + message to state DB per job
Expose via nightshift status / nightshift doctor
Log error-level on failure (currently swallowed)
Acceptance criteria
_ = job(ctx) replaced with if err := job(ctx); err != nil { ... }
Failure path: logs log.Errorf with job name + error, increments counter, writes (job_name, ts, error_text) to DB
nightshift status shows last error per job (timestamp + message) when one exists
nightshift doctor reports unhealthy when any job has failed within the last N scheduled intervals (configurable, default 3)
Unit test: stub job returning error; assert counter increments + DB row written + log emitted
DB migration added if new table/column required
Refs
internal/scheduler/scheduler.go:286
VC-102 (may obsolete)
CODEBASE_REVIEW.md

### Acceptance Criteria

_ = job(ctx) replaced with if err := job(ctx); err != nil { ... }
Failure path: logs log.Errorf with job name + error, increments counter, writes (job_name, ts, error_text) to DB
nightshift status shows last error per job (timestamp + message) when one exists
nightshift doctor reports unhealthy when any job has failed within the last N scheduled intervals (configurable, default 3)
Unit test: stub job returning error; assert counter increments + DB row written + log emitted
DB migration added if new table/column required
Refs
internal/scheduler/scheduler.go:286
VC-102 (may obsolete)
CODEBASE_REVIEW.md

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
