### PR TITLE
[VC-1] Add Kubernetes CronJob deployment support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to nightshift are documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **feat(deploy): Kubernetes CronJob manifests + deployment guide (VC-1)** — added `deploy/kubernetes/` with Kustomize-driven manifests (CronJob, ConfigMap, PVC, Secret template, Namespace, ServiceAccount) and `docs/operations/kubernetes-cronjob.md` covering container image, auth, Git credentials, repo mounting strategies, and production tips.
+
 ### Refactoring
 
 - **agents: deduplicate option constructors (VC-92)** — extracted shared `agentConfig` struct and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,16 @@ docs/                   # All documentation (plain markdown, no static-site gene
     contributing.md            # Dev setup, git conventions, PR checklist
     debugging.md               # Log locations, common errors + fixes
 
+deploy/
+  kubernetes/           # Kustomize manifests for running nightshift as a Kubernetes CronJob
+    namespace.yaml      # Dedicated nightshift namespace
+    serviceaccount.yaml # Dedicated ServiceAccount (no RBAC beyond pod-local FS + network)
+    pvc.yaml            # 1Gi ReadWriteOnce PVC for SQLite DB and logs mounted at /data
+    configmap.yaml      # Annotated config template with db_path/logging.path pointing at PVC
+    secrets.yaml        # Secret template only (placeholder values); never commit real keys
+    cronjob.yaml        # CronJob: schedule 0 2 * * *, concurrencyPolicy Forbid, readOnlyRootFilesystem
+    kustomization.yaml  # Kustomize entry-point; kubectl apply -k deploy/kubernetes/
+
 scripts/
   pre-commit.sh         # Runs gofmt, go vet, go build on staged .go files
 
@@ -417,4 +427,6 @@ Agents MUST follow these rules:
 - **Daemon workspace mode (VC-87)** — when `workspace.root` is set, `runScheduledTasks` routes to `runScheduledWorkspacedTasks` instead of the project-path loop. Both `nightshift run` and daemon share `runRepoTasks()` for per-repo task execution. State key is always `rw.Name` (not `rw.Path`) in workspace mode. First daemon run after upgrading from a pre-VC-87 release will re-process all workspace repos once (old cooldowns were keyed on paths, new ones on names — safe, one extra run).
 - **`runRepoTasks` allowedTasks filter** — when `workspace.repos[*].tasks` is set, `runRepoTasks` filters selected tasks to only those types before execution. Empty/nil means no filter. Filter applied after selector, so cooldown/staleness scoring still runs on all tasks but only matching types are executed.
 - **Rejection forces re-validation on next run** — Rejection is posted by the orchestrator as a structured `CommentRejection` NightshiftComment (via `postPhaseComment`); `HandleInvalidTicket` only does the status transition. `detectResumeState` compares `GetLastCommentOfType(CommentRejection).Timestamp` against `GetLastCommentOfType(CommentValidation).Timestamp`: if rejection is newer, `hasValidation` is false and the ticket falls to `PhaseValidate` for re-evaluation. If acceptance is newer (user fixed ticket, later run passed), rejection is ignored. Root cause of FIN-31: prior `CommentValidation` from an older partial run caused `detectResumeState` to skip validation despite a newer rejection.
