### PR TITLE
[VC-98] orchestrator: commit() is a no-op stub still wired into lifecycle

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -375,12 +375,7 @@ func (o *Orchestrator) RunTask(ctx context.Context, task *tasks.Task, workDir st
 		o.emit(Event{Type: EventPhaseEnd, Phase: StatusReviewing, TaskID: task.ID, Duration: time.Since(phaseStart), Iteration: iteration})
 
 		if review.Passed {
-			// Success - commit and return
 			o.log(result, "info", "review passed", map[string]any{"iteration": iteration})
-			if err := o.commit(ctx, task, impl, workDir); err != nil {
-				o.log(result, "warn", "commit failed", map[string]any{"error": err.Error()})
-				// Don't fail the task if commit fails, just log it
-			}
 			result.Status = StatusCompleted
 			result.Duration = time.Since(start)
 
@@ -772,17 +767,6 @@ func (o *Orchestrator) review(ctx context.Context, task *tasks.Task, impl *Imple
 	}
 
 	return review, nil
-}
-
-// commit finalizes successful task completion.
-func (o *Orchestrator) commit(_ context.Context, task *tasks.Task, impl *ImplementOutput, _ string) error {
-	// For now, commit is a no-op. In full implementation:
-	// - Create git commit with changes
-	// - Include a commit message with https://github.com/cedricfarinazzo/nightshift
-	// - Update task state
-	// - Send notifications
-	o.logger.Infof("commit: task=%s files=%d", task.ID, len(impl.FilesModified))
-	return nil
 }
 
 // Prompt builders


### PR DESCRIPTION
## VC-98 — orchestrator: commit() is a no-op stub still wired into lifecycle

**Jira ticket:** https://sedinfra.atlassian.net/browse/VC-98

### Description

Problem
internal/orchestrator/orchestrator.go:778-786 — commit() returns without doing anything but is still called from the task lifecycle. Dead path or unfinished implementation; either way it gives readers a false signal that commit logic exists.
Proposed solution
Investigate intent:
If commit belongs solely to jira pipeline (internal/jira/branch.go CommitAndPush) — delete stub and remove orchestrator call sites
If orchestrator was meant to commit for non-jira tasks (e.g. local task runs producing diffs) — implement it: stage changes, generate Conventional Commit message from task metadata, commit on the task branch
Decide which path, then close.
Acceptance criteria
Investigation comment posted on ticket naming the chosen path with reasoning
If delete: commit() stub removed, all call sites removed, orchestrator tests still pass, no behavior change for jira pipeline
If implement: commit() stages tracked changes, generates type(scope): summary message, commits on current branch, returns error on failure; unit test with temp git repo covers happy path + no-changes path + commit failure
No remaining no-op functions wired into lifecycle (grep for // TODO or empty-body func decls in orchestrator.go shows none)
Refs
internal/orchestrator/orchestrator.go:778-786
CODEBASE_REVIEW.md

### Acceptance Criteria

Investigation comment posted on ticket naming the chosen path with reasoning
If delete: commit() stub removed, all call sites removed, orchestrator tests still pass, no behavior change for jira pipeline
If implement: commit() stages tracked changes, generates type(scope): summary message, commits on current branch, returns error on failure; unit test with temp git repo covers happy path + no-changes path + commit failure
No remaining no-op functions wired into lifecycle (grep for // TODO or empty-body func decls in orchestrator.go shows none)
Refs
internal/orchestrator/orchestrator.go:778-786
CODEBASE_REVIEW.md

---
*Generated by [Nightshift](https://github.com/cedricfarinazzo/nightshift) — automated agent*
