### PR TITLE
fix(pidlock): treat unreadable lock file as held, not stale

### DIFF
--- a/cmd/nightshift/commands/pidlock.go
+++ b/cmd/nightshift/commands/pidlock.go
@@ -64,7 +64,14 @@ func tryAcquireLock(path, name string, now time.Time) (*PidLock, error) {
 
 	// File exists — check if the recorded PID is alive.
 	existingPID, existingStart, readErr := readPidLock(path)
-	if readErr == nil && isProcessRunning(existingPID) {
+	if readErr != nil {
+		// Unreadable / partial content — another acquirer wrote the file with
+		// O_EXCL but has not yet finished writing the PID line. Treating this
+		// as stale would clobber the winner's lock. Surface as held instead.
+		return nil, fmt.Errorf("%w: another %s acquiring lock (file content unreadable: %v)",
+			ErrLockHeld, name, readErr)
+	}
+	if isProcessRunning(existingPID) {
 		if existingStart.IsZero() {
 			return nil, fmt.Errorf("%w: another %s in progress, PID %d",
 				ErrLockHeld, name, existingPID)

--- a/cmd/nightshift/commands/pidlock_test.go
+++ b/cmd/nightshift/commands/pidlock_test.go
@@ -48,6 +48,31 @@ func TestAcquirePidLock_Exclusive(t *testing.T) {
 	}
 }
 
+// TestAcquirePidLock_EmptyFileHeldNotStale guards against a race where one
+// acquirer wins O_EXCL but hasn't yet written the PID line; a second acquirer
+// reading mid-write must see ErrLockHeld (not "stale, reclaim"). Pre-fix this
+// caused intermittent CI failures in TestAcquirePidLock_Exclusive (issue
+// surfaced rebasing VC-103 onto VC-101).
+func TestAcquirePidLock_EmptyFileHeldNotStale(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "empty.lock")
+
+	// Simulate the race: O_EXCL succeeded, file is empty, write has not yet
+	// landed. acquirePidLock from another contender must NOT reclaim.
+	if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := acquirePidLock(path, "test")
+	if !errors.Is(err, ErrLockHeld) {
+		t.Errorf("expected ErrLockHeld for empty lock file (acquire in progress), got: %v", err)
+	}
+	// Lock file must still exist — must not have been reclaimed.
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Errorf("lock file was reclaimed despite empty content: %v", statErr)
+	}
+}
+
 func TestAcquirePidLock_StaleReclaim(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

Race in \`acquirePidLock\` (added in #133 / VC-101): two goroutines contending could both succeed.

**Sequence:**
1. Goroutine A wins \`OpenFile(O_CREATE|O_EXCL)\` but has not yet written the PID line.
2. Goroutine B sees \`os.ErrExist\`, calls \`readPidLock\` mid-write, gets a parse error on the empty file.
3. Falls through to the \"stale lock, reclaim\" branch → removes A's file, creates a new lock.
4. Both goroutines believe they hold the lock.

Surfaced when rebasing #135 (VC-103) onto #133's pidlock code: \`TestAcquirePidLock_Exclusive\` failed intermittently on CI with \`expected exactly 1 success, got 2\`.

## Fix

When \`readPidLock\` returns a non-nil error, treat as \`ErrLockHeld\` (another acquirer is mid-write) instead of stale. Stale reclaim now requires a successfully parsed PID that no live process owns.

## Test plan

- [x] \`TestAcquirePidLock_EmptyFileHeldNotStale\` added — creates empty lock file, asserts \`ErrLockHeld\` and file not reclaimed.
- [x] \`go test ./cmd/nightshift/commands/ -run TestAcquirePidLock -count=20 -race\` — 120 passed, no flakes.
- [x] \`go test ./...\` — full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)