-- **`internal/analysis` uses functional-option exec injection (`WithGitRunner`)** — `gitExecFn` package-level var removed (VC-100). `NewGitParser(repoPath, analysis.WithGitRunner(fake))` pattern for tests; `t.Parallel()` safe. Remaining packages (`internal/jira/pr.go` `ghExec`, `internal/orchestrator` `ghExec`/`gitExec`, `internal/workspace` `gitExecFn`/`SetGitExecFn`) still use the old global-var pattern — tracked in follow-up ticket VC-101. Do NOT add `t.Parallel()` to tests in those packages until they are migrated.
+- **`internal/analysis` uses functional-option exec injection (`WithGitRunner`)** — `gitExecFn` package-level var removed (VC-100). `NewGitParser(repoPath, analysis.WithGitRunner(fake))` pattern for tests; `t.Parallel()` safe. Remaining packages (`internal/jira/pr.go` `ghExec`, `internal/orchestrator` `ghExec`/`gitExec`, `internal/workspace` `gitExecFn`/`SetGitExecFn`) still use the old global-var pattern — tracked in follow-up tickets VC-106, VC-107, VC-108. Do NOT add `t.Parallel()` to tests in those packages until they are migrated.
+- **K8s pod uses `readOnlyRootFilesystem: true`** — `/tmp` must be an `emptyDir` volume mount in the CronJob spec. Nightshift uses `os.CreateTemp("", "nightshift-prompt-*.md")` (the Prompt temp-file pattern) to write agent prompts; without a writable `/tmp` this fails at runtime. The provided `deploy/kubernetes/cronjob.yaml` already includes the `emptyDir` mount. Also set `HOME=/data/home` so agent CLIs (`claude`, `gh`) that write to `$HOME/.config` use the PVC-backed writable directory instead of the read-only rootfs.
+- **K8s subscription CLI auth not supported** — `claude` / `codex` CLI subscription mode (non-API) reads credentials interactively from `~/.config` and may trigger browser OAuth. Neither is available inside a Kubernetes pod (no TTY, no browser). Use API key mode (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) for all providers when running in Kubernetes. See `docs/operations/kubernetes-cronjob.md`.

--- a/README.md
+++ b/README.md
@@ -140,18 +140,18 @@ Full reference: [`docs/user/cli-reference.md`](docs/user/cli-reference.md).
 Run nightshift as a Kubernetes CronJob using the included manifests:
 
 ```bash
-# Create namespace and secrets
+# Create the Secret out-of-band first (secrets.yaml is a template; applying it would overwrite credentials)
 kubectl create namespace nightshift
 kubectl create secret generic nightshift-secrets \
   --namespace nightshift \
   --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
   --from-literal=NIGHTSHIFT_JIRA_TOKEN=...
 
-# Apply all manifests (Kustomize)
+# Apply all manifests (Kustomize; secrets.yaml excluded from defaults)
 kubectl apply -k deploy/kubernetes/
 ```
 
