### PR TITLE
[VC-103] jira run: missing --project flag (present in jira preview)

### DIFF
--- a/cmd/nightshift/commands/jira.go
+++ b/cmd/nightshift/commands/jira.go
@@ -1,6 +1,12 @@
 package commands
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cedricfarinazzo/nightshift/internal/jira"
+	"github.com/spf13/cobra"
+)
 
 var jiraCmd = &cobra.Command{
 	Use:   "jira",
@@ -11,4 +17,27 @@ Fetches tickets, validates, implements, creates PRs, and handles review feedback
 
 func init() {
 	rootCmd.AddCommand(jiraCmd)
+}
+
+// filterProjectsByKey returns only the projects whose Key matches key
+// (case-insensitive). Empty key returns projects unchanged. No match returns
+// an error listing configured keys.
+func filterProjectsByKey(projects []jira.ProjectConfig, key string) ([]jira.ProjectConfig, error) {
+	if key == "" {
+		return projects, nil
+	}
+	var filtered []jira.ProjectConfig
+	for _, p := range projects {
+		if strings.EqualFold(p.Key, key) {
+			filtered = append(filtered, p)
+		}
+	}
+	if len(filtered) == 0 {
+		keys := make([]string, len(projects))
+		for i, p := range projects {
+			keys[i] = p.Key
+		}
+		return nil, fmt.Errorf("project %q not found in config (configured: %s)", key, strings.Join(keys, ", "))
+	}
+	return filtered, nil
 }

--- a/cmd/nightshift/commands/jira.go
+++ b/cmd/nightshift/commands/jira.go
@@ -19,12 +19,22 @@ func init() {
 	rootCmd.AddCommand(jiraCmd)
 }
 
+// addProjectFlag registers the --project/-p flag on cmd with the canonical
+// help text. Call from init() in both jira_run.go and jira_preview.go so the
+// paired commands stay in sync.
+func addProjectFlag(cmd *cobra.Command) {
+	cmd.Flags().StringP("project", "p", "", "Jira project key — process only this project (default: all configured)")
+}
+
 // filterProjectsByKey returns only the projects whose Key matches key
 // (case-insensitive). Empty key returns projects unchanged. No match returns
 // an error listing configured keys.
 func filterProjectsByKey(projects []jira.ProjectConfig, key string) ([]jira.ProjectConfig, error) {
 	if key == "" {
 		return projects, nil
+	}
+	if len(projects) == 0 {
+		return nil, fmt.Errorf("no Jira projects configured")
 	}
 	var filtered []jira.ProjectConfig
 	for _, p := range projects {

--- a/cmd/nightshift/commands/jira_preview.go
+++ b/cmd/nightshift/commands/jira_preview.go
@@ -123,18 +123,9 @@ func runJiraPreview(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Filter projects with --project flag.
-	projects := cfg.Jira.Projects
-	if projectFilter != "" {
-		var filtered []jira.ProjectConfig
-		for _, p := range projects {
-			if strings.EqualFold(p.Key, projectFilter) {
-				filtered = append(filtered, p)
-			}
-		}
-		if len(filtered) == 0 {
-			return fmt.Errorf("no project with key %q found in config", projectFilter)
-		}
-		projects = filtered
+	projects, err := filterProjectsByKey(cfg.Jira.Projects, projectFilter)
+	if err != nil {
+		return err
 	}
 
 	// Validate the (potentially filtered) config.

--- a/cmd/nightshift/commands/jira_preview.go
+++ b/cmd/nightshift/commands/jira_preview.go
@@ -26,7 +26,7 @@ execution order, and budget without executing anything.`,
 }
 
 func init() {
-	jiraPreviewCmd.Flags().StringP("project", "p", "", "Jira project key (overrides config)")
+	addProjectFlag(jiraPreviewCmd)
 	jiraPreviewCmd.Flags().String("label", "", "Jira label filter (overrides config, default \"nightshift\")")
 	jiraPreviewCmd.Flags().Bool("json", false, "Output as JSON")
 	jiraPreviewCmd.Flags().Bool("plain", false, "Disable TUI pager")

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -33,7 +33,7 @@ ON REVIEW tickets: fetch PR feedback → re-work → push`,
 func init() {
 	jiraCmd.AddCommand(jiraRunCmd)
 
-	jiraRunCmd.Flags().StringP("project", "p", "", "Jira project key — process only this project (default: all configured)")
+	addProjectFlag(jiraRunCmd)
 	jiraRunCmd.Flags().String("label", "", "Jira label filter (overrides config, default \"nightshift\")")
 	jiraRunCmd.Flags().Int("max-tickets", 0, "Override max tickets per run (0 = use config)")
 	jiraRunCmd.Flags().String("ticket", "", "Process a single ticket by key (e.g., VC-123)")

--- a/cmd/nightshift/commands/jira_run.go
+++ b/cmd/nightshift/commands/jira_run.go
@@ -33,6 +33,7 @@ ON REVIEW tickets: fetch PR feedback → re-work → push`,
 func init() {
 	jiraCmd.AddCommand(jiraRunCmd)
 
+	jiraRunCmd.Flags().StringP("project", "p", "", "Jira project key — process only this project (default: all configured)")
 	jiraRunCmd.Flags().String("label", "", "Jira label filter (overrides config, default \"nightshift\")")
 	jiraRunCmd.Flags().Int("max-tickets", 0, "Override max tickets per run (0 = use config)")
 	jiraRunCmd.Flags().String("ticket", "", "Process a single ticket by key (e.g., VC-123)")
@@ -87,6 +88,15 @@ func runJira(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("init logging: %w", err)
 	}
 	cfg.Jira.Defaults()
+
+	if projectFilter, _ := cmd.Flags().GetString("project"); projectFilter != "" {
+		filtered, ferr := filterProjectsByKey(cfg.Jira.Projects, projectFilter)
+		if ferr != nil {
+			return ferr
+		}
+		cfg.Jira.Projects = filtered
+	}
+
 	if err := cfg.Jira.Validate(); err != nil {
 		return fmt.Errorf("jira config: %w", err)
 	}

--- a/cmd/nightshift/commands/jira_run_test.go
+++ b/cmd/nightshift/commands/jira_run_test.go
@@ -302,12 +302,12 @@ func TestFilterProjectsByKey(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		projects  []jira.ProjectConfig
-		key       string
-		wantLen   int
-		wantErr   bool
-		errSubstr string
+		name       string
+		projects   []jira.ProjectConfig
+		key        string
+		wantLen    int
+		wantErr    bool
+		errSubstrs []string
 	}{
 		{
 			name:    "match exact",
@@ -330,23 +330,23 @@ func TestFilterProjectsByKey(t *testing.T) {
 			wantLen: 2,
 		},
 		{
-			name:      "no match returns error with key",
-			key:       "ZZ",
-			wantErr:   true,
-			errSubstr: "ZZ",
+			name:       "no match returns error with key",
+			key:        "ZZ",
+			wantErr:    true,
+			errSubstrs: []string{"ZZ"},
 		},
 		{
-			name:      "no match error lists configured keys",
-			key:       "ZZ",
-			wantErr:   true,
-			errSubstr: "VC",
+			name:       "no match error lists configured keys",
+			key:        "ZZ",
+			wantErr:    true,
+			errSubstrs: []string{"VC", "FIN", "configured:"},
 		},
 		{
-			name:      "empty config returns error",
-			projects:  []jira.ProjectConfig{},
-			key:       "VC",
-			wantErr:   true,
-			errSubstr: "VC",
+			name:       "empty config returns error",
+			projects:   []jira.ProjectConfig{},
+			key:        "VC",
+			wantErr:    true,
+			errSubstrs: []string{"no Jira projects configured"},
 		},
 	}
 
@@ -361,8 +361,10 @@ func TestFilterProjectsByKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("expected error, got nil")
 				}
-				if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
-					t.Fatalf("error %q does not contain %q", err.Error(), tc.errSubstr)
+				for _, sub := range tc.errSubstrs {
+					if !strings.Contains(err.Error(), sub) {
+						t.Fatalf("error %q does not contain %q", err.Error(), sub)
+					}
 				}
 				return
 			}

--- a/cmd/nightshift/commands/jira_run_test.go
+++ b/cmd/nightshift/commands/jira_run_test.go
@@ -294,3 +294,94 @@ func TestRunJira_MissingConfig(t *testing.T) {
 		t.Errorf("expected error containing %q, got: %v", expected, err)
 	}
 }
+
+func TestFilterProjectsByKey(t *testing.T) {
+	projects := []jira.ProjectConfig{
+		{Key: "VC"},
+		{Key: "FIN"},
+	}
+
+	tests := []struct {
+		name      string
+		projects  []jira.ProjectConfig
+		key       string
+		wantLen   int
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "match exact",
+			key:     "VC",
+			wantLen: 1,
+		},
+		{
+			name:    "match case-insensitive lowercase",
+			key:     "vc",
+			wantLen: 1,
+		},
+		{
+			name:    "match case-insensitive mixed",
+			key:     "Fin",
+			wantLen: 1,
+		},
+		{
+			name:    "empty key returns all",
+			key:     "",
+			wantLen: 2,
+		},
+		{
+			name:      "no match returns error with key",
+			key:       "ZZ",
+			wantErr:   true,
+			errSubstr: "ZZ",
+		},
+		{
+			name:      "no match error lists configured keys",
+			key:       "ZZ",
+			wantErr:   true,
+			errSubstr: "VC",
+		},
+		{
+			name:      "empty config returns error",
+			projects:  []jira.ProjectConfig{},
+			key:       "VC",
+			wantErr:   true,
+			errSubstr: "VC",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := tc.projects
+			if input == nil {
+				input = projects
+			}
+			got, err := filterProjectsByKey(input, tc.key)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != tc.wantLen {
+				t.Fatalf("got %d projects, want %d", len(got), tc.wantLen)
+			}
+		})
+	}
+}
+
+func TestRunJiraCmd_ProjectFlagRegistered(t *testing.T) {
+	f := jiraRunCmd.Flags().Lookup("project")
+	if f == nil {
+		t.Fatal("--project flag not registered on jira run command")
+	}
+	if f.Shorthand != "p" {
+		t.Errorf("--project shorthand = %q, want %q", f.Shorthand, "p")
+	}
+}

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -90,6 +90,8 @@ PID file at `~/.local/share/nightshift/nightshift.pid` (atomic — only one daem
 
 ```bash
 nightshift jira run                          # process all labeled tickets
+nightshift jira run --project VC             # only this project (mirrors jira preview)
+nightshift jira run -p VC                    # short form
 nightshift jira run --ticket VC-42           # one ticket
 nightshift jira run --max-tickets 5
 nightshift jira run --skip-validation

--- a/docs/user/jira-pipeline.md
+++ b/docs/user/jira-pipeline.md
@@ -179,6 +179,8 @@ Status names from the Jira API are checked by substring keyword. Examples:
 ```bash
 # Run
 nightshift jira run                          # all labeled tickets, all projects
+nightshift jira run --project VC             # only the VC project (mirrors jira preview -p)
+nightshift jira run -p VC                    # short form
 nightshift jira run --ticket VC-42           # one ticket
 nightshift jira run --max-tickets 5
 nightshift jira run --label other-label


### PR DESCRIPTION
## VC-103 — jira run: missing --project flag (present in jira preview)

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-103

### Description

Problem
nightshift jira preview accepts --project, -p <KEY> to filter execution to a single Jira project (cmd/nightshift/commands/jira_preview.go:29, used at line 125-130 to filter the configured project list).
nightshift jira run has no equivalent flag. Operator wanting to run only one project must either:
edit config to temporarily remove other projects (destructive, easy to forget reverting)
run the full configured set and pay the budget for all projects
Inconsistent CLI surface — preview and run are paired commands and should accept the same selection flags.
Proposed solution
Add --project, -p <KEY> flag to nightshift jira run mirroring the preview implementation: filter cfg.Integrations.Jira.Projects by case-insensitive key match before dispatching. Empty value (default) preserves current behavior (all projects).
Acceptance criteria
nightshift jira run --project VC processes only the VC project, skips all others
nightshift jira run -p VC (short form) works identically
nightshift jira run (no flag) processes all configured projects (no behavior change)
Unknown project key → exit non-zero with "project KEY not found in config" message naming the configured keys
Case-insensitive match (matches preview behavior at jira_preview.go:130)
Flag documented in --help output and in docs/user/cli-reference.md + docs/user/jira-pipeline.md
Unit test covering: match, no-match, empty flag, case-insensitive match
Preview + run flag definitions extracted to a shared helper if duplication would otherwise occur
Refs
cmd/nightshift/commands/jira_preview.go:29 (flag def)
cmd/nightshift/commands/jira_preview.go:125-130 (filter logic)
cmd/nightshift/commands/jira_run.go (missing)

### Acceptance Criteria

nightshift jira run --project VC processes only the VC project, skips all others
nightshift jira run -p VC (short form) works identically
nightshift jira run (no flag) processes all configured projects (no behavior change)
Unknown project key → exit non-zero with "project KEY not found in config" message naming the configured keys
Case-insensitive match (matches preview behavior at jira_preview.go:130)
Flag documented in --help output and in docs/user/cli-reference.md + docs/user/jira-pipeline.md
Unit test covering: match, no-match, empty flag, case-insensitive match
Preview + run flag definitions extracted to a shared helper if duplication would otherwise occur
Refs
cmd/nightshift/commands/jira_preview.go:29 (flag def)
cmd/nightshift/commands/jira_preview.go:125-130 (filter logic)
cmd/nightshift/commands/jira_run.go (missing)

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
