### PR TITLE
chore(providers): update static model lists for all providers

### DIFF
--- a/cmd/nightshift/commands/setup.go
+++ b/cmd/nightshift/commands/setup.go
@@ -136,9 +136,10 @@ func modelOptionValues(opts []modelOption) []string {
 
 // claudeModels lists available Claude models (static fallback).
 // Updated at runtime via FetchAnthropicModels when ANTHROPIC_API_KEY is set.
-// Source: https://platform.claude.com/docs/en/about-claude/models/overview
+// Source: https://docs.anthropic.com/en/docs/about-claude/models/overview (2026-05-28)
 var claudeModels = []modelOption{
 	{label: "default", value: ""},
+	{label: "claude-opus-4-8", value: "claude-opus-4-8"},
 	{label: "claude-opus-4-7", value: "claude-opus-4-7"},
 	{label: "claude-sonnet-4-6", value: "claude-sonnet-4-6"},
 	{label: "claude-haiku-4-5-20251001", value: "claude-haiku-4-5-20251001"},

--- a/internal/providers/models.go
+++ b/internal/providers/models.go
@@ -115,18 +115,20 @@ func FetchOpenAIModels(ctx context.Context, apiKey string) ([]string, error) {
 
 // CopilotModels returns the hardcoded list of Copilot CLI model IDs.
 // No programmatic API exists for Copilot model listing.
-// Source: https://docs.github.com/en/copilot/reference/ai-models/supported-models (2026-05-10)
+// Source: https://docs.github.com/en/copilot/reference/ai-models/supported-models (2026-05-28)
 func CopilotModels() []string {
 	return []string{
 		"claude-haiku-4.5",
 		"claude-opus-4.5",
 		"claude-opus-4.6",
 		"claude-opus-4.7",
+		"claude-opus-4.8",
 		"claude-sonnet-4.5",
 		"claude-sonnet-4.6",
 		"gemini-2.5-pro",
 		"gemini-3-flash",
 		"gemini-3.1-pro",
+		"gemini-3.5-flash",
 		"gpt-4.1",
 		"gpt-5-mini",
 		"gpt-5.2",


### PR DESCRIPTION
## Summary

Updates the static model fallback lists based on the latest provider documentation (checked 2026-05-28).

### Changes

**`internal/providers/models.go` — `CopilotModels()`**
- Added `claude-opus-4.8` — Anthropic's newest and most capable model
- Added `gemini-3.5-flash` — confirmed in the GitHub Copilot supported-models IDE versions table

**`cmd/nightshift/commands/setup.go` — `claudeModels`**
- Added `claude-opus-4-8` at the top of the fallback list (above `claude-opus-4-7`)
- Updated source URL comment to current Anthropic docs URL with date 2026-05-28

### Sources
- Copilot models: https://docs.github.com/en/copilot/reference/ai-models/supported-models
- Claude models: https://docs.anthropic.com/en/docs/about-claude/models/overview