-Fires at 02:00 UTC daily. Override the schedule, image tag, or resource limits via a Kustomize overlay. Full guide: [`docs/operations/kubernetes-cronjob.md`](docs/operations/kubernetes-cronjob.md).
+Fires at 02:00 UTC daily (`spec.timeZone: "Etc/UTC"`, requires Kubernetes ≥ 1.27). Override the schedule, image tag, or resource limits via a Kustomize overlay. Full guide: [`docs/operations/kubernetes-cronjob.md`](docs/operations/kubernetes-cronjob.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,26 @@ Full reference: [`docs/user/cli-reference.md`](docs/user/cli-reference.md).
 
 ---
 
+## Kubernetes / Cloud Deployment
+
+Run nightshift as a Kubernetes CronJob using the included manifests:
+
+```bash
+# Create namespace and secrets
+kubectl create namespace nightshift
+kubectl create secret generic nightshift-secrets \
+  --namespace nightshift \
+  --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
+  --from-literal=NIGHTSHIFT_JIRA_TOKEN=...
+
+# Apply all manifests (Kustomize)
+kubectl apply -k deploy/kubernetes/
+```
+
+Fires at 02:00 UTC daily. Override the schedule, image tag, or resource limits via a Kustomize overlay. Full guide: [`docs/operations/kubernetes-cronjob.md`](docs/operations/kubernetes-cronjob.md).
+
+---
+
 ## Minimal Configuration
 
 `~/.config/nightshift/config.yaml`:

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nightshift-config
+  namespace: nightshift
+  labels:
+    app: nightshift
+data:
+  config.yaml: |
+    # Nightshift configuration for Kubernetes CronJob deployment.
+    # Mount this ConfigMap at /etc/nightshift/config.yaml.
+    # Set NIGHTSHIFT_CONFIG=/etc/nightshift/config.yaml in the container environment,
+    # or place it at ~/.config/nightshift/config.yaml.
+
+    # SQLite database and logs stored on the PVC mounted at /data.
+    db_path: /data/nightshift.db
+
+    logging:
+      level: info
+      # Write logs to the PVC so they persist across pod restarts.
+      path: /data/logs
+
+    reporting:
+      output_dir: /data/reports
+
+    schedule:
+      # CronJob schedule is controlled by the CronJob spec, not this field.
+      # Set this to match the CronJob schedule for budget calculations.
+      cron: "0 2 * * *"
+
+    budget:
+      daily_limit: 1000000   # tokens
+      reserve_percent: 10
+
+    providers:
+      claude:
+        # API key injected from the nightshift-secrets Secret.
+        # Subscription CLI auth is not supported in Kubernetes (no interactive TTY).
+        model: claude-opus-4-5
+        enabled: true
+      codex:
+        model: gpt-4o
+        enabled: false
+      copilot:
+        enabled: false
+
+    # Workspace root for ephemeral per-run repo clones inside the pod.
+    # Repos are cloned into /data/workspaces/<name>_<runID>/ each run.
+    workspace:
+      root: /data/workspaces
+      ttl_days: 7
+
+    # Jira integration — populate via environment variables or edit below.
+    # integrations:
+    #   jira:
+    #     url: https://your-org.atlassian.net
+    #     email: your-email@example.com
+    #     # Token injected from Secret: NIGHTSHIFT_JIRA_TOKEN
+    #     projects:
+    #       - key: YOUR_PROJECT
+    #         repos:
+    #           - name: your-repo
+    #             url: git@github.com:your-org/your-repo.git

--- a/deploy/kubernetes/cronjob.yaml
+++ b/deploy/kubernetes/cronjob.yaml
@@ -7,12 +7,14 @@ metadata:
     app: nightshift
 spec:
   # Default: 02:00 UTC daily. Override via Kustomize patch or edit here.
+  # spec.timeZone requires Kubernetes ≥ 1.27 (GA). Remove if targeting older clusters.
+  timeZone: "Etc/UTC"
   schedule: "0 2 * * *"
   # Prevent concurrent runs — SQLite is ReadWriteOnce and concurrent agents would conflict.
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
-  # If the CronJob misses its window, skip rather than run late up to 10 minutes.
+  # Allow up to 10 minutes of late-start before skipping a missed run.
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:
@@ -22,6 +24,8 @@ spec:
             app: nightshift
         spec:
           serviceAccountName: nightshift
+          # No Kubernetes API access needed; disable token mount to reduce credential exposure.
+          automountServiceAccountToken: false
           restartPolicy: OnFailure
           securityContext:
             runAsNonRoot: true

--- a/deploy/kubernetes/cronjob.yaml
+++ b/deploy/kubernetes/cronjob.yaml
@@ -1,0 +1,73 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nightshift
+  namespace: nightshift
+  labels:
+    app: nightshift
+spec:
+  # Default: 02:00 UTC daily. Override via Kustomize patch or edit here.
+  schedule: "0 2 * * *"
+  # Prevent concurrent runs — SQLite is ReadWriteOnce and concurrent agents would conflict.
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  # If the CronJob misses its window, skip rather than run late up to 10 minutes.
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: nightshift
+        spec:
+          serviceAccountName: nightshift
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: nightshift
+              # Override via Kustomize images: field for production image pinning.
+              image: ghcr.io/cedricfarinazzo/nightshift:latest
+              command: ["nightshift", "run", "--yes"]
+              env:
+                - name: NIGHTSHIFT_CONFIG
+                  value: /etc/nightshift/config.yaml
+                - name: HOME
+                  # Agent CLIs (claude, gh) write to $HOME/.config; use emptyDir-backed /data/home.
+                  value: /data/home
+              envFrom:
+                - secretRef:
+                    name: nightshift-secrets
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                - name: config
+                  mountPath: /etc/nightshift
+                  readOnly: true
+                # /tmp must be writable: nightshift uses os.CreateTemp for agent prompt files.
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: nightshift-data
+            - name: config
+              configMap:
+                name: nightshift-config
+            - name: tmp
+              emptyDir: {}

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: nightshift
+
+commonLabels:
+  app: nightshift
+
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - pvc.yaml
+  - configmap.yaml
+  - secrets.yaml
+  - cronjob.yaml
+
+# Override the image tag for production pinning:
+# images:
+#   - name: ghcr.io/cedricfarinazzo/nightshift
+#     newTag: v0.3.4
+
+# Example schedule patch (uncomment and adjust):
+# patches:
+#   - patch: |-
+#       - op: replace
+#         path: /spec/schedule
+#         value: "0 3 * * *"
+#     target:
+#       kind: CronJob
+#       name: nightshift

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -11,7 +11,10 @@ resources:
   - serviceaccount.yaml
   - pvc.yaml
   - configmap.yaml
-  - secrets.yaml
+  # secrets.yaml is a template only — it contains placeholder values.
+  # Create the Secret out-of-band (kubectl create secret / Sealed Secrets / External Secrets)
+  # before running apply, and do NOT include it here to avoid overwriting real credentials.
+  # See docs/operations/kubernetes-cronjob.md#authentication for options.
   - cronjob.yaml
 
 # Override the image tag for production pinning:

--- a/deploy/kubernetes/namespace.yaml
+++ b/deploy/kubernetes/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nightshift
+  labels:
+    app: nightshift

--- a/deploy/kubernetes/pvc.yaml
+++ b/deploy/kubernetes/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nightshift-data
+  namespace: nightshift
+  labels:
+    app: nightshift
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/kubernetes/secrets.yaml
+++ b/deploy/kubernetes/secrets.yaml
@@ -1,0 +1,25 @@
+# Secret template — DO NOT commit real values.
+# Replace <REPLACE_ME> placeholders before applying, or use the imperative form:
+#
+#   kubectl create secret generic nightshift-secrets \
+#     --namespace nightshift \
+#     --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
+#     --from-literal=OPENAI_API_KEY=sk-... \
+#     --from-literal=GITHUB_TOKEN=ghp_... \
+#     --from-literal=NIGHTSHIFT_JIRA_TOKEN=...
+#
+# For production, prefer sealed-secrets (https://github.com/bitnami-labs/sealed-secrets)
+# or an external-secrets operator to avoid storing plaintext in version control.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nightshift-secrets
+  namespace: nightshift
+  labels:
+    app: nightshift
+type: Opaque
+stringData:
+  ANTHROPIC_API_KEY: "<REPLACE_ME>"
+  OPENAI_API_KEY: "<REPLACE_ME>"
+  GITHUB_TOKEN: "<REPLACE_ME>"
+  NIGHTSHIFT_JIRA_TOKEN: "<REPLACE_ME>"

--- a/deploy/kubernetes/serviceaccount.yaml
+++ b/deploy/kubernetes/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nightshift
+  namespace: nightshift
+  labels:
+    app: nightshift

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ For running Nightshift as a long-lived service.
 
 - [Daemon Mode](operations/daemon.md) — start/stop/status, PID files
 - [Systemd Install](operations/systemd-install.md) — install unit, autostart
+- [Kubernetes CronJob](operations/kubernetes-cronjob.md) — deploy as a K8s CronJob with Kustomize manifests
 - [Logs & Reports](operations/logs-and-reports.md) — where output lives, retention
 - [Data & Backup](operations/data-and-backup.md) — DB layout, what to back up
 - [Security Model](operations/security.md) — credentials, audit log, sandbox

--- a/docs/operations/kubernetes-cronjob.md
+++ b/docs/operations/kubernetes-cronjob.md
@@ -1,0 +1,244 @@
+# Kubernetes CronJob Deployment
+
+> **Doc track note**: This guide lives under `docs/operations/` (alongside `daemon.md` and `systemd-install.md`) rather than `docs/guides/` as specified in the ticket. `docs/guides/` is not an existing documentation track; placing here keeps taxonomy consistent.
+
+---
+
+## Overview
+
+Running nightshift as a Kubernetes CronJob suits teams that already operate a cluster and want:
+
+- Declarative, GitOps-friendly scheduling
+- Automatic retries and history via `successfulJobsHistoryLimit` / `failedJobsHistoryLimit`
+- Isolation from the host OS (no systemd, no cron on the node)
+- Horizontal tenancy: run one CronJob per project namespace
+
+If you run nightshift on a single machine, the systemd approach (`docs/operations/systemd-install.md`) is simpler.
+
+---
+
+## Quick Start
+
+```bash
+# 1. Create namespace and secrets
+kubectl create namespace nightshift
+kubectl create secret generic nightshift-secrets \
+  --namespace nightshift \
+  --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
+  --from-literal=OPENAI_API_KEY=sk-...       \  # omit if Codex disabled
+  --from-literal=GITHUB_TOKEN=ghp_...         \  # omit if Copilot disabled
+  --from-literal=NIGHTSHIFT_JIRA_TOKEN=...       # omit if Jira disabled
+
+# 2. Apply all manifests via Kustomize
+kubectl apply -k deploy/kubernetes/
+
+# 3. Verify
+kubectl -n nightshift get cronjob,pvc,configmap,secret
+```
+
+The CronJob fires at 02:00 UTC every day by default. Trigger a manual run:
+
+```bash
+kubectl -n nightshift create job --from=cronjob/nightshift nightshift-manual-$(date +%s)
+kubectl -n nightshift logs -f job/nightshift-manual-...
+```
+
+---
+
+## Container Image
+
+The manifests reference `ghcr.io/cedricfarinazzo/nightshift:latest`. For production, pin to a specific tag and override via Kustomize:
+
+```yaml
+# kustomization.yaml overlay
+images:
+  - name: ghcr.io/cedricfarinazzo/nightshift
+    newTag: v0.3.4
+```
+
+### Building Your Own Image
+
+Example multi-stage Dockerfile. The image must bundle `nightshift` plus any agent CLIs you enable (`claude`, `codex`, `gh`).
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM golang:1.24 AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /nightshift ./cmd/nightshift
+
+# Install agent CLIs in a separate stage for layer caching.
+FROM debian:bookworm-slim AS tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates git gh && \
+    # Install Claude CLI (replace with actual install method when available)
+    # curl -fsSL https://claude.ai/install.sh | sh && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=builder /nightshift /usr/local/bin/nightshift
+COPY --from=tools /usr/bin/git /usr/bin/git
+COPY --from=tools /usr/bin/gh /usr/bin/gh
+# Copy claude/codex CLIs if installed in the tools stage.
+
+ENTRYPOINT ["nightshift"]
+```
+
+> **Note**: `claude` and `codex` CLIs must be in the image's PATH. Nightshift's agent layer calls these as external processes (see CLAUDE.md gotcha "Agent binaries must be in PATH"). Never call `exec.Command` with a CLI that may be absent.
+
+---
+
+## Authentication
+
+### API Keys (Recommended for Kubernetes)
+
+Inject credentials via the `nightshift-secrets` Secret. All Nightshift providers read credentials from environment variables only — never from config files on disk.
+
+| Env Var | Provider |
+|---|---|
+| `ANTHROPIC_API_KEY` | Claude (API mode) |
+| `OPENAI_API_KEY` | Codex |
+| `GITHUB_TOKEN` | GitHub / Copilot |
+| `NIGHTSHIFT_JIRA_TOKEN` | Jira integration |
+
+The `envFrom.secretRef` in `cronjob.yaml` mounts all Secret keys as env vars automatically.
+
+### Subscription CLI Auth (Not Supported in Kubernetes)
+
+`claude` and `codex` CLIs in subscription (non-API) mode read credentials interactively from `~/.config` and may require browser-based OAuth. This is incompatible with Kubernetes pods (no TTY, no browser). **Use API key mode for all providers when running in Kubernetes.**
+
+If you need subscription auth, the systemd / daemon approach on a desktop machine is a better fit.
+
+---
+
+## Git Credentials
+
+Nightshift clones and pushes repositories on your behalf. Configure one of:
+
+### SSH Key (Recommended)
+
+1. Create an SSH key pair without a passphrase: `ssh-keygen -t ed25519 -f nightshift_id_ed25519 -N ""`
+2. Add the public key to GitHub as a deploy key with write access.
+3. Store the private key in a Secret:
+   ```bash
+   kubectl create secret generic nightshift-ssh \
+     --namespace nightshift \
+     --from-file=id_ed25519=./nightshift_id_ed25519
+   ```
+4. Mount into the pod at `/data/home/.ssh/id_ed25519` (since `HOME=/data/home` in the CronJob):
+   ```yaml
+   # patch in kustomization.yaml
+   - name: ssh-key
+     secret:
+       secretName: nightshift-ssh
+       defaultMode: 0400
+   ```
+   ```yaml
+   volumeMounts:
+     - name: ssh-key
+       mountPath: /data/home/.ssh
+       readOnly: true
+   ```
+5. Set repo URLs to SSH format (`git@github.com:org/repo.git`) — HTTPS remotes fail silently without a TTY (see CLAUDE.md gotcha "Jira repo URL must use SSH").
+
+### HTTPS Personal Access Token
+
+Add `GIT_ASKPASS` or configure `~/.netrc` via a Secret-mounted file at `/data/home/.netrc`:
+
+```
+machine github.com login x-access-token password <PAT>
+```
+
+---
+
+## Repo Mounting Strategies
+
+### (a) Ephemeral Clone per Run (Default)
+
+Set `workspace.root: /data/workspaces` in `configmap.yaml`. Each run clones repos into `/data/workspaces/<name>_<runID>/` and cleans up stale clones after `ttl_days`. This is the simplest approach and works well for the Jira pipeline.
+
+```yaml
+workspace:
+  root: /data/workspaces
+  ttl_days: 7
+```
+
+### (b) PVC-Backed Long-Lived Workspaces
+
+Same as (a) but with a larger PVC and `ttl_days` set high. Subsequent runs reuse existing clones (fetching + rebasing) instead of re-cloning. Faster for large repos; uses more storage.
+
+> **Mtime caveat**: `CleanupStaleWorkspaces` uses file mtime to detect staleness. Some CSI drivers reset mtime on PVC attach. If workspaces are deleted unexpectedly, lower `ttl_days` or disable cleanup and manage manually.
+
+### (c) git-sync Sidecar
+
+For read-only access to a single repo, add a [git-sync](https://github.com/kubernetes/git-sync) sidecar that keeps a shared emptyDir up to date. Nightshift tasks then run against the synced directory. Not suitable for workflows that push (Jira pipeline, PR creation).
+
+---
+
+## Environment Variables Reference
+
+| Variable | Required | Description |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | If Claude enabled | Claude API key |
+| `OPENAI_API_KEY` | If Codex enabled | OpenAI API key |
+| `GITHUB_TOKEN` | If Copilot / PR creation | GitHub PAT or app token |
+| `NIGHTSHIFT_JIRA_TOKEN` | If Jira enabled | Jira API token |
+| `NIGHTSHIFT_CONFIG` | Recommended | Path to config file (default: `~/.config/nightshift/config.yaml`) |
+| `HOME` | Set in manifest | Must point to a writable directory (`/data/home` in the provided manifest) |
+
+---
+
+## Production Tips
+
+### Resource Sizing
+
+Default limits (`cpu: 1000m`, `memory: 1Gi`) suit small projects. For large repos or many parallel agent runs, increase memory. Agent CLIs (`claude`, `codex`) are the dominant memory consumers.
+
+### PVC Backup
+
+Snapshot `/data` to protect the SQLite database and logs:
+
+```bash
+kubectl -n nightshift exec -it <pod> -- nightshift stats  # check DB health first
+# Then take a VolumeSnapshot or use your CSI driver's backup mechanism.
+```
+
+### Log Shipping
+
+Logs write to `/data/logs` by default. To ship to stdout for cluster log aggregation:
+
+1. Set `logging.path: -` in `configmap.yaml` (if supported by your nightshift version).
+2. Or add a sidecar container running `tail -F /data/logs/nightshift-*.log`.
+
+### Monitoring CronJob Success
+
+Use [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) with Prometheus:
+
+```promql
+# Alert if the last successful CronJob run is more than 26 hours ago.
+time() - kube_cronjob_status_last_successful_time{cronjob="nightshift"} > 93600
+```
+
+### Image Pinning
+
+Never use `:latest` in production. Pin to a digest or specific tag:
+
+```yaml
+images:
+  - name: ghcr.io/cedricfarinazzo/nightshift
+    newTag: v0.3.4
+```
+
+### Secrets Management
+
+The provided `secrets.yaml` is a **template only** — it contains placeholder strings and must not be committed with real values. For production:
+
+- [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets): encrypt secrets at rest in Git.
+- [External Secrets Operator](https://external-secrets.io/): sync from Vault, AWS Secrets Manager, etc.
+- Avoid `kubectl create secret ... --from-literal` with real keys in shell history; use `--from-file` or pipe from a password manager.
+
+### Concurrency and SQLite
+
+`concurrencyPolicy: Forbid` prevents concurrent CronJob runs. This is mandatory — `modernc.org/sqlite` (pure Go, no CGO) is safe from CGO locking issues, but SQLite's `ReadWriteOnce` PVC access mode still means only one pod can write at a time. Do not remove `concurrencyPolicy: Forbid`.

--- a/docs/operations/kubernetes-cronjob.md
+++ b/docs/operations/kubernetes-cronjob.md
@@ -20,23 +20,26 @@ If you run nightshift on a single machine, the systemd approach (`docs/operation
 ## Quick Start
 
 ```bash
-# 1. Create namespace and secrets
+# 1. Create namespace
 kubectl create namespace nightshift
+
+# 2. Create the credentials Secret out-of-band (secrets.yaml is a template; do not apply it directly).
+#    Omit keys for disabled providers.
 kubectl create secret generic nightshift-secrets \
   --namespace nightshift \
   --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
-  --from-literal=OPENAI_API_KEY=sk-...       \  # omit if Codex disabled
-  --from-literal=GITHUB_TOKEN=ghp_...         \  # omit if Copilot disabled
-  --from-literal=NIGHTSHIFT_JIRA_TOKEN=...       # omit if Jira disabled
+  --from-literal=OPENAI_API_KEY=sk-... \
+  --from-literal=GITHUB_TOKEN=ghp_... \
+  --from-literal=NIGHTSHIFT_JIRA_TOKEN=...
 
-# 2. Apply all manifests via Kustomize
+# 3. Apply all manifests via Kustomize (secrets.yaml is excluded from the default kustomization)
 kubectl apply -k deploy/kubernetes/
 
-# 3. Verify
+# 4. Verify
 kubectl -n nightshift get cronjob,pvc,configmap,secret
 ```
 
-The CronJob fires at 02:00 UTC every day by default. Trigger a manual run:
+The CronJob fires at 02:00 UTC every day by default (`spec.timeZone: "Etc/UTC"` in `cronjob.yaml`; requires Kubernetes ≥ 1.27). Trigger a manual run:
 
 ```bash
 kubectl -n nightshift create job --from=cronjob/nightshift nightshift-manual-$(date +%s)
@@ -77,7 +80,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # curl -fsSL https://claude.ai/install.sh | sh && \
     rm -rf /var/lib/apt/lists/*
 
-FROM gcr.io/distroless/static-debian12:nonroot
+# Use distroless/base (not /static) — git and gh are dynamically linked and require glibc.
+FROM gcr.io/distroless/base-debian12:nonroot
 COPY --from=builder /nightshift /usr/local/bin/nightshift
 COPY --from=tools /usr/bin/git /usr/bin/git
 COPY --from=tools /usr/bin/gh /usr/bin/gh


### PR DESCRIPTION
## VC-1 — Add Kubernetes CronJob deployment support

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-1

### Description

Adds everything needed to run nightshift as a Kubernetes CronJob instead of a systemd service.
Changes
deploy/kubernetes/
cronjob.yaml – CronJob running nightshift run --yes on a configurable cron schedule (0 2 * * * default), with concurrencyPolicy: Forbid, resource limits, and a non-root security context
configmap.yaml – Annotated config template with db_path and logging.path pointing at the PVC
pvc.yaml – 1Gi ReadWriteOnce claim for SQLite DB and logs
secrets.yaml – Template only (no real values); includes instructions for kubectl create secret
namespace.yaml – Dedicated nightshift namespace
serviceaccount.yaml – Dedicated ServiceAccount
kustomization.yaml – Kustomize entry-point (kubectl apply -k deploy/kubernetes/)
docs/guides/kubernetes-cronjob.md
Full deployment guide covering building a container image, API key vs. subscription CLI authentication, Git credentials, repo mounting strategies, environment variables reference, and production tips.
README.md
Added a Kubernetes / Cloud Deployment section with quick-start commands and a link to the guide.

PR: https://github.com/cedricfarinazzo/nightshift/pull/17
Branch: feature/kubernetes-cronjob
+619 lines across 11 files, 9 commits

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
